### PR TITLE
Ariadne: fares, favorites, day-aware departures, iOS routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ Companion surfacing, implemented on iOS, Android and Web (UI on top of data the 
 
 Ariadne, the offline transit assistant (a constrained, tool-only intent router, implemented on iOS, Android and Web; brought forward from the 1.5 roadmap slot in constrained form):
 
-- "Ask Ariadne" from the Home screen opens a chat that parses natural language fully offline and dispatches to the deterministic use cases the app already ships (departures, last train, trip planning, line info, alerts, find station). It never generates a transit fact; it picks an approved action and the projector/planner answers.
+- "Ask Ariadne" from the Home screen opens a chat that parses natural language fully offline and dispatches to the deterministic use cases the app already ships (departures, last train, trip planning, line info, ticket prices, service alerts, find station, favorite a station). It never generates a transit fact; it picks an approved action and the projector/planner answers.
+- Day-aware departures: "M3 from Syntagma this weekend / tomorrow / Saturday" projects that whole service day from 00:00 (`ComputeDeparturesFromBandsUseCase.invokeForDay`, the projector dayOffset path on iOS), not just today.
+- Fares: surfaces the relevant ticket products with prices (standard single vs the airport ticket). Favorites: a real `FavoritesRepository` (Kotlin, SQLDelight) + UserDefaults store on iOS persist the toggle.
+- iOS trip planning now runs a full Dijkstra (`JourneyPlanner.swift`, with transfer edges between co-located interchange ids) so iOS matches the Android/Web `PlanJourneyUseCase` for any number of transfers.
 - Trilingual by design (EN/EL/SQ) via a rule parser, so no supported language degrades. Shared brain in `core/domain/assistant` (`AthensTransitParser`, `AssistantIntent`), mirrored in Swift under `iosApp/.../Features/Assistant`. Scope is fenced to Syrmos and Athens public transport; weather is accepted only as a routing constraint, everything else is declined.
 - This also wired `PlanJourneyUseCase` (Dijkstra routing that already existed but was never in the DI graph) into the Compose app; iOS uses a compact 0/1-transfer planner over the bundled network.
 

--- a/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
@@ -28,10 +28,13 @@ val featureModule = module {
             stationRepository = get(),
             getLinesUseCase = get(),
             getNextDepartures = get(),
+            bandProjector = get(),
             getLastTrain = get(),
             planJourney = get(),
             searchStations = get(),
             announcementsRepository = get(),
+            faresRepository = get(),
+            favoritesRepository = get(),
         )
     }
     factory { LinesViewModel(getLinesUseCase = get()) }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/di/DataModule.kt
@@ -1,5 +1,6 @@
 package com.syrmos.core.data.di
 
+import com.syrmos.core.data.repository.FavoritesRepository
 import com.syrmos.core.data.repository.LineRepositoryImpl
 import com.syrmos.core.data.repository.ScheduleRepositoryImpl
 import com.syrmos.core.data.repository.StationRepositoryImpl
@@ -24,5 +25,6 @@ val dataModule = module {
     single { LineRepositoryImpl(database = get(), resourceReader = get()) }
     single { StationRepositoryImpl(database = get(), resourceReader = get()) }
     single { ScheduleRepositoryImpl(database = get()) }
+    single { FavoritesRepository(database = get()) }
     single { TransitPatternRepositoryImpl(resourceReader = get()) }
 }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/FavoritesRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/FavoritesRepository.kt
@@ -1,0 +1,45 @@
+package com.syrmos.core.data.repository
+
+import com.syrmos.core.database.SyrmosDatabase
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * Persists user favorites against the bundled SQLDelight `favorite_entity`
+ * table. This is the primitive Ariadne's "favorite this station" writes to and
+ * a future favorites screen will read from, the same shape as the existing
+ * repositories. Station favorites are keyed by station id under the "station"
+ * type.
+ */
+@OptIn(ExperimentalTime::class)
+class FavoritesRepository(
+    private val database: SyrmosDatabase,
+) {
+    private val queries get() = database.syrmosDatabaseQueries
+
+    fun isStationFavorite(stationId: String): Boolean =
+        queries.isFavorite(TYPE_STATION, stationId).executeAsOne() > 0L
+
+    /** Toggles the station's favorite state and returns the new value. */
+    fun toggleStation(stationId: String): Boolean {
+        return if (isStationFavorite(stationId)) {
+            queries.deleteFavorite(TYPE_STATION, stationId)
+            false
+        } else {
+            queries.insertFavorite(
+                id = "$TYPE_STATION:$stationId",
+                type = TYPE_STATION,
+                reference_id = stationId,
+                created_at = Clock.System.now().toString(),
+            )
+            true
+        }
+    }
+
+    fun favoriteStationIds(): List<String> =
+        queries.getFavoritesByType(TYPE_STATION).executeAsList().map { it.reference_id }
+
+    private companion object {
+        const val TYPE_STATION = "station"
+    }
+}

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AssistantModels.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AssistantModels.kt
@@ -42,6 +42,12 @@ sealed interface AssistantIntent {
     /** Line overview (terminals, span, stations). */
     data class ExplainLine(val lineId: String) : AssistantIntent
 
+    /** Ticket prices. [airport] surfaces the airport fare specifically. */
+    data class ExplainFare(val airport: Boolean = false) : AssistantIntent
+
+    /** Add/remove a station from favorites. */
+    data class ToggleFavorite(val stationId: String?) : AssistantIntent
+
     /** Current service alerts / status, optionally for one line. */
     data class ShowAlerts(val lineId: String? = null) : AssistantIntent
 

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AthensTransitParser.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AthensTransitParser.kt
@@ -38,7 +38,9 @@ class AthensTransitParser(
             containsAny(text, MAP_WORDS) ||
             containsAny(text, LAST_TRAIN_PHRASES) ||
             containsAny(text, PLAN_PHRASES) ||
-            containsAny(text, FIND_WORDS)
+            containsAny(text, FIND_WORDS) ||
+            containsAny(text, FARE_WORDS) ||
+            containsAny(text, FAVORITE_WORDS)
 
         // Weather is allowed ONLY as a routing constraint, never as a topic.
         // "weather in london" stays out of scope; "raining, get me to X" routes
@@ -48,6 +50,25 @@ class AthensTransitParser(
 
         // Nothing transit-related at all: decline.
         if (!strongTransit && !intentSignal && !weather) return AssistantIntent.OutOfScope
+
+        // 0a. Fares. Checked before planning so "how much to the airport" is a
+        //     fare question, not a trip. The airport flag surfaces the airport
+        //     ticket specifically.
+        if (containsAny(text, FARE_WORDS)) {
+            return AssistantIntent.ExplainFare(airport = containsAny(text, AIRPORT_WORDS))
+        }
+
+        // 0b. Favorites. Needs a station to act on.
+        if (containsAny(text, FAVORITE_WORDS)) {
+            return AssistantIntent.ToggleFavorite(stationId = mentionedStations.firstOrNull())
+                .let { intent ->
+                    if (intent.stationId == null) {
+                        AssistantIntent.NeedsClarification(intent, MissingSlot.STATION)
+                    } else {
+                        intent
+                    }
+                }
+        }
 
         // 1. Plan a trip. Triggered by an explicit "how do I get" phrase, an
         //    explicit "to" frame with a station, weather routing, or two
@@ -291,6 +312,19 @@ class AthensTransitParser(
             "line", "about", "tell me about",
             "γραμμη", "σχετικα",
             "linja", "rreth",
+        )
+        private val FARE_WORDS = listOf(
+            "fare", "fares", "ticket", "tickets", "how much", "price", "cost", "cheap",
+            "εισιτηρι", "ποσο κανει", "ποσο κοστιζει", "τιμη", "κοστος",
+            "bilete", "sa kushton", "kushton", "cmim", "cmimi",
+        )
+        private val FAVORITE_WORDS = listOf(
+            "favorite", "favourite", "save this", "bookmark", "add to favorites", "pin",
+            "αγαπημεν", "αποθηκευσ", "προσθεσε στα αγαπημενα", "σημειωσε",
+            "i preferuar", "te preferuarat", "ruaj", "shto te te preferuarat",
+        )
+        private val AIRPORT_WORDS = listOf(
+            "airport", "αεροδρομιο", "aeroport",
         )
         private val ALERT_WORDS = listOf(
             "alert", "alerts", "status", "disruption", "delay", "delays", "problem", "closed", "closure",

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/DayContextResolver.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/DayContextResolver.kt
@@ -1,0 +1,33 @@
+package com.syrmos.core.domain.assistant
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Maps a parsed [DayContext] to a day offset from today, so a "this weekend" or
+ * "tomorrow" question projects the right service day instead of falling back to
+ * today. Pure and testable: pass [today] explicitly. ISO weekday numbering,
+ * Monday = 1 … Sunday = 7, Saturday = 6.
+ */
+object DayContextResolver {
+    fun dayOffset(day: DayContext, today: LocalDate): Int {
+        val dow = today.dayOfWeek.isoDayNumber
+        return when (day) {
+            DayContext.TODAY -> 0
+            DayContext.TOMORROW -> 1
+            DayContext.SATURDAY -> (6 - dow + 7) % 7
+            DayContext.SUNDAY -> (7 - dow + 7) % 7
+            // Already the weekend? Use today; otherwise the next Saturday.
+            DayContext.WEEKEND -> if (dow >= 6) 0 else 6 - dow
+        }
+    }
+
+    fun dayOffset(day: DayContext): Int {
+        val today = Clock.System.now()
+            .toLocalDateTime(TimeZone.of("Europe/Athens")).date
+        return dayOffset(day, today)
+    }
+}

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/ComputeDeparturesFromBandsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/ComputeDeparturesFromBandsUseCase.kt
@@ -114,6 +114,54 @@ class ComputeDeparturesFromBandsUseCase(
         return sorted
     }
 
+    /**
+     * Projects a whole future service day from 00:00, for the assistant's
+     * "this weekend / tomorrow / Saturday" questions. [dayOffset] is days from
+     * today (0 = today from midnight). Returns the day's earliest [limit]
+     * departures at [stationId]; empty when bundles aren't loaded yet.
+     */
+    fun invokeForDay(
+        lineIds: List<String>,
+        direction: Direction,
+        dayOffset: Int,
+        limit: Int = 8,
+        stationId: String? = null,
+    ): List<UpcomingDeparture> {
+        val bundles = scheduleSync.lineBundles.value
+        if (bundles.isEmpty()) return emptyList()
+
+        val zone = TimeZone.of("Europe/Athens")
+        val today = Clock.System.now().toLocalDateTime(zone).date
+        val targetDate = today.plusDays(dayOffset)
+        val holidayDayType = resolveHolidayDayType(targetDate)
+
+        val results = mutableListOf<UpcomingDeparture>()
+        for (lineId in lineIds) {
+            val bundle = bundles[lineId] ?: continue
+            val offsetMinutes = if (stationId != null) {
+                stationOffsets?.offsetFor(
+                    lineId = lineId,
+                    direction = direction.name.lowercase(),
+                    stationId = stationId,
+                )?.minutesFromOrigin ?: 0
+            } else {
+                0
+            }
+            projectForLine(
+                bundle = bundle,
+                today = targetDate,
+                nowMinutes = 0,
+                holidayDayType = holidayDayType,
+                lineId = lineId,
+                direction = direction,
+                limit = limit,
+                offsetMinutes = offsetMinutes,
+                out = results,
+            )
+        }
+        return results.sortedBy { it.minutesAway }.take(limit)
+    }
+
     private fun nextAirportLookahead(
         bundle: SyrmosSchedulesService.LineSchedule,
         today: LocalDate,

--- a/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/assistant/AthensTransitParserTest.kt
+++ b/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/assistant/AthensTransitParserTest.kt
@@ -120,6 +120,40 @@ class AthensTransitParserTest {
     }
 
     @Test
+    fun fare_query_airport() {
+        val intent = parser.parse("how much is a ticket to the Airport")
+        val fare = assertIs<AssistantIntent.ExplainFare>(intent)
+        assertTrue(fare.airport)
+    }
+
+    @Test
+    fun fare_query_standard() {
+        val intent = parser.parse("what's the ticket price")
+        val fare = assertIs<AssistantIntent.ExplainFare>(intent)
+        assertEquals(false, fare.airport)
+    }
+
+    @Test
+    fun greek_fare_query() {
+        assertIs<AssistantIntent.ExplainFare>(parser.parse("πόσο κάνει το εισιτήριο"))
+    }
+
+    @Test
+    fun favorite_station() {
+        val intent = parser.parse("favorite Syntagma")
+        val fav = assertIs<AssistantIntent.ToggleFavorite>(intent)
+        assertEquals("M2_SYN", fav.stationId)
+    }
+
+    @Test
+    fun favorite_without_station_asks_for_station() {
+        val intent = parser.parse("save this station")
+        val clar = assertIs<AssistantIntent.NeedsClarification>(intent)
+        assertIs<AssistantIntent.ToggleFavorite>(clar.base)
+        assertEquals(MissingSlot.STATION, clar.missing)
+    }
+
+    @Test
     fun out_of_scope_weather_elsewhere() {
         assertIs<AssistantIntent.OutOfScope>(parser.parse("what's the weather in London"))
     }

--- a/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/assistant/DayContextResolverTest.kt
+++ b/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/assistant/DayContextResolverTest.kt
@@ -1,0 +1,44 @@
+package com.syrmos.core.domain.assistant
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Pins DayContext -> day-offset math. 2026-06-29 is a Monday. */
+class DayContextResolverTest {
+    private val monday = LocalDate(2026, 6, 29)   // Monday
+    private val saturday = LocalDate(2026, 7, 4)  // Saturday
+    private val sunday = LocalDate(2026, 7, 5)    // Sunday
+
+    @Test fun today_is_zero() {
+        assertEquals(0, DayContextResolver.dayOffset(DayContext.TODAY, monday))
+    }
+
+    @Test fun tomorrow_is_one() {
+        assertEquals(1, DayContextResolver.dayOffset(DayContext.TOMORROW, monday))
+    }
+
+    @Test fun saturday_from_monday_is_five() {
+        assertEquals(5, DayContextResolver.dayOffset(DayContext.SATURDAY, monday))
+    }
+
+    @Test fun sunday_from_monday_is_six() {
+        assertEquals(6, DayContextResolver.dayOffset(DayContext.SUNDAY, monday))
+    }
+
+    @Test fun weekend_from_monday_is_next_saturday() {
+        assertEquals(5, DayContextResolver.dayOffset(DayContext.WEEKEND, monday))
+    }
+
+    @Test fun weekend_on_saturday_is_today() {
+        assertEquals(0, DayContextResolver.dayOffset(DayContext.WEEKEND, saturday))
+    }
+
+    @Test fun weekend_on_sunday_is_today() {
+        assertEquals(0, DayContextResolver.dayOffset(DayContext.WEEKEND, sunday))
+    }
+
+    @Test fun saturday_on_saturday_is_today() {
+        assertEquals(0, DayContextResolver.dayOffset(DayContext.SATURDAY, saturday))
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/assistant/AssistantViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/assistant/AssistantViewModel.kt
@@ -2,13 +2,17 @@ package com.syrmos.feature.home.assistant
 
 import com.syrmos.core.common.AppLanguage
 import com.syrmos.core.common.LocalizationManager
+import com.syrmos.core.data.repository.FavoritesRepository
 import com.syrmos.core.data.repository.StationRepositoryImpl
 import com.syrmos.core.data.sync.AnnouncementsRepository
+import com.syrmos.core.data.sync.FaresRepository
 import com.syrmos.core.domain.assistant.AssistantIntent
 import com.syrmos.core.domain.assistant.AssistantVocabularyBuilder
 import com.syrmos.core.domain.assistant.AthensTransitParser
 import com.syrmos.core.domain.assistant.DayContext
+import com.syrmos.core.domain.assistant.DayContextResolver
 import com.syrmos.core.domain.assistant.MissingSlot
+import com.syrmos.core.domain.usecase.ComputeDeparturesFromBandsUseCase
 import com.syrmos.core.domain.usecase.GetLastTrainUseCase
 import com.syrmos.core.domain.usecase.GetLinesUseCase
 import com.syrmos.core.domain.usecase.GetNextDeparturesUseCase
@@ -61,10 +65,13 @@ class AssistantViewModel(
     private val stationRepository: StationRepositoryImpl,
     private val getLinesUseCase: GetLinesUseCase,
     private val getNextDepartures: GetNextDeparturesUseCase,
+    private val bandProjector: ComputeDeparturesFromBandsUseCase,
     private val getLastTrain: GetLastTrainUseCase,
     private val planJourney: PlanJourneyUseCase,
     private val searchStations: SearchStationsUseCase,
     private val announcementsRepository: AnnouncementsRepository,
+    private val faresRepository: FaresRepository,
+    private val favoritesRepository: FavoritesRepository,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val _uiState = MutableStateFlow(AssistantUiState())
@@ -107,6 +114,8 @@ class AssistantViewModel(
         is AssistantIntent.PlanTrip -> resolvePlanTrip(intent)
         is AssistantIntent.FindStation -> resolveFindStation(intent)
         is AssistantIntent.ExplainLine -> resolveExplainLine(intent)
+        is AssistantIntent.ExplainFare -> resolveFare(intent)
+        is AssistantIntent.ToggleFavorite -> resolveFavorite(intent)
         is AssistantIntent.ShowAlerts -> resolveAlerts(intent)
         is AssistantIntent.OpenMap -> resolveOpenMap(intent)
         AssistantIntent.Help -> botMessage(helpText())
@@ -117,6 +126,11 @@ class AssistantViewModel(
     private suspend fun resolveDepartures(intent: AssistantIntent.ShowDepartures): AssistantMessage {
         val station = resolveStation(intent.stationId, intent.lineId) ?: return botMessage(clarify(MissingSlot.STATION))
         val lineIds = intent.lineId?.let { listOf(it) } ?: station.lineIds
+
+        if (intent.day != DayContext.TODAY) {
+            return resolveDeparturesForDay(intent.day, station, lineIds)
+        }
+
         val departures = mutableListOf<UpcomingDeparture>()
         for (lineId in lineIds) {
             for (direction in Direction.entries) {
@@ -129,23 +143,57 @@ class AssistantViewModel(
                 "Δεν υπάρχουν άλλα δρομολόγια από ${stationName(station)} τώρα.",
                 "Nuk ka më trena nga ${stationName(station)} tani."))
         }
-        val header = t("Next from ${stationName(station)}:",
-            "Επόμενα από ${stationName(station)}:",
-            "Të ardhshmet nga ${stationName(station)}:")
-        val dayNote = if (intent.day != DayContext.TODAY) {
-            "\n" + t("Showing today. Open the line for the full ${intent.day.name.lowercase()} timetable.",
-                "Εμφανίζεται σήμερα. Άνοιξε τη γραμμή για όλο το πρόγραμμα.",
-                "Po shfaqet sot. Hap linjën për orarin e plotë.")
-        } else ""
         return AssistantMessage(
             id = nextId++,
             fromUser = false,
-            text = header + dayNote,
+            text = t("Next from ${stationName(station)}:",
+                "Επόμενα από ${stationName(station)}:",
+                "Të ardhshmet nga ${stationName(station)}:"),
             departures = sorted,
             action = intent.lineId?.let { AssistantAction.OpenLine(normalizeLine(it)) }
                 ?: AssistantAction.OpenStation(station.id),
             actionLabel = t("Open", "Άνοιγμα", "Hap"),
         )
+    }
+
+    /** "this weekend / tomorrow / Saturday": project that whole service day from 00:00. */
+    private fun resolveDeparturesForDay(day: DayContext, station: Station, lineIds: List<String>): AssistantMessage {
+        val dayOffset = DayContextResolver.dayOffset(day)
+        val expanded = lineIds.flatMap { if (it == "M3") listOf("M3", "M3_AIR") else listOf(it) }
+        val departures = mutableListOf<UpcomingDeparture>()
+        for (lineId in expanded) {
+            for (direction in Direction.entries) {
+                departures += bandProjector.invokeForDay(listOf(lineId), direction, dayOffset, limit = 3, stationId = station.id)
+            }
+        }
+        // Day-projection times are clock times (countdown from midnight is
+        // meaningless for a future day), so surface them as text, not as the
+        // live "X min" chips the today path uses.
+        val sorted = departures.distinctBy { it.time + it.lineId }.sortedBy { it.minutesAway }.take(4)
+        val label = dayLabel(day)
+        if (sorted.isEmpty()) {
+            return botMessage(t("I don't have $label's schedule for ${stationName(station)} offline.",
+                "Δεν έχω το πρόγραμμα του $label για ${stationName(station)} εκτός σύνδεσης.",
+                "Nuk e kam orarin e $label për ${stationName(station)} pa internet."))
+        }
+        val times = sorted.joinToString(", ") { "${it.lineId} ${it.time}" }
+        return AssistantMessage(
+            id = nextId++,
+            fromUser = false,
+            text = t("First trains $label from ${stationName(station)}: $times.",
+                "Πρώτα δρομολόγια $label από ${stationName(station)}: $times.",
+                "Trenat e parë $label nga ${stationName(station)}: $times."),
+            action = AssistantAction.OpenStation(station.id),
+            actionLabel = t("Open", "Άνοιγμα", "Hap"),
+        )
+    }
+
+    private fun dayLabel(day: DayContext): String = when (day) {
+        DayContext.TOMORROW -> t("tomorrow", "αύριο", "nesër")
+        DayContext.WEEKEND -> t("this weekend", "το Σαββατοκύριακο", "këtë fundjavë")
+        DayContext.SATURDAY -> t("Saturday", "το Σάββατο", "të shtunën")
+        DayContext.SUNDAY -> t("Sunday", "την Κυριακή", "të dielën")
+        DayContext.TODAY -> t("today", "σήμερα", "sot")
     }
 
     private suspend fun resolveLastTrain(intent: AssistantIntent.LastTrain): AssistantMessage {
@@ -225,6 +273,60 @@ class AssistantViewModel(
         )
     }
 
+    private suspend fun resolveFare(intent: AssistantIntent.ExplainFare): AssistantMessage {
+        faresRepository.hydrateFromBundleIfNeeded()
+        val products = faresRepository.products.value
+        if (products.isEmpty()) {
+            return botMessage(t("I don't have fare prices available offline right now.",
+                "Δεν έχω διαθέσιμες τιμές εισιτηρίων εκτός σύνδεσης τώρα.",
+                "Nuk kam çmime biletash të disponueshme pa internet tani."))
+        }
+        val picks = if (intent.airport) {
+            products.filter { it.tags.any { tag -> tag.contains("airport") } }
+                .sortedBy { it.fullPriceEur ?: Double.MAX_VALUE }.take(2)
+        } else {
+            products.filter { it.section == "single" }
+                .sortedBy { it.fullPriceEur ?: Double.MAX_VALUE }.take(2)
+        }.ifEmpty { products.take(2) }
+        val lines = picks.joinToString(" · ") { "${fareTitle(it)} ${money(it.fullPriceEur)}" }
+        return botMessage(lines)
+    }
+
+    private fun resolveFavorite(intent: AssistantIntent.ToggleFavorite): AssistantMessage {
+        val stationId = intent.stationId ?: return botMessage(clarify(MissingSlot.STATION))
+        val station = stations.firstOrNull { it.id == stationId }
+        val name = station?.let { stationName(it) } ?: stationId
+        val nowFavorite = favoritesRepository.toggleStation(stationId)
+        val text = if (nowFavorite) {
+            t("Added $name to your favorites.", "Πρόσθεσα τον $name στα αγαπημένα σου.",
+                "Shtova $name te të preferuarat e tua.")
+        } else {
+            t("Removed $name from your favorites.", "Αφαίρεσα τον $name από τα αγαπημένα σου.",
+                "Hoqa $name nga të preferuarat e tua.")
+        }
+        return AssistantMessage(
+            id = nextId++,
+            fromUser = false,
+            text = text,
+            action = station?.let { AssistantAction.OpenStation(it.id) },
+            actionLabel = station?.let { t("Open", "Άνοιγμα", "Hap") },
+        )
+    }
+
+    private fun fareTitle(product: com.syrmos.core.network.SyrmosSchedulesService.FareProduct): String =
+        when (LocalizationManager.language.value) {
+            AppLanguage.GREEK -> product.titleEl.ifBlank { product.titleEn }
+            AppLanguage.ALBANIAN -> product.titleSq.ifBlank { product.titleEn }
+            else -> product.titleEn
+        }
+
+    /** Formats a euro amount without depending on platform String.format. */
+    private fun money(amount: Double?): String {
+        if (amount == null) return ""
+        val cents = kotlin.math.round(amount * 100).toLong()
+        return "€${cents / 100}.${(cents % 100).toString().padStart(2, '0')}"
+    }
+
     private suspend fun resolveAlerts(intent: AssistantIntent.ShowAlerts): AssistantMessage {
         val feed = announcementsRepository.feed.first()
         val alerts = feed.announcements.filter { it.isServiceAlert }
@@ -281,9 +383,9 @@ class AssistantViewModel(
     )
 
     private fun helpText(): String = t(
-        "I can show next departures, the last train home, plan a trip between two stations, explain a line, and show service alerts. I only cover Syrmos and Athens public transport, fully offline.",
-        "Μπορώ να δείξω επόμενες αναχωρήσεις, το τελευταίο τρένο, διαδρομή μεταξύ δύο σταθμών, να εξηγήσω μια γραμμή και ειδοποιήσεις. Καλύπτω μόνο το Syrmos και τις συγκοινωνίες της Αθήνας, εκτός σύνδεσης.",
-        "Mund të tregoj nisjet, trenin e fundit, një udhëtim mes dy stacioneve, të shpjegoj një linjë dhe njoftimet. Mbuloj vetëm Syrmos dhe transportin e Athinës, pa internet.",
+        "I can show next departures (today or a future day), the last train home, plan a trip, explain a line, ticket prices, service alerts, and favorite a station. I only cover Syrmos and Athens public transport, fully offline.",
+        "Μπορώ να δείξω επόμενες αναχωρήσεις (σήμερα ή άλλη μέρα), το τελευταίο τρένο, διαδρομή, να εξηγήσω μια γραμμή, τιμές εισιτηρίων, ειδοποιήσεις και να προσθέσω σταθμό στα αγαπημένα. Καλύπτω μόνο το Syrmos και τις συγκοινωνίες της Αθήνας, εκτός σύνδεσης.",
+        "Mund të tregoj nisjet (sot ose një ditë tjetër), trenin e fundit, një udhëtim, të shpjegoj një linjë, çmimet e biletave, njoftimet dhe të ruaj një stacion. Mbuloj vetëm Syrmos dhe transportin e Athinës, pa internet.",
     )
 
     private fun outOfScopeText(): String = t(

--- a/iosApp/Syrmos.xcodeproj/project.pbxproj
+++ b/iosApp/Syrmos.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		DA7A0011F00D0011F00D0011 /* iosApp/Features/Assistant/AriadneParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0012F00D0012F00D0012 /* iosApp/Features/Assistant/AriadneParser.swift */; };
 		DA7A0013F00D0013F00D0013 /* iosApp/Features/Assistant/AriadneModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0014F00D0014F00D0014 /* iosApp/Features/Assistant/AriadneModel.swift */; };
 		DA7A0015F00D0015F00D0015 /* iosApp/Features/Assistant/AriadneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0016F00D0016F00D0016 /* iosApp/Features/Assistant/AriadneView.swift */; };
+		DA7A0130F00D0130F00D0130 /* iosApp/Features/Assistant/JourneyPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0131F00D0131F00D0131 /* iosApp/Features/Assistant/JourneyPlanner.swift */; };
 		AAAA111111111111111111B3 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA111111111111111111B4 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift */; };
 		AABB01CD02EF030405060708 /* Resources/seed-schedules-v2 in Resources */ = {isa = PBXBuildFile; fileRef = AABB01CD02EF030405060709 /* Resources/seed-schedules-v2 */; };
 		B264406F57304E569BAAED79 /* iosApp/Features/Timetables/TimetablesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09288EF8307B4CDC9D065AED /* iosApp/Features/Timetables/TimetablesView.swift */; };
@@ -117,6 +118,7 @@
 		DA7A0012F00D0012F00D0012 /* iosApp/Features/Assistant/AriadneParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneParser.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0014F00D0014F00D0014 /* iosApp/Features/Assistant/AriadneModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneModel.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0016F00D0016F00D0016 /* iosApp/Features/Assistant/AriadneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneView.swift; sourceTree = SOURCE_ROOT; };
+		DA7A0131F00D0131F00D0131 /* iosApp/Features/Assistant/JourneyPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/JourneyPlanner.swift; sourceTree = SOURCE_ROOT; };
 		AAAA111111111111111111B4 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Onboarding/OnboardingMeshBackground.swift; sourceTree = SOURCE_ROOT; };
 		AABB01CD02EF030405060709 /* Resources/seed-schedules-v2 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Resources/seed-schedules-v2"; sourceTree = "<group>"; };
 		B9C311F839BA02691F04AB93 /* NearbyStationDestinationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NearbyStationDestinationTests.swift; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 				DA7A0012F00D0012F00D0012 /* iosApp/Features/Assistant/AriadneParser.swift */,
 				DA7A0014F00D0014F00D0014 /* iosApp/Features/Assistant/AriadneModel.swift */,
 				DA7A0016F00D0016F00D0016 /* iosApp/Features/Assistant/AriadneView.swift */,
+				DA7A0131F00D0131F00D0131 /* iosApp/Features/Assistant/JourneyPlanner.swift */,
 				AAAA111111111111111111B4 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift */,
 			);
 			name = Onboarding;
@@ -590,6 +593,7 @@
 				DA7A0011F00D0011F00D0011 /* iosApp/Features/Assistant/AriadneParser.swift in Sources */,
 				DA7A0013F00D0013F00D0013 /* iosApp/Features/Assistant/AriadneModel.swift in Sources */,
 				DA7A0015F00D0015F00D0015 /* iosApp/Features/Assistant/AriadneView.swift in Sources */,
+				DA7A0130F00D0130F00D0130 /* iosApp/Features/Assistant/JourneyPlanner.swift in Sources */,
 				AAAA111111111111111111B3 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift in Sources */,
 				03FBB75EEE74C7E43F7A609B /* iosApp/DesignSystem/CompactTabHeader.swift in Sources */,
 				8218D06AFB1A4111BBE6A6BA /* iosApp/Core/Persistence/SyrmosVisualOverridesStore.swift in Sources */,

--- a/iosApp/iosApp/Features/Assistant/AriadneModel.swift
+++ b/iosApp/iosApp/Features/Assistant/AriadneModel.swift
@@ -51,6 +51,10 @@ final class AriadneModel: ObservableObject {
             return resolveFindStation(query)
         case let .explainLine(lineId):
             return resolveExplainLine(lineId)
+        case let .explainFare(airport):
+            return resolveFare(airport: airport)
+        case let .toggleFavorite(stationId):
+            return resolveFavorite(stationId: stationId)
         case let .showAlerts(lineId):
             return await resolveAlerts(lineId: lineId)
         case let .openMap(stationId):
@@ -69,6 +73,11 @@ final class AriadneModel: ObservableObject {
             return bot(clarify(.station))
         }
         let lineIds = lineId.map { [$0] } ?? station.lineIds
+
+        if day != .today {
+            return resolveDeparturesForDay(day: day, station: station, lineIds: lineIds)
+        }
+
         let deps = ScheduleProjector.nextDepartures(for: station.id, lineIds: lineIds, limit: 4)
         if deps.isEmpty {
             return bot(t("No more trains from \(name(station)) right now.",
@@ -76,10 +85,100 @@ final class AriadneModel: ObservableObject {
                 "Nuk ka më trena nga \(name(station)) tani."))
         }
         let header = t("Next from \(name(station)):", "Επόμενα από \(name(station)):", "Të ardhshmet nga \(name(station)):")
-        let note = day == .today ? "" : "\n" + t("Showing today. Open the line for the full timetable.",
-            "Εμφανίζεται σήμερα. Άνοιξε τη γραμμή για όλο το πρόγραμμα.",
-            "Po shfaqet sot. Hap linjën për orarin e plotë.")
-        return AriadneMessage(fromUser: false, text: header + note, departures: Array(deps.prefix(4)))
+        return AriadneMessage(fromUser: false, text: header, departures: Array(deps.prefix(4)))
+    }
+
+    /// "this weekend / tomorrow / Saturday": project that whole service day from
+    /// 00:00 via the projector's dayOffset path. Times are shown as text (a
+    /// countdown from midnight is meaningless for a future day).
+    private func resolveDeparturesForDay(day: DayContext, station: TransitStation, lineIds: [String]) -> AriadneMessage {
+        let offset = Self.dayOffset(for: day)
+        let deps = ScheduleProjector.nextDepartures(for: station.id, lineIds: lineIds, limit: 4, dayOffset: offset)
+        let label = dayLabel(day)
+        if deps.isEmpty {
+            return bot(t("I don't have \(label)'s schedule for \(name(station)) offline.",
+                "Δεν έχω το πρόγραμμα \(label) για \(name(station)) εκτός σύνδεσης.",
+                "Nuk e kam orarin \(label) për \(name(station)) pa internet."))
+        }
+        let times = deps.prefix(4).map { "\($0.lineId) \($0.time)" }.joined(separator: ", ")
+        return bot(t("First trains \(label) from \(name(station)): \(times).",
+            "Πρώτα δρομολόγια \(label) από \(name(station)): \(times).",
+            "Trenat e parë \(label) nga \(name(station)): \(times)."))
+    }
+
+    /// Days from today to the requested DayContext (Athens calendar). Mirrors
+    /// the KMP DayContextResolver.
+    private static func dayOffset(for day: DayContext) -> Int {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Europe/Athens") ?? .current
+        // Calendar weekday: Sunday = 1 ... Saturday = 7. Convert to ISO Mon=1..Sun=7.
+        let weekday = cal.component(.weekday, from: Date())
+        let iso = weekday == 1 ? 7 : weekday - 1
+        switch day {
+        case .today: return 0
+        case .tomorrow: return 1
+        case .saturday: return (6 - iso + 7) % 7
+        case .sunday: return (7 - iso + 7) % 7
+        case .weekend: return iso >= 6 ? 0 : 6 - iso
+        }
+    }
+
+    private func dayLabel(_ day: DayContext) -> String {
+        switch day {
+        case .tomorrow: return t("tomorrow", "αύριο", "nesër")
+        case .weekend: return t("this weekend", "το Σαββατοκύριακο", "këtë fundjavë")
+        case .saturday: return t("Saturday", "το Σάββατο", "të shtunën")
+        case .sunday: return t("Sunday", "την Κυριακή", "të dielën")
+        case .today: return t("today", "σήμερα", "sot")
+        }
+    }
+
+    private func resolveFare(airport: Bool) -> AriadneMessage {
+        let products = SyrmosFaresStore.shared.products
+        if products.isEmpty {
+            return bot(t("I don't have fare prices available offline right now.",
+                "Δεν έχω διαθέσιμες τιμές εισιτηρίων εκτός σύνδεσης τώρα.",
+                "Nuk kam çmime biletash të disponueshme pa internet tani."))
+        }
+        let picks: [SyrmosFaresStore.Product]
+        if airport {
+            picks = products.filter { $0.tags.contains { $0.contains("airport") } }
+                .sorted { ($0.fullPriceEur ?? .greatestFiniteMagnitude) < ($1.fullPriceEur ?? .greatestFiniteMagnitude) }
+        } else {
+            picks = products.filter { $0.section == "single" }
+                .sorted { ($0.fullPriceEur ?? .greatestFiniteMagnitude) < ($1.fullPriceEur ?? .greatestFiniteMagnitude) }
+        }
+        let chosen = (picks.isEmpty ? Array(products.prefix(2)) : Array(picks.prefix(2)))
+        let line = chosen.map { "\($0.localizedTitle(loc.language)) \(money($0.fullPriceEur))" }.joined(separator: " · ")
+        return bot(line)
+    }
+
+    private func resolveFavorite(stationId: String?) -> AriadneMessage {
+        guard let id = stationId else { return bot(clarify(.station)) }
+        let st = station(id)
+        let label = st.map { name($0) } ?? id
+        let nowFavorite = toggleFavorite(id)
+        return bot(nowFavorite
+            ? t("Added \(label) to your favorites.", "Πρόσθεσα τον \(label) στα αγαπημένα σου.", "Shtova \(label) te të preferuarat e tua.")
+            : t("Removed \(label) from your favorites.", "Αφαίρεσα τον \(label) από τα αγαπημένα σου.", "Hoqa \(label) nga të preferuarat e tua."))
+    }
+
+    /// Favorites persistence on iOS (UserDefaults set of station ids). Returns
+    /// the new state. Parallels the KMP FavoritesRepository.
+    private func toggleFavorite(_ stationId: String) -> Bool {
+        let key = "syrmos.favorite.stations"
+        var set = Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
+        let nowFavorite: Bool
+        if set.contains(stationId) { set.remove(stationId); nowFavorite = false }
+        else { set.insert(stationId); nowFavorite = true }
+        UserDefaults.standard.set(Array(set), forKey: key)
+        return nowFavorite
+    }
+
+    private func money(_ amount: Double?) -> String {
+        guard let amount else { return "" }
+        let cents = Int((amount * 100).rounded())
+        return "€\(cents / 100).\(String(format: "%02d", cents % 100))"
     }
 
     private func resolveLastTrain(stationId: String?, lineId: String?) -> AriadneMessage {
@@ -98,36 +197,26 @@ final class AriadneModel: ObservableObject {
             "Treni i fundit \(displayLine(last.lineId)) nga \(name(station)) niset \(last.time). Nisu deri atëherë."))
     }
 
-    /// Compact 0-or-1-transfer planner over the bundled network. The Athens
-    /// rail map is small enough that direct or single-interchange routes cover
-    /// almost every pair; deeper routing is the KMP Dijkstra planner's job.
+    /// Full point-to-point routing via `JourneyPlanner` (Dijkstra), matching
+    /// the Android/Web `PlanJourneyUseCase`.
     private func resolvePlanTrip(from: String?, to: String?, lowExposure: Bool) -> AriadneMessage {
         guard let fromId = from else { return bot(clarify(.originStation)) }
         guard let toId = to else { return bot(clarify(.destinationStation)) }
-        guard let a = station(fromId), let b = station(toId) else { return bot(outOfScopeText()) }
-        let exposure = lowExposure ? "\n" + t("I can't check live weather offline, but this is the simplest route.",
-            "Δεν μπορώ να δω τον καιρό εκτός σύνδεσης, αλλά αυτή είναι η απλούστερη διαδρομή.",
-            "Nuk e kontrolloj dot motin pa internet, por kjo është rruga më e thjeshtë.") : ""
-
-        // Direct: a shared line.
-        if let shared = Set(a.lineIds).intersection(b.lineIds).first {
-            return bot(t("Take \(displayLine(shared)) directly from \(name(a)) to \(name(b)). No change.",
-                "Πάρε \(displayLine(shared)) απευθείας από \(name(a)) στο \(name(b)). Χωρίς αλλαγή.",
-                "Merr \(displayLine(shared)) drejtpërdrejt nga \(name(a)) te \(name(b)). Pa ndërrim.") + exposure)
+        guard let plan = JourneyPlanner.plan(from: fromId, to: toId, language: loc.language) else {
+            return bot(t("I couldn't find a rail route between those.",
+                "Δεν βρήκα σιδηροδρομική διαδρομή ανάμεσά τους.",
+                "Nuk gjeta një rrugë hekurudhore mes tyre."))
         }
-        // One transfer at a shared interchange.
-        for la in a.lineIds {
-            for lb in b.lineIds {
-                if let interchange = interchangeBetween(la, lb) {
-                    return bot(t("Take \(displayLine(la)) to \(name(interchange)), change to \(displayLine(lb)) to \(name(b)). 1 change.",
-                        "Πάρε \(displayLine(la)) ως \(name(interchange)), άλλαξε σε \(displayLine(lb)) για \(name(b)). 1 αλλαγή.",
-                        "Merr \(displayLine(la)) te \(name(interchange)), ndërro në \(displayLine(lb)) për \(name(b)). 1 ndërrim.") + exposure)
-                }
-            }
-        }
-        return bot(t("That trip needs more than one change. Open the Map to plan it visually.",
-            "Αυτή η διαδρομή χρειάζεται πάνω από μία αλλαγή. Άνοιξε τον Χάρτη.",
-            "Ai udhëtim kërkon më shumë se një ndërrim. Hap Hartën."))
+        let legs = plan.legs.map { "\(displayLine($0.lineId)) \($0.toName)" }.joined(separator: " → ")
+        let transfers = plan.transfers == 0
+            ? t("no change", "χωρίς αλλαγή", "pa ndërrim")
+            : t("\(plan.transfers) change(s)", "\(plan.transfers) αλλαγή/ές", "\(plan.transfers) ndërrim(e)")
+        let exposure = lowExposure ? "\n" + t("I can't check live weather offline, but this is the fewest-transfer route.",
+            "Δεν μπορώ να δω τον καιρό εκτός σύνδεσης, αλλά αυτή έχει τις λιγότερες αλλαγές.",
+            "Nuk e kontrolloj dot motin pa internet, por kjo ka më pak ndërrime.") : ""
+        return bot(t("\(legs). About \(plan.totalMinutes) min, \(transfers).",
+            "\(legs). Περίπου \(plan.totalMinutes) λεπτά, \(transfers).",
+            "\(legs). Rreth \(plan.totalMinutes) min, \(transfers).") + exposure)
     }
 
     private func resolveFindStation(_ query: String) -> AriadneMessage {
@@ -196,13 +285,6 @@ final class AriadneModel: ObservableObject {
     }
 
     private func station(_ id: String) -> TransitStation? { allStations().first { $0.id == id } }
-
-    /// A station served by both lines (a usable interchange), if any.
-    private func interchangeBetween(_ lineA: String, _ lineB: String) -> TransitStation? {
-        let onA = SyrmosData.stations(for: normalizeLine(lineA))
-        let onBIds = Set(SyrmosData.stations(for: normalizeLine(lineB)).map { $0.id })
-        return onA.first { onBIds.contains($0.id) }
-    }
 
     private func name(_ st: TransitStation) -> String {
         loc.language == .greek && !st.nameEl.isEmpty ? st.nameEl : st.name

--- a/iosApp/iosApp/Features/Assistant/AriadneParser.swift
+++ b/iosApp/iosApp/Features/Assistant/AriadneParser.swift
@@ -15,6 +15,8 @@ indirect enum AssistantIntent: Equatable {
     case findStation(query: String)
     case planTrip(fromStationId: String?, toStationId: String?, lowExposure: Bool)
     case explainLine(lineId: String)
+    case explainFare(airport: Bool)
+    case toggleFavorite(stationId: String?)
     case showAlerts(lineId: String?)
     case openMap(stationId: String?)
     case help
@@ -80,11 +82,24 @@ struct AthensTransitParser {
             containsAny(text, Self.mapWords) ||
             containsAny(text, Self.lastTrainPhrases) ||
             containsAny(text, Self.planPhrases) ||
-            containsAny(text, Self.findWords)
+            containsAny(text, Self.findWords) ||
+            containsAny(text, Self.fareWords) ||
+            containsAny(text, Self.favoriteWords)
 
         let weather = containsAny(text, Self.weatherWords)
         if weather && !strongTransit { return .outOfScope }
         if !strongTransit && !intentSignal && !weather { return .outOfScope }
+
+        // 0a. Fares (before planning, so "how much to the airport" is a fare).
+        if containsAny(text, Self.fareWords) {
+            return .explainFare(airport: containsAny(text, Self.airportWords))
+        }
+
+        // 0b. Favorites.
+        if containsAny(text, Self.favoriteWords) {
+            let base = AssistantIntent.toggleFavorite(stationId: stations.first)
+            return stations.first == nil ? .needsClarification(base: base, missing: .station) : base
+        }
 
         // 1. Plan a trip.
         let hasToMarker = Self.toMarkers.contains { text.contains($0) }
@@ -248,6 +263,12 @@ struct AthensTransitParser {
     private static let findWords = ["where is", "find", "locate", "nearest", "near me", "closest",
         "που ειναι", "βρες", "κοντιν", "κοντα μου", "πλησιεστερ", "ku eshte", "gjej", "me afert", "afer meje"]
     private static let lineWords = ["line", "about", "tell me about", "γραμμη", "σχετικα", "linja", "rreth"]
+    private static let fareWords = ["fare", "fares", "ticket", "tickets", "how much", "price", "cost", "cheap",
+        "εισιτηρι", "ποσο κανει", "ποσο κοστιζει", "τιμη", "κοστος", "bilete", "sa kushton", "kushton", "cmim", "cmimi"]
+    private static let favoriteWords = ["favorite", "favourite", "save this", "bookmark", "add to favorites", "pin",
+        "αγαπημεν", "αποθηκευσ", "προσθεσε στα αγαπημενα", "σημειωσε",
+        "i preferuar", "te preferuarat", "ruaj", "shto te te preferuarat"]
+    private static let airportWords = ["airport", "αεροδρομιο", "aeroport"]
     private static let alertWords = ["alert", "alerts", "status", "disruption", "delay", "delays", "problem", "closed", "closure",
         "ειδοποι", "κατασταση", "καθυστερη", "προβλημα", "κλειστ", "διακοπη", "njoftim", "vonese", "mbyll"]
     private static let mapWords = ["map", "show on map", "on the map", "χαρτη", "στον χαρτη", "harta", "ne harte"]

--- a/iosApp/iosApp/Features/Assistant/JourneyPlanner.swift
+++ b/iosApp/iosApp/Features/Assistant/JourneyPlanner.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Point-to-point routing across the bundled Athens rail network, the Swift
+/// port of the KMP `PlanJourneyUseCase` (Dijkstra over a station graph). Any
+/// number of transfers, so iOS matches Android/Web.
+///
+/// One iOS-specific wrinkle: interchange stations carry a different station id
+/// per line here (e.g. M2_SYN vs M3_SYN at Syntagma), so the graph adds explicit
+/// transfer edges between co-located stations (same accent-folded name) to let
+/// Dijkstra change lines at a physical interchange.
+enum JourneyPlanner {
+    struct Leg {
+        let lineId: String
+        let toName: String
+        let stops: Int
+        let minutes: Int
+    }
+
+    struct Plan {
+        let legs: [Leg]
+        let totalMinutes: Int
+        let transfers: Int
+    }
+
+    private struct Edge {
+        let to: String
+        let lineId: String?   // nil = transfer between co-located stations
+        let weight: Int
+    }
+
+    static func plan(from fromId: String, to toId: String, language: AppLanguage) -> Plan? {
+        if fromId == toId { return nil }
+        let stations = allStations()
+        let byId = Dictionary(uniqueKeysWithValues: stations.map { ($0.id, $0) })
+        guard byId[fromId] != nil, byId[toId] != nil else { return nil }
+
+        var graph: [String: [Edge]] = [:]
+
+        // Same-line edges between consecutive stations.
+        for line in SyrmosData.lines {
+            let weight = travelTime(for: line.type)
+            let ordered = SyrmosData.stations(for: line.id)
+            for i in 0..<max(0, ordered.count - 1) {
+                let a = ordered[i].id
+                let b = ordered[i + 1].id
+                graph[a, default: []].append(Edge(to: b, lineId: line.id, weight: weight))
+                graph[b, default: []].append(Edge(to: a, lineId: line.id, weight: weight))
+            }
+        }
+
+        // Transfer edges between co-located stations (same physical place,
+        // different per-line ids).
+        var groups: [String: [String]] = [:]
+        for st in stations {
+            groups[norm(st.name.isEmpty ? st.nameEl : st.name), default: []].append(st.id)
+        }
+        for (_, ids) in groups where ids.count > 1 {
+            for i in 0..<ids.count {
+                for j in (i + 1)..<ids.count {
+                    graph[ids[i], default: []].append(Edge(to: ids[j], lineId: nil, weight: TRANSFER_MINUTES))
+                    graph[ids[j], default: []].append(Edge(to: ids[i], lineId: nil, weight: TRANSFER_MINUTES))
+                }
+            }
+        }
+
+        // Dijkstra.
+        var dist: [String: Int] = [fromId: 0]
+        var prev: [String: (String, Edge)] = [:]
+        var visited = Set<String>()
+        var frontier: [(String, Int)] = [(fromId, 0)]
+
+        while !frontier.isEmpty {
+            frontier.sort { $0.1 < $1.1 }
+            let (current, d) = frontier.removeFirst()
+            if visited.contains(current) { continue }
+            visited.insert(current)
+            if current == toId { break }
+            for edge in graph[current] ?? [] {
+                let nd = d + edge.weight
+                if nd < (dist[edge.to] ?? Int.max) {
+                    dist[edge.to] = nd
+                    prev[edge.to] = (current, edge)
+                    frontier.append((edge.to, nd))
+                }
+            }
+        }
+
+        guard prev[toId] != nil else { return nil }
+
+        // Reconstruct (stationId, edge) path from origin to destination.
+        var path: [(String, Edge)] = []
+        var node = toId
+        while node != fromId {
+            guard let (p, e) = prev[node] else { break }
+            path.insert((node, e), at: 0)
+            node = p
+        }
+
+        // Merge consecutive same-line edges into legs; transfer edges split legs.
+        var legs: [Leg] = []
+        var curLine: String?
+        var stops = 0
+        var minutes = 0
+        var lastName = byId[fromId].map { displayName($0, language) } ?? fromId
+
+        func flush(endName: String) {
+            if let line = curLine {
+                legs.append(Leg(lineId: line, toName: endName, stops: stops, minutes: minutes))
+            }
+        }
+
+        for (stationId, edge) in path {
+            let stationName = byId[stationId].map { displayName($0, language) } ?? stationId
+            if edge.lineId == nil {
+                // Transfer: close the current leg at this interchange.
+                flush(endName: stationName)
+                curLine = nil
+                stops = 0
+                minutes = 0
+                lastName = stationName
+            } else if edge.lineId != curLine {
+                flush(endName: lastName)
+                curLine = edge.lineId
+                stops = 1
+                minutes = edge.weight
+                lastName = stationName
+            } else {
+                stops += 1
+                minutes += edge.weight
+                lastName = stationName
+            }
+        }
+        flush(endName: byId[toId].map { displayName($0, language) } ?? toId)
+
+        if legs.isEmpty { return nil }
+        let total = dist[toId] ?? legs.reduce(0) { $0 + $1.minutes }
+        return Plan(legs: legs, totalMinutes: total, transfers: max(0, legs.count - 1))
+    }
+
+    // MARK: - Helpers
+
+    private static let TRANSFER_MINUTES = 3
+
+    private static func travelTime(for type: TransitType) -> Int {
+        switch type {
+        case .metro: return 2
+        case .tram: return 3
+        case .suburban: return 4
+        }
+    }
+
+    private static func allStations() -> [TransitStation] {
+        var seen = Set<String>()
+        var out: [TransitStation] = []
+        for line in SyrmosData.lines {
+            for st in SyrmosData.stations(for: line.id) where !seen.contains(st.id) {
+                seen.insert(st.id); out.append(st)
+            }
+        }
+        return out
+    }
+
+    private static func displayName(_ st: TransitStation, _ lang: AppLanguage) -> String {
+        lang == .greek && !st.nameEl.isEmpty ? st.nameEl : st.name
+    }
+
+    private static func norm(_ s: String) -> String {
+        String(AthensTransitParser.fold(s).filter { $0.isLetter || $0.isNumber })
+    }
+}

--- a/iosApp/iosAppTests/AriadneParserTests.swift
+++ b/iosApp/iosAppTests/AriadneParserTests.swift
@@ -77,6 +77,35 @@ final class AriadneParserTests: XCTestCase {
         guard case .help = parser.parse("what can you do?") else { return XCTFail("expected help") }
     }
 
+    func test_fareAirport() {
+        guard case let .explainFare(airport) = parser.parse("how much is a ticket to the Airport") else {
+            return XCTFail("expected fare")
+        }
+        XCTAssertTrue(airport)
+    }
+
+    func test_fareStandard() {
+        guard case let .explainFare(airport) = parser.parse("what's the ticket price") else {
+            return XCTFail("expected fare")
+        }
+        XCTAssertFalse(airport)
+    }
+
+    func test_favoriteStation() {
+        guard case let .toggleFavorite(stationId) = parser.parse("favorite Syntagma") else {
+            return XCTFail("expected favorite")
+        }
+        XCTAssertEqual(stationId, "M2_SYN")
+    }
+
+    func test_favoriteWithoutStationAsksStation() {
+        guard case let .needsClarification(base, missing) = parser.parse("save this station") else {
+            return XCTFail("expected clarification")
+        }
+        XCTAssertEqual(missing, .station)
+        guard case .toggleFavorite = base else { return XCTFail("expected toggleFavorite base") }
+    }
+
     func test_outOfScopeWeatherElsewhere() {
         guard case .outOfScope = parser.parse("what's the weather in London") else {
             return XCTFail("expected out of scope")


### PR DESCRIPTION
Closes the parity/coverage gaps in the offline assistant, across iOS, Android and Web.

## Fares + favorites
- New `ExplainFare` and `ToggleFavorite` intents (parser + resolver, EN/EL/SQ).
- Fares surface the relevant ticket products with prices (standard single vs airport) from the bundled catalogue.
- Favorites persist: `FavoritesRepository` (Kotlin, SQLDelight `favorite_entity`) + a UserDefaults store on iOS.

## Day-aware departures
- `DayContextResolver` maps "this weekend / tomorrow / Saturday" to a day offset.
- `ComputeDeparturesFromBandsUseCase.invokeForDay` projects a whole future service day from 00:00; iOS uses the projector `dayOffset` path. No more "showing today" fallback.

## iOS full routing
- `JourneyPlanner.swift` ports `PlanJourneyUseCase` (Dijkstra) with transfer edges between co-located interchange ids, so iOS matches Android/Web for any number of transfers.

## Verification
- `./gradlew check` green; iOS builds + 25 tests pass.
- New tests: fare/favorite parsing (both stacks), `DayContextResolver`.