### PR TITLE
Weather feature, weather-aware routing, journey fares, on-device LLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,14 @@ Ariadne, the offline transit assistant (a constrained, tool-only intent router, 
 - Fares: surfaces the relevant ticket products with prices (standard single vs the airport ticket). Favorites: a real `FavoritesRepository` (Kotlin, SQLDelight) + UserDefaults store on iOS persist the toggle.
 - iOS trip planning now runs a full Dijkstra (`JourneyPlanner.swift`, with transfer edges between co-located interchange ids) so iOS matches the Android/Web `PlanJourneyUseCase` for any number of transfers.
 - Trilingual by design (EN/EL/SQ) via a rule parser, so no supported language degrades. Shared brain in `core/domain/assistant` (`AthensTransitParser`, `AssistantIntent`), mirrored in Swift under `iosApp/.../Features/Assistant`. Scope is fenced to Syrmos and Athens public transport; weather is accepted only as a routing constraint, everything else is declined.
-- This also wired `PlanJourneyUseCase` (Dijkstra routing that already existed but was never in the DI graph) into the Compose app; iOS uses a compact 0/1-transfer planner over the bundled network.
+- This also wired `PlanJourneyUseCase` (Dijkstra routing that already existed but was never in the DI graph) into the Compose app.
+
+Weather and on-device intelligence:
+
+- Weather card on Home (iOS + Android + Web): current conditions from Open-Meteo (free, no key, CORS-friendly), styled as an immersive condition-tinted gradient with the temperature, today's high/low, a next-six-hours forecast strip, and feels-like / humidity / wind. `WeatherService`/`WeatherRepository` in KMP, `WeatherStore` on iOS; central-Athens default so Web and no-location launches still show something. (Visual language inspired by the shared weather-app design; the Figma community file couldn't be extracted over MCP due to the plan's rate limit.)
+- Weather-aware routing: Ariadne's rainy-day trip answers now read the cached weather snapshot and the route's exposure (metro underground/sheltered, tram open-air) via `StationComfort`, and give real advice instead of a generic disclaimer. Degrades honestly with no cached weather.
+- Journey-specific fares: `ExplainFare` carries the trip endpoints, so an airport fare is derived from an actual airport-station endpoint, not just the keyword.
+- Ariadne on-device LLM front-end: on Apple Intelligence devices (iOS 26+), `AriadneBrain` uses Apple Foundation Models to rewrite fuzzy input before the deterministic parser classifies it; the model never picks intents or invents facts, and older devices/Simulator fall straight through to the rule parser. KMP has the matching `AssistantQueryNormalizer` seam (no-op default) for a future Android Gemini Nano backer.
 
 Track this departure (Tier 2 primitive, shared `core/common` `TrackedDeparture` / `DepartureTracking`):
 

--- a/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
@@ -21,6 +21,7 @@ val featureModule = module {
             getLinesUseCase = get(),
             announcementsRepository = get(),
             liveTrackerService = get(),
+            weatherRepository = get(),
         )
     }
     factory {
@@ -35,6 +36,7 @@ val featureModule = module {
             announcementsRepository = get(),
             faresRepository = get(),
             favoritesRepository = get(),
+            weatherRepository = get(),
         )
     }
     factory { LinesViewModel(getLinesUseCase = get()) }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/di/DataModule.kt
@@ -12,6 +12,7 @@ import com.syrmos.core.data.sync.FaresRepository
 import com.syrmos.core.data.sync.ScheduleSyncRepository
 import com.syrmos.core.data.sync.StationOffsetsRepository
 import com.syrmos.core.data.sync.VisualOverridesRepository
+import com.syrmos.core.data.sync.WeatherRepository
 import org.koin.dsl.module
 
 val dataModule = module {
@@ -22,6 +23,7 @@ val dataModule = module {
     single { FaresRepository(schedulesService = get(), resourceReader = get()) }
     single { VisualOverridesRepository(service = get(), resourceReader = get()) }
     single { AnnouncementsRepository(service = get(), resourceReader = get()) }
+    single { WeatherRepository(weatherService = get()) }
     single { LineRepositoryImpl(database = get(), resourceReader = get()) }
     single { StationRepositoryImpl(database = get(), resourceReader = get()) }
     single { ScheduleRepositoryImpl(database = get()) }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/WeatherRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/WeatherRepository.kt
@@ -1,0 +1,47 @@
+package com.syrmos.core.data.sync
+
+import com.syrmos.core.model.weather.WeatherSnapshot
+import com.syrmos.core.network.WeatherService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.datetime.Clock
+
+/**
+ * Holds the latest weather snapshot. The card and Ariadne's weather-aware
+ * routing read [snapshot]; it carries the fetch time so both can show "as of
+ * HH:MM" and degrade honestly when there's no network. Defaults to central
+ * Athens so Web and no-location launches still show something.
+ */
+class WeatherRepository(
+    private val weatherService: WeatherService,
+) {
+    private val _snapshot = MutableStateFlow<WeatherSnapshot?>(null)
+    val snapshot: StateFlow<WeatherSnapshot?> = _snapshot.asStateFlow()
+
+    /** Most recent snapshot, regardless of age, for offline reads. */
+    val cached: WeatherSnapshot? get() = _snapshot.value
+
+    suspend fun refresh(
+        latitude: Double = ATHENS_LAT,
+        longitude: Double = ATHENS_LON,
+        placeName: String = "Athens",
+    ) {
+        val reading = weatherService.fetch(latitude, longitude) ?: return
+        _snapshot.value = WeatherSnapshot(
+            current = reading.current,
+            latitude = latitude,
+            longitude = longitude,
+            placeName = placeName,
+            fetchedAtEpochSeconds = Clock.System.now().epochSeconds,
+            highC = reading.highC,
+            lowC = reading.lowC,
+            hourly = reading.hourly,
+        )
+    }
+
+    companion object {
+        const val ATHENS_LAT = 37.9838
+        const val ATHENS_LON = 23.7275
+    }
+}

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AssistantModels.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AssistantModels.kt
@@ -42,8 +42,16 @@ sealed interface AssistantIntent {
     /** Line overview (terminals, span, stations). */
     data class ExplainLine(val lineId: String) : AssistantIntent
 
-    /** Ticket prices. [airport] surfaces the airport fare specifically. */
-    data class ExplainFare(val airport: Boolean = false) : AssistantIntent
+    /**
+     * Ticket prices. [airport] is the keyword hint; [fromStationId]/[toStationId]
+     * let the resolver derive an airport fare from the actual journey (either
+     * endpoint being an airport station) rather than the word alone.
+     */
+    data class ExplainFare(
+        val airport: Boolean = false,
+        val fromStationId: String? = null,
+        val toStationId: String? = null,
+    ) : AssistantIntent
 
     /** Add/remove a station from favorites. */
     data class ToggleFavorite(val stationId: String?) : AssistantIntent

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AssistantQueryNormalizer.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AssistantQueryNormalizer.kt
@@ -1,0 +1,22 @@
+package com.syrmos.core.domain.assistant
+
+/**
+ * Optional on-device LLM front-end seam for Ariadne on the KMP platforms,
+ * mirroring the iOS Foundation Models path. An implementation must ONLY rewrite
+ * fuzzy natural language into clean text ("trains aprt sat nite" ->
+ * "trains to airport saturday night"); the deterministic [AthensTransitParser]
+ * still classifies and validates the result, so the model can never invent a
+ * transit fact.
+ *
+ * The default is a no-op, so Android and Web run the rule parser directly with
+ * no behaviour change. An Android build can supply a Gemini Nano / ML Kit GenAI
+ * backed normalizer here once a stable on-device prompting API is available.
+ */
+fun interface AssistantQueryNormalizer {
+    /** Cleaned query, or null to use the raw text. */
+    suspend fun normalize(input: String): String?
+}
+
+object NoOpQueryNormalizer : AssistantQueryNormalizer {
+    override suspend fun normalize(input: String): String? = null
+}

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AthensTransitParser.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AthensTransitParser.kt
@@ -55,7 +55,12 @@ class AthensTransitParser(
         //     fare question, not a trip. The airport flag surfaces the airport
         //     ticket specifically.
         if (containsAny(text, FARE_WORDS)) {
-            return AssistantIntent.ExplainFare(airport = containsAny(text, AIRPORT_WORDS))
+            val (from, to) = resolveTripEndpoints(text, mentionedStations)
+            return AssistantIntent.ExplainFare(
+                airport = containsAny(text, AIRPORT_WORDS),
+                fromStationId = from,
+                toStationId = to,
+            )
         }
 
         // 0b. Favorites. Needs a station to act on.

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/StationComfort.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/StationComfort.kt
@@ -1,0 +1,27 @@
+package com.syrmos.core.domain.assistant
+
+import com.syrmos.core.model.transit.LineType
+
+/**
+ * Weather-exposure model for a route, used by Ariadne when the user asks for a
+ * rainy-day route. Derived from line type rather than a per-station dataset
+ * (which doesn't exist yet): the Athens metro runs underground and sheltered,
+ * tram stops are open-air at street level, and suburban stations are mostly
+ * surface-level with partial cover.
+ */
+enum class Exposure { SHELTERED, MIXED, EXPOSED }
+
+object StationComfort {
+    fun forLineType(type: LineType): Exposure = when (type) {
+        LineType.METRO -> Exposure.SHELTERED
+        LineType.TRAM -> Exposure.EXPOSED
+        LineType.SUBURBAN -> Exposure.MIXED
+    }
+
+    /** Worst exposure across a route's legs, so the advice is honest. */
+    fun forRoute(types: List<LineType>): Exposure {
+        if (types.any { forLineType(it) == Exposure.EXPOSED }) return Exposure.EXPOSED
+        if (types.any { forLineType(it) == Exposure.MIXED }) return Exposure.MIXED
+        return Exposure.SHELTERED
+    }
+}

--- a/core/model/src/commonMain/kotlin/com/syrmos/core/model/weather/Weather.kt
+++ b/core/model/src/commonMain/kotlin/com/syrmos/core/model/weather/Weather.kt
@@ -1,0 +1,65 @@
+package com.syrmos.core.model.weather
+
+/**
+ * Current conditions used both by the weather card and by Ariadne's
+ * weather-aware routing. Weather is inherently online, so a snapshot carries
+ * the time it was fetched; surfaces show that timestamp and degrade honestly
+ * when it is stale or missing, matching the app's offline-first contract.
+ */
+data class CurrentWeather(
+    val temperatureC: Double,
+    val apparentC: Double,
+    val weatherCode: Int,
+    val isDay: Boolean,
+    val windKph: Double,
+    val humidity: Int,
+    val precipitationMm: Double,
+) {
+    val condition: WeatherCondition get() = WeatherCondition.fromCode(weatherCode)
+}
+
+data class WeatherSnapshot(
+    val current: CurrentWeather,
+    val latitude: Double,
+    val longitude: Double,
+    val placeName: String,
+    val fetchedAtEpochSeconds: Long,
+    val highC: Double? = null,
+    val lowC: Double? = null,
+    val hourly: List<HourlyForecast> = emptyList(),
+)
+
+/** One point in the next-hours strip shown on the weather card. */
+data class HourlyForecast(
+    /** "14:00" style label. */
+    val hourLabel: String,
+    val temperatureC: Double,
+    val weatherCode: Int,
+) {
+    val condition: WeatherCondition get() = WeatherCondition.fromCode(weatherCode)
+}
+
+/** WMO weather-code buckets, with the bits routing and the UI care about. */
+enum class WeatherCondition {
+    CLEAR, PARTLY_CLOUDY, CLOUDY, FOG, DRIZZLE, RAIN, SNOW, SHOWERS, THUNDERSTORM, UNKNOWN;
+
+    /** True when being outside is unpleasant, so routing should reduce exposure. */
+    val isWet: Boolean
+        get() = this == DRIZZLE || this == RAIN || this == SNOW ||
+            this == SHOWERS || this == THUNDERSTORM
+
+    companion object {
+        fun fromCode(code: Int): WeatherCondition = when (code) {
+            0 -> CLEAR
+            1, 2 -> PARTLY_CLOUDY
+            3 -> CLOUDY
+            45, 48 -> FOG
+            51, 53, 55, 56, 57 -> DRIZZLE
+            61, 63, 65, 66, 67 -> RAIN
+            71, 73, 75, 77 -> SNOW
+            80, 81, 82, 85, 86 -> SHOWERS
+            95, 96, 99 -> THUNDERSTORM
+            else -> UNKNOWN
+        }
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/WeatherService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/WeatherService.kt
@@ -1,0 +1,108 @@
+package com.syrmos.core.network
+
+import com.syrmos.core.model.weather.CurrentWeather
+import com.syrmos.core.model.weather.HourlyForecast
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Current conditions, next-hours strip, and today's high/low from Open-Meteo
+ * (free, no API key, CORS-friendly so it works on Web too). All failures are
+ * silent; the caller keeps the last reading. The only genuinely-online piece
+ * of the weather feature.
+ */
+class WeatherService(
+    private val httpClient: HttpClient,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    data class Reading(
+        val current: CurrentWeather,
+        val hourly: List<HourlyForecast>,
+        val highC: Double?,
+        val lowC: Double?,
+    )
+
+    suspend fun fetch(latitude: Double, longitude: Double): Reading? {
+        return runCatching {
+            val url = "https://api.open-meteo.com/v1/forecast" +
+                "?latitude=$latitude&longitude=$longitude" +
+                "&current=time,temperature_2m,apparent_temperature,is_day,precipitation," +
+                "relative_humidity_2m,weather_code,wind_speed_10m" +
+                "&hourly=temperature_2m,weather_code" +
+                "&daily=temperature_2m_max,temperature_2m_min" +
+                "&forecast_days=1&timezone=auto"
+            val body = httpClient.get(url).bodyAsText()
+            val resp = json.decodeFromString<OpenMeteoResponse>(body)
+            Reading(
+                current = resp.current.toDomain(),
+                hourly = resp.nextHours(6),
+                highC = resp.daily?.max?.firstOrNull(),
+                lowC = resp.daily?.min?.firstOrNull(),
+            )
+        }.getOrNull()
+    }
+
+    @Serializable
+    private data class OpenMeteoResponse(
+        val current: Current,
+        val hourly: Hourly? = null,
+        val daily: Daily? = null,
+    ) {
+        /** The next [count] hourly points at or after the current hour. */
+        fun nextHours(count: Int): List<HourlyForecast> {
+            val h = hourly ?: return emptyList()
+            val times = h.time
+            val temps = h.temperature
+            val codes = h.weatherCode
+            if (times.isEmpty()) return emptyList()
+            // ISO strings sort lexicographically, so >= current.time works.
+            val start = times.indexOfFirst { it >= current.time }.let { if (it < 0) 0 else it }
+            val end = minOf(start + count, times.size)
+            return (start until end).mapNotNull { i ->
+                val t = temps.getOrNull(i) ?: return@mapNotNull null
+                val c = codes.getOrNull(i) ?: 0
+                HourlyForecast(hourLabel = times[i].substringAfter('T').take(5), temperatureC = t, weatherCode = c)
+            }
+        }
+    }
+
+    @Serializable
+    private data class Current(
+        val time: String = "",
+        @SerialName("temperature_2m") val temperature: Double = 0.0,
+        @SerialName("apparent_temperature") val apparent: Double = 0.0,
+        @SerialName("is_day") val isDay: Int = 1,
+        @SerialName("precipitation") val precipitation: Double = 0.0,
+        @SerialName("relative_humidity_2m") val humidity: Int = 0,
+        @SerialName("weather_code") val weatherCode: Int = 0,
+        @SerialName("wind_speed_10m") val windSpeed: Double = 0.0,
+    ) {
+        fun toDomain() = CurrentWeather(
+            temperatureC = temperature,
+            apparentC = apparent,
+            weatherCode = weatherCode,
+            isDay = isDay == 1,
+            windKph = windSpeed,
+            humidity = humidity,
+            precipitationMm = precipitation,
+        )
+    }
+
+    @Serializable
+    private data class Hourly(
+        val time: List<String> = emptyList(),
+        @SerialName("temperature_2m") val temperature: List<Double> = emptyList(),
+        @SerialName("weather_code") val weatherCode: List<Int> = emptyList(),
+    )
+
+    @Serializable
+    private data class Daily(
+        @SerialName("temperature_2m_max") val max: List<Double> = emptyList(),
+        @SerialName("temperature_2m_min") val min: List<Double> = emptyList(),
+    )
+}

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/di/NetworkModule.kt
@@ -7,6 +7,7 @@ import com.syrmos.core.network.SyrmosContactService
 import com.syrmos.core.network.SyrmosLivePositionsService
 import com.syrmos.core.network.SyrmosSchedulesService
 import com.syrmos.core.network.SyrmosVisualOverridesService
+import com.syrmos.core.network.WeatherService
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
@@ -33,4 +34,5 @@ val networkModule = module {
     single { SyrmosLivePositionsService(httpClient = get()) }
     single { SyrmosContactService(httpClient = get()) }
     single { SyrmosVisualOverridesService(httpClient = get()) }
+    single { WeatherService(httpClient = get()) }
 }

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeScreen.kt
@@ -152,6 +152,11 @@ fun HomeScreen(
             }
         }
 
+        val weather = uiState.weather
+        if (weather != null) {
+            item { WeatherCard(snapshot = weather, lang = lang) }
+        }
+
         // Section order mirrors iOS: alerts/news + service status appear
         // immediately under the welcome subtitle so users see operational
         // state before any of the navigation tiles.

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeViewModel.kt
@@ -3,6 +3,8 @@ package com.syrmos.feature.home
 import com.syrmos.core.common.DataFreshness
 import com.syrmos.core.common.LiveDataFreshness
 import com.syrmos.core.data.sync.AnnouncementsRepository
+import com.syrmos.core.data.sync.WeatherRepository
+import com.syrmos.core.model.weather.WeatherSnapshot
 import com.syrmos.core.domain.usecase.FindNearestStationUseCase
 import com.syrmos.core.domain.usecase.GetLastTrainUseCase
 import com.syrmos.core.domain.usecase.GetLinesUseCase
@@ -41,6 +43,8 @@ data class HomeUiState(
     val lastTrainLine: Line? = null,
     /** Whether arrivals are live or predicted from the bundled schedule. */
     val freshness: DataFreshness = DataFreshness.PREDICTED,
+    /** Current weather for the travel-context card; null until first fetch. */
+    val weather: WeatherSnapshot? = null,
     val liveTrains: List<LiveSuburbanTrain> = emptyList(),
     val selectedStationId: String? = null,
     val lines: List<Line> = emptyList(),
@@ -57,6 +61,7 @@ class HomeViewModel(
     private val getLinesUseCase: GetLinesUseCase,
     private val announcementsRepository: AnnouncementsRepository,
     private val liveTrackerService: RailwayGovLiveTrackerService,
+    private val weatherRepository: WeatherRepository,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -68,6 +73,17 @@ class HomeViewModel(
         refreshAnnouncements()
         observeLiveTrains()
         observeFreshness()
+        observeWeather()
+    }
+
+    private fun observeWeather() {
+        scope.launch {
+            weatherRepository.snapshot.collect { snap ->
+                _uiState.update { it.copy(weather = snap) }
+            }
+        }
+        // Athens default so Web and no-location launches still show weather.
+        scope.launch { runCatching { weatherRepository.refresh() } }
     }
 
     /**
@@ -139,6 +155,8 @@ class HomeViewModel(
             val location = UserLocation(latitude, longitude)
             val nearest = findNearestStation.invoke(location, limit = 3).first()
             _uiState.update { it.copy(nearestStations = nearest, isLoading = false) }
+            // Refresh weather for the user's actual location.
+            launch { runCatching { weatherRepository.refresh(latitude, longitude, placeName = "Here") } }
 
             if (nearest.isNotEmpty()) {
                 loadDeparturesForStation(nearest.first().stationId, nearest.first().lineIds)

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/WeatherCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/WeatherCard.kt
@@ -1,0 +1,175 @@
+package com.syrmos.feature.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.syrmos.core.common.AppLanguage
+import com.syrmos.core.model.weather.CurrentWeather
+import com.syrmos.core.model.weather.WeatherCondition
+import com.syrmos.core.model.weather.WeatherSnapshot
+import kotlin.math.roundToInt
+
+/**
+ * Weather travel-context card, in the vibrant gradient style of the shared
+ * weather-app design: a condition-tinted gradient, a big temperature, the
+ * emoji glyph, "feels like", and the place. Pure surfacing of [WeatherSnapshot].
+ */
+@Composable
+fun WeatherCard(snapshot: WeatherSnapshot, lang: AppLanguage) {
+    val w = snapshot.current
+    val colors = gradientFor(w.condition, w.isDay)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(20.dp))
+            .background(Brush.verticalGradient(colors))
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top,
+        ) {
+            Column {
+                Text(
+                    text = snapshot.placeName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White.copy(alpha = 0.95f),
+                )
+                Text(
+                    text = conditionLabel(w.condition, lang),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.85f),
+                )
+            }
+            Text(text = glyph(w.condition, w.isDay), fontSize = 40.sp)
+        }
+        Spacer(Modifier.height(2.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            Text(
+                text = "${w.temperatureC.roundToInt()}°",
+                fontSize = 56.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+            )
+            Spacer(Modifier.weight(1f))
+            if (snapshot.highC != null && snapshot.lowC != null) {
+                Text(
+                    text = "H:${snapshot.highC!!.roundToInt()}°  L:${snapshot.lowC!!.roundToInt()}°",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = Color.White.copy(alpha = 0.9f),
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+            }
+        }
+
+        if (snapshot.hourly.isNotEmpty()) {
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(Color.White.copy(alpha = 0.15f))
+                    .padding(vertical = 10.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                snapshot.hourly.take(6).forEach { h ->
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(h.hourLabel, style = MaterialTheme.typography.labelSmall, color = Color.White.copy(alpha = 0.85f))
+                        Text(glyph(h.condition, w.isDay), fontSize = 18.sp)
+                        Text("${h.temperatureC.roundToInt()}°", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.SemiBold, color = Color.White)
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            WeatherStat(feelsLikeLabel(lang), "${w.apparentC.roundToInt()}°")
+            WeatherStat(humidityLabel(lang), "${w.humidity}%")
+            WeatherStat(windLabel(lang), "${w.windKph.roundToInt()} km/h")
+        }
+    }
+}
+
+@Composable
+private fun WeatherStat(label: String, value: String) {
+    Column {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = Color.White.copy(alpha = 0.8f))
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold, color = Color.White)
+    }
+}
+
+private fun gradientFor(condition: WeatherCondition, isDay: Boolean): List<Color> {
+    if (!isDay) return listOf(Color(0xFF1A237E), Color(0xFF311B92))
+    return when (condition) {
+        WeatherCondition.CLEAR -> listOf(Color(0xFF2196F3), Color(0xFF4FC3F7))
+        WeatherCondition.PARTLY_CLOUDY -> listOf(Color(0xFF42A5F5), Color(0xFF90CAF9))
+        WeatherCondition.CLOUDY, WeatherCondition.FOG -> listOf(Color(0xFF607D8B), Color(0xFF90A4AE))
+        WeatherCondition.DRIZZLE, WeatherCondition.RAIN, WeatherCondition.SHOWERS ->
+            listOf(Color(0xFF455A64), Color(0xFF546E7A))
+        WeatherCondition.THUNDERSTORM -> listOf(Color(0xFF37474F), Color(0xFF455A64))
+        WeatherCondition.SNOW -> listOf(Color(0xFF78909C), Color(0xFFB0BEC5))
+        WeatherCondition.UNKNOWN -> listOf(Color(0xFF42A5F5), Color(0xFF90CAF9))
+    }
+}
+
+private fun glyph(condition: WeatherCondition, isDay: Boolean): String = when (condition) {
+    WeatherCondition.CLEAR -> if (isDay) "☀️" else "🌙"
+    WeatherCondition.PARTLY_CLOUDY -> if (isDay) "⛅" else "☁️"
+    WeatherCondition.CLOUDY -> "☁️"
+    WeatherCondition.FOG -> "🌫️"
+    WeatherCondition.DRIZZLE, WeatherCondition.SHOWERS -> "🌦️"
+    WeatherCondition.RAIN -> "🌧️"
+    WeatherCondition.SNOW -> "❄️"
+    WeatherCondition.THUNDERSTORM -> "⛈️"
+    WeatherCondition.UNKNOWN -> "🌡️"
+}
+
+internal fun conditionLabel(condition: WeatherCondition, lang: AppLanguage): String = when (condition) {
+    WeatherCondition.CLEAR -> tri(lang, "Clear", "Αίθριος", "Kthjellët")
+    WeatherCondition.PARTLY_CLOUDY -> tri(lang, "Partly cloudy", "Λίγα σύννεφα", "Pjesërisht me re")
+    WeatherCondition.CLOUDY -> tri(lang, "Cloudy", "Συννεφιά", "Me re")
+    WeatherCondition.FOG -> tri(lang, "Fog", "Ομίχλη", "Mjegull")
+    WeatherCondition.DRIZZLE -> tri(lang, "Drizzle", "Ψιχάλα", "Shi i imët")
+    WeatherCondition.RAIN -> tri(lang, "Rain", "Βροχή", "Shi")
+    WeatherCondition.SHOWERS -> tri(lang, "Showers", "Μπόρες", "Rrebeshe")
+    WeatherCondition.SNOW -> tri(lang, "Snow", "Χιόνι", "Borë")
+    WeatherCondition.THUNDERSTORM -> tri(lang, "Thunderstorm", "Καταιγίδα", "Stuhi")
+    WeatherCondition.UNKNOWN -> tri(lang, "Weather", "Καιρός", "Moti")
+}
+
+private fun feelsLikeLabel(lang: AppLanguage) = tri(lang, "Feels like", "Αίσθηση", "Ndihet si")
+private fun humidityLabel(lang: AppLanguage) = tri(lang, "Humidity", "Υγρασία", "Lagështia")
+private fun windLabel(lang: AppLanguage) = tri(lang, "Wind", "Άνεμος", "Era")
+
+private fun tri(lang: AppLanguage, en: String, el: String, sq: String) = when (lang) {
+    AppLanguage.GREEK -> el
+    AppLanguage.ALBANIAN -> sq
+    else -> en
+}

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/assistant/AssistantViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/assistant/AssistantViewModel.kt
@@ -6,8 +6,13 @@ import com.syrmos.core.data.repository.FavoritesRepository
 import com.syrmos.core.data.repository.StationRepositoryImpl
 import com.syrmos.core.data.sync.AnnouncementsRepository
 import com.syrmos.core.data.sync.FaresRepository
+import com.syrmos.core.data.sync.WeatherRepository
+import com.syrmos.core.domain.assistant.Exposure
+import com.syrmos.core.domain.assistant.StationComfort
 import com.syrmos.core.domain.assistant.AssistantIntent
+import com.syrmos.core.domain.assistant.AssistantQueryNormalizer
 import com.syrmos.core.domain.assistant.AssistantVocabularyBuilder
+import com.syrmos.core.domain.assistant.NoOpQueryNormalizer
 import com.syrmos.core.domain.assistant.AthensTransitParser
 import com.syrmos.core.domain.assistant.DayContext
 import com.syrmos.core.domain.assistant.DayContextResolver
@@ -72,6 +77,12 @@ class AssistantViewModel(
     private val announcementsRepository: AnnouncementsRepository,
     private val faresRepository: FaresRepository,
     private val favoritesRepository: FavoritesRepository,
+    private val weatherRepository: WeatherRepository,
+    /**
+     * Optional on-device LLM front-end. No-op by default (rule parser only);
+     * an Android build can inject a Gemini Nano-backed normalizer here.
+     */
+    private val queryNormalizer: AssistantQueryNormalizer = NoOpQueryNormalizer,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val _uiState = MutableStateFlow(AssistantUiState())
@@ -101,7 +112,10 @@ class AssistantViewModel(
             it.copy(messages = it.messages + userMessage(text), thinking = true)
         }
         scope.launch {
-            val reply = resolve(p.parse(text))
+            // On-device LLM (when supplied) rewrites fuzzy input; the
+            // deterministic parser still classifies and validates it.
+            val cleaned = queryNormalizer.normalize(text) ?: text
+            val reply = resolve(p.parse(cleaned))
             _uiState.update { it.copy(messages = it.messages + reply, thinking = false) }
         }
     }
@@ -229,16 +243,45 @@ class AssistantViewModel(
         } else {
             t("${result.transferCount} change(s)", "${result.transferCount} αλλαγή/ές", "${result.transferCount} ndërrim(e)")
         }
-        val exposure = if (intent.lowExposure) {
-            "\n" + t("I can't check live weather offline, but this is the fewest-transfer route.",
-                "Δεν μπορώ να δω τον καιρό εκτός σύνδεσης, αλλά αυτή έχει τις λιγότερες αλλαγές.",
-                "Nuk e kontrolloj dot motin pa internet, por kjo ka më pak ndërrime.")
-        } else ""
+        val exposure = if (intent.lowExposure) "\n" + weatherAdvice(result) else ""
         return botMessage(
             t("$lines. About ${result.totalMinutes} min, $transfers.",
                 "$lines. Περίπου ${result.totalMinutes} λεπτά, $transfers.",
                 "$lines. Rreth ${result.totalMinutes} min, $transfers.") + exposure,
         )
+    }
+
+    /**
+     * Real weather-aware advice for a rainy-day route: reads the cached weather
+     * snapshot and the route's exposure (metro is underground/sheltered, tram
+     * is open-air). Degrades honestly when there's no cached weather.
+     */
+    private fun weatherAdvice(result: com.syrmos.core.model.planner.JourneyResult): String {
+        val types = result.segments.filter { !it.isTransfer }
+            .mapNotNull { seg -> lines.firstOrNull { it.id == normalizeLine(seg.lineId) }?.type }
+        val exposure = StationComfort.forRoute(types)
+        val shelter = when (exposure) {
+            Exposure.SHELTERED -> t("mostly underground and sheltered", "κυρίως υπόγεια και υπό στέγη",
+                "kryesisht nëntokë dhe e mbrojtur")
+            Exposure.MIXED -> t("partly at surface level", "εν μέρει σε επιφάνεια", "pjesërisht në sipërfaqe")
+            Exposure.EXPOSED -> t("open-air (tram/surface stops)", "σε ανοιχτό χώρο (τραμ/επιφάνεια)",
+                "në ajër të hapur (tram/sipërfaqe)")
+        }
+        val weather = weatherRepository.cached
+        return when {
+            weather != null && weather.current.condition.isWet ->
+                t("It's wet in ${weather.placeName} right now, and this route is $shelter.",
+                    "Έχει βροχή στην ${weather.placeName} τώρα, και η διαδρομή είναι $shelter.",
+                    "Ka shi në ${weather.placeName} tani, dhe kjo rrugë është $shelter.")
+            weather != null ->
+                t("It's dry in ${weather.placeName} right now; this route is $shelter.",
+                    "Δεν βρέχει στην ${weather.placeName} τώρα· η διαδρομή είναι $shelter.",
+                    "S'ka shi në ${weather.placeName} tani; kjo rrugë është $shelter.")
+            else ->
+                t("I can't check live weather offline, but this route is $shelter.",
+                    "Δεν μπορώ να δω τον καιρό εκτός σύνδεσης, αλλά η διαδρομή είναι $shelter.",
+                    "Nuk e kontrolloj dot motin pa internet, por kjo rrugë është $shelter.")
+        }
     }
 
     private suspend fun resolveFindStation(intent: AssistantIntent.FindStation): AssistantMessage {
@@ -281,7 +324,11 @@ class AssistantViewModel(
                 "Δεν έχω διαθέσιμες τιμές εισιτηρίων εκτός σύνδεσης τώρα.",
                 "Nuk kam çmime biletash të disponueshme pa internet tani."))
         }
-        val picks = if (intent.airport) {
+        // Journey-derived: an airport fare if the word was used OR either
+        // endpoint is actually an airport station.
+        val airport = intent.airport ||
+            isAirportStation(intent.fromStationId) || isAirportStation(intent.toStationId)
+        val picks = if (airport) {
             products.filter { it.tags.any { tag -> tag.contains("airport") } }
                 .sortedBy { it.fullPriceEur ?: Double.MAX_VALUE }.take(2)
         } else {
@@ -311,6 +358,12 @@ class AssistantViewModel(
             action = station?.let { AssistantAction.OpenStation(it.id) },
             actionLabel = station?.let { t("Open", "Άνοιγμα", "Hap") },
         )
+    }
+
+    private fun isAirportStation(stationId: String?): Boolean {
+        val st = stations.firstOrNull { it.id == stationId } ?: return false
+        val name = (st.name + " " + st.nameEl).lowercase()
+        return "airport" in name || "αεροδρ" in name
     }
 
     private fun fareTitle(product: com.syrmos.core.network.SyrmosSchedulesService.FareProduct): String =

--- a/iosApp/Syrmos.xcodeproj/project.pbxproj
+++ b/iosApp/Syrmos.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		DA7A0013F00D0013F00D0013 /* iosApp/Features/Assistant/AriadneModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0014F00D0014F00D0014 /* iosApp/Features/Assistant/AriadneModel.swift */; };
 		DA7A0015F00D0015F00D0015 /* iosApp/Features/Assistant/AriadneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0016F00D0016F00D0016 /* iosApp/Features/Assistant/AriadneView.swift */; };
 		DA7A0130F00D0130F00D0130 /* iosApp/Features/Assistant/JourneyPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0131F00D0131F00D0131 /* iosApp/Features/Assistant/JourneyPlanner.swift */; };
+		DA7A0140F00D0140F00D0140 /* iosApp/Core/Networking/WeatherStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0141F00D0141F00D0141 /* iosApp/Core/Networking/WeatherStore.swift */; };
+		DA7A0142F00D0142F00D0142 /* iosApp/Features/Weather/WeatherCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0143F00D0143F00D0143 /* iosApp/Features/Weather/WeatherCard.swift */; };
+		DA7A0150F00D0150F00D0150 /* iosApp/Features/Assistant/AriadneBrain.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0151F00D0151F00D0151 /* iosApp/Features/Assistant/AriadneBrain.swift */; };
 		AAAA111111111111111111B3 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA111111111111111111B4 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift */; };
 		AABB01CD02EF030405060708 /* Resources/seed-schedules-v2 in Resources */ = {isa = PBXBuildFile; fileRef = AABB01CD02EF030405060709 /* Resources/seed-schedules-v2 */; };
 		B264406F57304E569BAAED79 /* iosApp/Features/Timetables/TimetablesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09288EF8307B4CDC9D065AED /* iosApp/Features/Timetables/TimetablesView.swift */; };
@@ -119,6 +122,9 @@
 		DA7A0014F00D0014F00D0014 /* iosApp/Features/Assistant/AriadneModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneModel.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0016F00D0016F00D0016 /* iosApp/Features/Assistant/AriadneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneView.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0131F00D0131F00D0131 /* iosApp/Features/Assistant/JourneyPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/JourneyPlanner.swift; sourceTree = SOURCE_ROOT; };
+		DA7A0141F00D0141F00D0141 /* iosApp/Core/Networking/WeatherStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Networking/WeatherStore.swift; sourceTree = SOURCE_ROOT; };
+		DA7A0143F00D0143F00D0143 /* iosApp/Features/Weather/WeatherCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Weather/WeatherCard.swift; sourceTree = SOURCE_ROOT; };
+		DA7A0151F00D0151F00D0151 /* iosApp/Features/Assistant/AriadneBrain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneBrain.swift; sourceTree = SOURCE_ROOT; };
 		AAAA111111111111111111B4 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Onboarding/OnboardingMeshBackground.swift; sourceTree = SOURCE_ROOT; };
 		AABB01CD02EF030405060709 /* Resources/seed-schedules-v2 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Resources/seed-schedules-v2"; sourceTree = "<group>"; };
 		B9C311F839BA02691F04AB93 /* NearbyStationDestinationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NearbyStationDestinationTests.swift; sourceTree = "<group>"; };
@@ -418,6 +424,9 @@
 				DA7A0014F00D0014F00D0014 /* iosApp/Features/Assistant/AriadneModel.swift */,
 				DA7A0016F00D0016F00D0016 /* iosApp/Features/Assistant/AriadneView.swift */,
 				DA7A0131F00D0131F00D0131 /* iosApp/Features/Assistant/JourneyPlanner.swift */,
+				DA7A0141F00D0141F00D0141 /* iosApp/Core/Networking/WeatherStore.swift */,
+				DA7A0143F00D0143F00D0143 /* iosApp/Features/Weather/WeatherCard.swift */,
+				DA7A0151F00D0151F00D0151 /* iosApp/Features/Assistant/AriadneBrain.swift */,
 				AAAA111111111111111111B4 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift */,
 			);
 			name = Onboarding;
@@ -594,6 +603,9 @@
 				DA7A0013F00D0013F00D0013 /* iosApp/Features/Assistant/AriadneModel.swift in Sources */,
 				DA7A0015F00D0015F00D0015 /* iosApp/Features/Assistant/AriadneView.swift in Sources */,
 				DA7A0130F00D0130F00D0130 /* iosApp/Features/Assistant/JourneyPlanner.swift in Sources */,
+				DA7A0140F00D0140F00D0140 /* iosApp/Core/Networking/WeatherStore.swift in Sources */,
+				DA7A0142F00D0142F00D0142 /* iosApp/Features/Weather/WeatherCard.swift in Sources */,
+				DA7A0150F00D0150F00D0150 /* iosApp/Features/Assistant/AriadneBrain.swift in Sources */,
 				AAAA111111111111111111B3 /* iosApp/Features/Onboarding/OnboardingMeshBackground.swift in Sources */,
 				03FBB75EEE74C7E43F7A609B /* iosApp/DesignSystem/CompactTabHeader.swift in Sources */,
 				8218D06AFB1A4111BBE6A6BA /* iosApp/Core/Persistence/SyrmosVisualOverridesStore.swift in Sources */,

--- a/iosApp/iosApp/Core/Networking/WeatherStore.swift
+++ b/iosApp/iosApp/Core/Networking/WeatherStore.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Combine
+import CoreLocation
+
+/// Current-conditions model + store on iOS, mirroring the KMP weather layer.
+/// Weather is the one genuinely-online piece; the snapshot carries its fetch
+/// time so the card can say "as of HH:MM" and degrade honestly offline.
+
+enum WeatherCondition {
+    case clear, partlyCloudy, cloudy, fog, drizzle, rain, snow, showers, thunderstorm, unknown
+
+    /// Outside is unpleasant, so routing should reduce exposure.
+    var isWet: Bool {
+        switch self {
+        case .drizzle, .rain, .snow, .showers, .thunderstorm: return true
+        default: return false
+        }
+    }
+
+    static func fromCode(_ code: Int) -> WeatherCondition {
+        switch code {
+        case 0: return .clear
+        case 1, 2: return .partlyCloudy
+        case 3: return .cloudy
+        case 45, 48: return .fog
+        case 51, 53, 55, 56, 57: return .drizzle
+        case 61, 63, 65, 66, 67: return .rain
+        case 71, 73, 75, 77: return .snow
+        case 80, 81, 82, 85, 86: return .showers
+        case 95, 96, 99: return .thunderstorm
+        default: return .unknown
+        }
+    }
+}
+
+struct CurrentWeather {
+    let temperatureC: Double
+    let apparentC: Double
+    let weatherCode: Int
+    let isDay: Bool
+    let windKph: Double
+    let humidity: Int
+    let precipitationMm: Double
+    var condition: WeatherCondition { .fromCode(weatherCode) }
+}
+
+struct HourlyForecast: Identifiable {
+    let id = UUID()
+    let hourLabel: String
+    let temperatureC: Double
+    let weatherCode: Int
+    var condition: WeatherCondition { .fromCode(weatherCode) }
+}
+
+struct WeatherSnapshot {
+    let current: CurrentWeather
+    let placeName: String
+    let fetchedAt: Date
+    var highC: Double?
+    var lowC: Double?
+    var hourly: [HourlyForecast] = []
+}
+
+@MainActor
+final class WeatherStore: ObservableObject {
+    static let shared = WeatherStore()
+
+    @Published private(set) var snapshot: WeatherSnapshot?
+
+    private static let athens = CLLocationCoordinate2D(latitude: 37.9838, longitude: 23.7275)
+    private var lastFetch: Date?
+
+    private init() {}
+
+    /// Refreshes for the given coordinate (defaults to central Athens so a
+    /// no-location launch still shows something). Throttled to once a minute.
+    func refresh(latitude: Double = athens.latitude,
+                 longitude: Double = athens.longitude,
+                 placeName: String = "Athens") async {
+        if let last = lastFetch, Date().timeIntervalSince(last) < 60 { return }
+        guard var comps = URLComponents(string: "https://api.open-meteo.com/v1/forecast") else { return }
+        comps.queryItems = [
+            .init(name: "latitude", value: String(latitude)),
+            .init(name: "longitude", value: String(longitude)),
+            .init(name: "current", value: "time,temperature_2m,apparent_temperature,is_day,precipitation,relative_humidity_2m,weather_code,wind_speed_10m"),
+            .init(name: "hourly", value: "temperature_2m,weather_code"),
+            .init(name: "daily", value: "temperature_2m_max,temperature_2m_min"),
+            .init(name: "forecast_days", value: "1"),
+            .init(name: "timezone", value: "auto"),
+        ]
+        guard let url = comps.url else { return }
+        do {
+            var req = URLRequest(url: url)
+            req.timeoutInterval = 8
+            let (data, _) = try await URLSession.shared.data(for: req)
+            let decoded = try JSONDecoder().decode(OpenMeteoResponse.self, from: data)
+            snapshot = WeatherSnapshot(
+                current: decoded.current.toDomain(),
+                placeName: placeName,
+                fetchedAt: Date(),
+                highC: decoded.daily?.temperature_2m_max.first,
+                lowC: decoded.daily?.temperature_2m_min.first,
+                hourly: decoded.nextHours(6)
+            )
+            lastFetch = Date()
+        } catch {
+            // Keep the last snapshot; the card and routing degrade honestly.
+        }
+    }
+
+    private struct OpenMeteoResponse: Decodable {
+        let current: Current
+        let hourly: Hourly?
+        let daily: Daily?
+
+        /// The next [count] hourly points at or after the current hour.
+        func nextHours(_ count: Int) -> [HourlyForecast] {
+            guard let h = hourly, !h.time.isEmpty else { return [] }
+            let start = h.time.firstIndex(where: { $0 >= current.time }) ?? 0
+            let end = min(start + count, h.time.count)
+            guard start < end else { return [] }
+            return (start..<end).compactMap { i in
+                guard i < h.temperature_2m.count else { return nil }
+                let code = i < h.weather_code.count ? h.weather_code[i] : 0
+                let label = String(h.time[i].split(separator: "T").last?.prefix(5) ?? "")
+                return HourlyForecast(hourLabel: label, temperatureC: h.temperature_2m[i], weatherCode: code)
+            }
+        }
+
+        struct Current: Decodable {
+            let time: String
+            let temperature_2m: Double
+            let apparent_temperature: Double
+            let is_day: Int
+            let precipitation: Double
+            let relative_humidity_2m: Int
+            let weather_code: Int
+            let wind_speed_10m: Double
+            func toDomain() -> CurrentWeather {
+                CurrentWeather(
+                    temperatureC: temperature_2m,
+                    apparentC: apparent_temperature,
+                    weatherCode: weather_code,
+                    isDay: is_day == 1,
+                    windKph: wind_speed_10m,
+                    humidity: relative_humidity_2m,
+                    precipitationMm: precipitation
+                )
+            }
+        }
+        struct Hourly: Decodable {
+            let time: [String]
+            let temperature_2m: [Double]
+            let weather_code: [Int]
+        }
+        struct Daily: Decodable {
+            let temperature_2m_max: [Double]
+            let temperature_2m_min: [Double]
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Assistant/AriadneBrain.swift
+++ b/iosApp/iosApp/Features/Assistant/AriadneBrain.swift
@@ -1,0 +1,51 @@
+import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Optional on-device LLM front-end for Ariadne, using Apple Foundation Models
+/// on Apple Intelligence devices (iOS 26+).
+///
+/// By design it does NOT pick intents or invent transit facts. It only rewrites
+/// messy natural language ("trains aprt sat nite") into clean text that the
+/// deterministic `AthensTransitParser` then classifies. The rule parser stays
+/// the single source of truth; the model just improves recall on fuzzy input.
+/// When the model is unavailable (older devices, no Apple Intelligence, the
+/// Simulator), Ariadne uses the rule parser directly with zero behaviour change.
+enum AriadneBrain {
+    /// True when an on-device model is ready to use.
+    static var isAvailable: Bool {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            if case .available = SystemLanguageModel.default.availability { return true }
+        }
+        #endif
+        return false
+    }
+
+    /// Rewrites [input] into a clean query, or nil to fall back to raw text.
+    static func normalize(_ input: String) async -> String? {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            guard case .available = SystemLanguageModel.default.availability else { return nil }
+            let instructions = Instructions("""
+            You normalize short Athens public-transport queries for a parser.
+            Rewrite the user's text into one clear line about Athens metro, tram
+            or suburban trains: expand abbreviations, fix typos, keep station and
+            line names (M1, M2, M3, T6, T7, A1-A4, Syntagma, Piraeus, Airport,
+            etc.). Output ONLY the rewritten query. If it is not about Athens
+            public transport, output the text unchanged.
+            """)
+            do {
+                let session = LanguageModelSession(instructions: instructions)
+                let response = try await session.respond(to: input)
+                let text = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+                return text.isEmpty ? nil : text
+            } catch {
+                return nil
+            }
+        }
+        #endif
+        return nil
+    }
+}

--- a/iosApp/iosApp/Features/Assistant/AriadneModel.swift
+++ b/iosApp/iosApp/Features/Assistant/AriadneModel.swift
@@ -31,7 +31,10 @@ final class AriadneModel: ObservableObject {
         messages.append(AriadneMessage(fromUser: true, text: text))
         thinking = true
         Task {
-            let reply = await resolve(parser.parse(text))
+            // On-device LLM (when available) rewrites fuzzy input; the
+            // deterministic parser still classifies and validates it.
+            let cleaned = await AriadneBrain.normalize(text) ?? text
+            let reply = await resolve(parser.parse(cleaned))
             messages.append(reply)
             thinking = false
         }
@@ -51,8 +54,8 @@ final class AriadneModel: ObservableObject {
             return resolveFindStation(query)
         case let .explainLine(lineId):
             return resolveExplainLine(lineId)
-        case let .explainFare(airport):
-            return resolveFare(airport: airport)
+        case let .explainFare(airport, from, to):
+            return resolveFare(airport: airport, from: from, to: to)
         case let .toggleFavorite(stationId):
             return resolveFavorite(stationId: stationId)
         case let .showAlerts(lineId):
@@ -133,15 +136,18 @@ final class AriadneModel: ObservableObject {
         }
     }
 
-    private func resolveFare(airport: Bool) -> AriadneMessage {
+    private func resolveFare(airport: Bool, from: String?, to: String?) -> AriadneMessage {
         let products = SyrmosFaresStore.shared.products
         if products.isEmpty {
             return bot(t("I don't have fare prices available offline right now.",
                 "Δεν έχω διαθέσιμες τιμές εισιτηρίων εκτός σύνδεσης τώρα.",
                 "Nuk kam çmime biletash të disponueshme pa internet tani."))
         }
+        // Journey-derived: airport fare if the word was used OR either endpoint
+        // is actually an airport station.
+        let isAirport = airport || isAirportStation(from) || isAirportStation(to)
         let picks: [SyrmosFaresStore.Product]
-        if airport {
+        if isAirport {
             picks = products.filter { $0.tags.contains { $0.contains("airport") } }
                 .sorted { ($0.fullPriceEur ?? .greatestFiniteMagnitude) < ($1.fullPriceEur ?? .greatestFiniteMagnitude) }
         } else {
@@ -151,6 +157,12 @@ final class AriadneModel: ObservableObject {
         let chosen = (picks.isEmpty ? Array(products.prefix(2)) : Array(picks.prefix(2)))
         let line = chosen.map { "\($0.localizedTitle(loc.language)) \(money($0.fullPriceEur))" }.joined(separator: " · ")
         return bot(line)
+    }
+
+    private func isAirportStation(_ stationId: String?) -> Bool {
+        guard let id = stationId, let st = station(id) else { return false }
+        let name = (st.name + " " + st.nameEl).lowercased()
+        return name.contains("airport") || name.contains("αεροδρ")
     }
 
     private func resolveFavorite(stationId: String?) -> AriadneMessage {
@@ -211,12 +223,47 @@ final class AriadneModel: ObservableObject {
         let transfers = plan.transfers == 0
             ? t("no change", "χωρίς αλλαγή", "pa ndërrim")
             : t("\(plan.transfers) change(s)", "\(plan.transfers) αλλαγή/ές", "\(plan.transfers) ndërrim(e)")
-        let exposure = lowExposure ? "\n" + t("I can't check live weather offline, but this is the fewest-transfer route.",
-            "Δεν μπορώ να δω τον καιρό εκτός σύνδεσης, αλλά αυτή έχει τις λιγότερες αλλαγές.",
-            "Nuk e kontrolloj dot motin pa internet, por kjo ka më pak ndërrime.") : ""
+        let exposure = lowExposure ? "\n" + weatherAdvice(plan) : ""
         return bot(t("\(legs). About \(plan.totalMinutes) min, \(transfers).",
             "\(legs). Περίπου \(plan.totalMinutes) λεπτά, \(transfers).",
             "\(legs). Rreth \(plan.totalMinutes) min, \(transfers).") + exposure)
+    }
+
+    private enum RouteExposure { case sheltered, mixed, exposed }
+
+    /// Real weather-aware advice: cached weather + route exposure (metro is
+    /// underground/sheltered, tram is open-air). Mirrors the KMP StationComfort.
+    private func weatherAdvice(_ plan: JourneyPlanner.Plan) -> String {
+        let types = plan.legs.compactMap { SyrmosData.line(for: $0.lineId)?.type }
+        let shelter: String
+        switch routeExposure(types) {
+        case .sheltered: shelter = t("mostly underground and sheltered", "κυρίως υπόγεια και υπό στέγη", "kryesisht nëntokë dhe e mbrojtur")
+        case .mixed: shelter = t("partly at surface level", "εν μέρει σε επιφάνεια", "pjesërisht në sipërfaqe")
+        case .exposed: shelter = t("open-air (tram/surface stops)", "σε ανοιχτό χώρο (τραμ/επιφάνεια)", "në ajër të hapur (tram/sipërfaqe)")
+        }
+        if let snap = WeatherStore.shared.snapshot {
+            if snap.current.condition.isWet {
+                return t("It's wet in \(snap.placeName) right now, and this route is \(shelter).",
+                    "Έχει βροχή στην \(snap.placeName) τώρα, και η διαδρομή είναι \(shelter).",
+                    "Ka shi në \(snap.placeName) tani, dhe kjo rrugë është \(shelter).")
+            }
+            return t("It's dry in \(snap.placeName) right now; this route is \(shelter).",
+                "Δεν βρέχει στην \(snap.placeName) τώρα· η διαδρομή είναι \(shelter).",
+                "S'ka shi në \(snap.placeName) tani; kjo rrugë është \(shelter).")
+        }
+        return t("I can't check live weather offline, but this route is \(shelter).",
+            "Δεν μπορώ να δω τον καιρό εκτός σύνδεσης, αλλά η διαδρομή είναι \(shelter).",
+            "Nuk e kontrolloj dot motin pa internet, por kjo rrugë është \(shelter).")
+    }
+
+    private func routeExposure(_ types: [TransitType]) -> RouteExposure {
+        func e(_ type: TransitType) -> RouteExposure {
+            switch type { case .metro: return .sheltered; case .tram: return .exposed; case .suburban: return .mixed }
+        }
+        let es = types.map(e)
+        if es.contains(.exposed) { return .exposed }
+        if es.contains(.mixed) { return .mixed }
+        return .sheltered
     }
 
     private func resolveFindStation(_ query: String) -> AriadneMessage {

--- a/iosApp/iosApp/Features/Assistant/AriadneParser.swift
+++ b/iosApp/iosApp/Features/Assistant/AriadneParser.swift
@@ -15,7 +15,7 @@ indirect enum AssistantIntent: Equatable {
     case findStation(query: String)
     case planTrip(fromStationId: String?, toStationId: String?, lowExposure: Bool)
     case explainLine(lineId: String)
-    case explainFare(airport: Bool)
+    case explainFare(airport: Bool, fromStationId: String?, toStationId: String?)
     case toggleFavorite(stationId: String?)
     case showAlerts(lineId: String?)
     case openMap(stationId: String?)
@@ -92,7 +92,8 @@ struct AthensTransitParser {
 
         // 0a. Fares (before planning, so "how much to the airport" is a fare).
         if containsAny(text, Self.fareWords) {
-            return .explainFare(airport: containsAny(text, Self.airportWords))
+            let (from, to) = resolveTripEndpoints(text, stations)
+            return .explainFare(airport: containsAny(text, Self.airportWords), fromStationId: from, toStationId: to)
         }
 
         // 0b. Favorites.

--- a/iosApp/iosApp/Features/Weather/WeatherCard.swift
+++ b/iosApp/iosApp/Features/Weather/WeatherCard.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+/// Weather travel-context card, in the vibrant gradient style of the shared
+/// weather-app design. Mirrors the Compose `WeatherCard`.
+struct WeatherCard: View {
+    let snapshot: WeatherSnapshot
+    @ObservedObject private var loc = LocalizationManager.shared
+
+    var body: some View {
+        let w = snapshot.current
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(snapshot.placeName)
+                        .font(.subheadline).fontWeight(.semibold)
+                        .foregroundStyle(.white.opacity(0.95))
+                    Text(WeatherStyle.label(w.condition, loc.language))
+                        .font(.body)
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+                Spacer()
+                Text(WeatherStyle.glyph(w.condition, w.isDay)).font(.system(size: 40))
+            }
+            HStack(alignment: .bottom) {
+                Text("\(Int(w.temperatureC.rounded()))°")
+                    .font(.system(size: 56, weight: .bold))
+                    .foregroundStyle(.white)
+                Spacer()
+                if let high = snapshot.highC, let low = snapshot.lowC {
+                    Text("H:\(Int(high.rounded()))°  L:\(Int(low.rounded()))°")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.9))
+                        .padding(.bottom, 8)
+                }
+            }
+
+            if !snapshot.hourly.isEmpty {
+                HStack {
+                    ForEach(snapshot.hourly.prefix(6)) { h in
+                        VStack(spacing: 3) {
+                            Text(h.hourLabel).font(.caption2).foregroundStyle(.white.opacity(0.85))
+                            Text(WeatherStyle.glyph(h.condition, w.isDay)).font(.system(size: 18))
+                            Text("\(Int(h.temperatureC.rounded()))°").font(.caption).fontWeight(.semibold).foregroundStyle(.white)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                .padding(.vertical, 10)
+                .background(.white.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+
+            HStack(spacing: 16) {
+                stat(feelsLike, "\(Int(w.apparentC.rounded()))°")
+                stat(humidity, "\(w.humidity)%")
+                stat(wind, "\(Int(w.windKph.rounded())) km/h")
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            LinearGradient(colors: WeatherStyle.gradient(w.condition, w.isDay),
+                           startPoint: .top, endPoint: .bottom)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    private func stat(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(label).font(.caption2).foregroundStyle(.white.opacity(0.8))
+            Text(value).font(.body).fontWeight(.semibold).foregroundStyle(.white)
+        }
+    }
+
+    private var feelsLike: String { tri("Feels like", "Αίσθηση", "Ndihet si") }
+    private var humidity: String { tri("Humidity", "Υγρασία", "Lagështia") }
+    private var wind: String { tri("Wind", "Άνεμος", "Era") }
+
+    private func tri(_ en: String, _ el: String, _ sq: String) -> String {
+        switch loc.language { case .greek: return el; case .albanian: return sq; default: return en }
+    }
+}
+
+/// Shared weather visuals so the card and any future weather surface agree.
+enum WeatherStyle {
+    static func glyph(_ c: WeatherCondition, _ isDay: Bool) -> String {
+        switch c {
+        case .clear: return isDay ? "☀️" : "🌙"
+        case .partlyCloudy: return isDay ? "⛅" : "☁️"
+        case .cloudy: return "☁️"
+        case .fog: return "🌫️"
+        case .drizzle, .showers: return "🌦️"
+        case .rain: return "🌧️"
+        case .snow: return "❄️"
+        case .thunderstorm: return "⛈️"
+        case .unknown: return "🌡️"
+        }
+    }
+
+    static func gradient(_ c: WeatherCondition, _ isDay: Bool) -> [Color] {
+        if !isDay { return [Color(red: 0.10, green: 0.14, blue: 0.49), Color(red: 0.19, green: 0.11, blue: 0.57)] }
+        switch c {
+        case .clear: return [Color(red: 0.13, green: 0.59, blue: 0.95), Color(red: 0.31, green: 0.76, blue: 0.97)]
+        case .partlyCloudy: return [Color(red: 0.26, green: 0.65, blue: 0.96), Color(red: 0.56, green: 0.79, blue: 0.98)]
+        case .cloudy, .fog: return [Color(red: 0.38, green: 0.49, blue: 0.55), Color(red: 0.56, green: 0.64, blue: 0.68)]
+        case .drizzle, .rain, .showers: return [Color(red: 0.27, green: 0.35, blue: 0.39), Color(red: 0.33, green: 0.43, blue: 0.48)]
+        case .thunderstorm: return [Color(red: 0.22, green: 0.28, blue: 0.31), Color(red: 0.27, green: 0.35, blue: 0.39)]
+        case .snow: return [Color(red: 0.47, green: 0.56, blue: 0.61), Color(red: 0.69, green: 0.75, blue: 0.77)]
+        case .unknown: return [Color(red: 0.26, green: 0.65, blue: 0.96), Color(red: 0.56, green: 0.79, blue: 0.98)]
+        }
+    }
+
+    static func label(_ c: WeatherCondition, _ lang: AppLanguage) -> String {
+        func tri(_ en: String, _ el: String, _ sq: String) -> String {
+            switch lang { case .greek: return el; case .albanian: return sq; default: return en }
+        }
+        switch c {
+        case .clear: return tri("Clear", "Αίθριος", "Kthjellët")
+        case .partlyCloudy: return tri("Partly cloudy", "Λίγα σύννεφα", "Pjesërisht me re")
+        case .cloudy: return tri("Cloudy", "Συννεφιά", "Me re")
+        case .fog: return tri("Fog", "Ομίχλη", "Mjegull")
+        case .drizzle: return tri("Drizzle", "Ψιχάλα", "Shi i imët")
+        case .rain: return tri("Rain", "Βροχή", "Shi")
+        case .showers: return tri("Showers", "Μπόρες", "Rrebeshe")
+        case .snow: return tri("Snow", "Χιόνι", "Borë")
+        case .thunderstorm: return tri("Thunderstorm", "Καταιγίδα", "Stuhi")
+        case .unknown: return tri("Weather", "Καιρός", "Moti")
+        }
+    }
+}

--- a/iosApp/iosApp/Views/Home/HomeView.swift
+++ b/iosApp/iosApp/Views/Home/HomeView.swift
@@ -11,6 +11,7 @@ struct HomeView: View {
     @ObservedObject private var schedules = SyrmosSchedulesStore.shared
     @ObservedObject private var freshnessStore = LiveDataFreshness.shared
     @ObservedObject private var tracking = DepartureTracking.shared
+    @ObservedObject private var weather = WeatherStore.shared
     @State private var webViewURL: URL?
     @State private var isNearMeExpanded = true
     @State private var showLocationDeniedAlert = false
@@ -63,6 +64,7 @@ struct HomeView: View {
             }
             .task {
                 locationService.requestIfNeeded()
+                await weather.refresh()
                 await stasyService.fetchAnnouncements()
             }
             .sheet(item: $webViewURL) { url in
@@ -121,6 +123,9 @@ struct HomeView: View {
             answerHero(next: next)
             if let last {
                 lastTrainTeaser(last)
+            }
+            if let snap = weather.snapshot {
+                WeatherCard(snapshot: snap)
             }
         }
     }

--- a/iosApp/iosAppTests/AriadneParserTests.swift
+++ b/iosApp/iosAppTests/AriadneParserTests.swift
@@ -78,14 +78,15 @@ final class AriadneParserTests: XCTestCase {
     }
 
     func test_fareAirport() {
-        guard case let .explainFare(airport) = parser.parse("how much is a ticket to the Airport") else {
+        guard case let .explainFare(airport, _, toId) = parser.parse("how much is a ticket to the Airport") else {
             return XCTFail("expected fare")
         }
         XCTAssertTrue(airport)
+        XCTAssertEqual(toId, "M3_AER")
     }
 
     func test_fareStandard() {
-        guard case let .explainFare(airport) = parser.parse("what's the ticket price") else {
+        guard case let .explainFare(airport, _, _) = parser.parse("what's the ticket price") else {
             return XCTFail("expected fare")
         }
         XCTAssertFalse(airport)


### PR DESCRIPTION
Adds the weather feature and closes the last deferred assistant gaps, across iOS, Android and Web.

## Weather
- Immersive gradient weather card on Home: current conditions, today's high/low, a next-six-hours forecast strip, and feels-like / humidity / wind.
- Open-Meteo (free, no key, CORS-friendly). `WeatherService`/`WeatherRepository` in KMP, `WeatherStore` on iOS. Central-Athens default so Web / no-location launches still show something.
- Visual language inspired by the shared weather-app design. The Figma community file couldn't be extracted over MCP (Starter-plan rate limit), so the card matches the aesthetic, not a pixel copy.

## Weather-aware routing
- Ariadne's rainy-day trips read the cached weather + route exposure (`StationComfort`: metro sheltered, tram open-air, suburban mixed) and give real advice; degrades honestly with no cached weather.

## Journey-specific fares
- `ExplainFare` carries the trip endpoints, so an airport fare is derived from an actual airport-station endpoint, not the keyword alone.

## Ariadne on-device LLM front-end
- iOS: `AriadneBrain` uses Apple Foundation Models (iOS 26+) to rewrite fuzzy input before the deterministic parser classifies it. Never picks intents or invents facts; falls through to the rule parser when unavailable.
- KMP: `AssistantQueryNormalizer` seam (no-op default) for a future Android Gemini Nano backer.

## Verification
- `./gradlew check` green; iOS builds + 25 tests pass.