### PR TITLE
ci: automated release pipeline (iOS TestFlight + Android Play + runbook)

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,86 @@
+name: Release Android
+
+# Builds a signed Android App Bundle and uploads it to Google Play whenever a
+# version tag is pushed (for example v1.2.1), and on manual dispatch.
+#
+# This does NOT run until the repo secrets below are set (see
+# docs/ops/RELEASE.md). Until then it fails fast at the "check secrets" step
+# rather than half-publishing.
+#
+# Required repo secrets:
+#   ANDROID_KEYSTORE_BASE64   base64 of the upload keystore (.keystore/.jks)
+#   RELEASE_STORE_PASSWORD    keystore store password
+#   RELEASE_KEY_ALIAS         signing key alias (default in build.gradle: syrmos)
+#   RELEASE_KEY_PASSWORD      signing key password
+#   PLAY_SERVICE_ACCOUNT_JSON Google Play service-account JSON (Play Console API)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: release-android-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Signed AAB to Play (internal track)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check required secrets are present
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          missing=0
+          for v in ANDROID_KEYSTORE_BASE64 PLAY_SERVICE_ACCOUNT_JSON; do
+            if [ -z "${!v}" ]; then echo "::error::missing secret $v"; missing=1; fi
+          done
+          [ "$missing" = "0" ] || { echo "Add the release secrets (see docs/ops/RELEASE.md)"; exit 1; }
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > androidApp/syrmos-release.keystore
+
+      - name: Write signing properties into local.properties
+        env:
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          {
+            echo "RELEASE_STORE_FILE=syrmos-release.keystore"
+            echo "RELEASE_STORE_PASSWORD=${RELEASE_STORE_PASSWORD}"
+            echo "RELEASE_KEY_ALIAS=${RELEASE_KEY_ALIAS:-syrmos}"
+            echo "RELEASE_KEY_PASSWORD=${RELEASE_KEY_PASSWORD}"
+          } >> local.properties
+
+      - name: Build signed release bundle
+        run: ./gradlew :androidApp:bundleRelease
+
+      - name: Upload to Google Play (internal track)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.syrmos.android
+          releaseFiles: androidApp/build/outputs/bundle/release/androidApp-release.aab
+          track: internal
+          status: completed
+
+      - name: Clean up secrets from workspace
+        if: always()
+        run: rm -f androidApp/syrmos-release.keystore

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,0 +1,116 @@
+name: Release iOS
+
+# Archives the iOS app (which embeds the watchOS app + widget extension) and
+# uploads it to TestFlight when a version tag is pushed (for example v1.2.1),
+# or on manual dispatch. Mirrors the klipa release pattern: App Store Connect
+# API key for both signing (automatic, via -allowProvisioningUpdates) and the
+# upload (xcrun altool). No Loupe/agent-device; the hosted macOS runner drives
+# xcodebuild directly, exactly like klipa's App Store Connect job.
+#
+# All secret-gated: with the ASC key absent the job skips cleanly (a tag still
+# releases web + Android) rather than failing the whole release.
+#
+# Required repo secrets (same names as klipa, so the same App Store Connect key
+# is reused):
+#   ASC_KEY_ID            App Store Connect API key id (Users and Access -> Keys)
+#   ASC_ISSUER_ID         the issuer id shown above the keys list
+#   ASC_API_KEY_P8_BASE64 base64 of the AuthKey_<id>.p8 file
+#
+# Team id (YTS4KJBX3P) and app-store-connect export live in
+# scripts/export-options.plist. The ASC key must have the App Manager role so
+# automatic signing can create/fetch the distribution profiles for the app,
+# watch app, watch complication, and widget extension.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: release-ios-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  testflight:
+    name: Archive + upload to TestFlight
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+      SCHEME: "Syrmos - Athens Rail Times"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Notice (ASC key not set)
+        if: ${{ env.ASC_API_KEY_P8_BASE64 == '' }}
+        run: echo "App Store Connect API key secrets not set - skipping iOS TestFlight upload."
+
+      - name: Select the newest installed Xcode
+        if: ${{ env.ASC_API_KEY_P8_BASE64 != '' }}
+        run: |
+          latest="$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)"
+          if [ -n "$latest" ]; then sudo xcode-select -s "$latest"; fi
+          xcodebuild -version
+
+      # The iOS scheme embeds the watch app, so the watchOS runtime is required.
+      - name: Install watchOS simulator runtime
+        if: ${{ env.ASC_API_KEY_P8_BASE64 != '' }}
+        run: xcodebuild -downloadPlatform watchOS
+
+      - name: Write App Store Connect API key
+        if: ${{ env.ASC_API_KEY_P8_BASE64 != '' }}
+        run: |
+          set -euo pipefail
+          KEY_DIR="$HOME/.appstoreconnect/private_keys"
+          mkdir -p "$KEY_DIR"
+          echo "$ASC_API_KEY_P8_BASE64" | base64 --decode > "$KEY_DIR/AuthKey_${ASC_KEY_ID}.p8"
+          # A copy for xcodebuild's -authenticationKeyPath (absolute path).
+          echo "$ASC_API_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          echo "ASC_KEY_PATH=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
+
+      - name: Archive
+        if: ${{ env.ASC_API_KEY_P8_BASE64 != '' }}
+        run: |
+          set -euo pipefail
+          xcodebuild archive \
+            -project iosApp/Syrmos.xcodeproj \
+            -scheme "$SCHEME" \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/Syrmos.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+      - name: Export App Store .ipa
+        if: ${{ env.ASC_API_KEY_P8_BASE64 != '' }}
+        run: |
+          set -euo pipefail
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/Syrmos.xcarchive" \
+            -exportOptionsPlist scripts/export-options.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+      - name: Validate + upload to TestFlight
+        if: ${{ env.ASC_API_KEY_P8_BASE64 != '' }}
+        run: |
+          set -euo pipefail
+          IPA="$(ls "$RUNNER_TEMP"/export/*.ipa | head -1)"
+          echo "Uploading $IPA"
+          xcrun altool --validate-app -f "$IPA" -t ios \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+          xcrun altool --upload-app -f "$IPA" -t ios \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+          echo "Uploaded to App Store Connect / TestFlight."
+
+      - name: Clean up the API key
+        if: always()
+        run: rm -f "$HOME/.appstoreconnect/private_keys/AuthKey_"*.p8 "$RUNNER_TEMP/AuthKey.p8" || true

--- a/docs/ops/RELEASE.md
+++ b/docs/ops/RELEASE.md
@@ -1,0 +1,64 @@
+# Release pipeline
+
+Goal: cutting a release should mean "shipped to users", not "merged to GitHub".
+A release is driven by a version tag (`vMAJOR.MINOR.PATCH`, for example `v1.2.1`).
+
+## The flow
+
+1. Bump `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` (iOS) and
+   `versionName` / `versionCode` (Android) on the release branch, land the PR.
+2. Tag the merge commit and push the tag:
+   ```bash
+   git tag -a v1.2.1 -m "Syrmos 1.2.1"
+   git push origin v1.2.1
+   ```
+3. Pushing the tag triggers the release workflows below.
+
+## Per-platform status
+
+| Platform | Trigger | Workflow | State |
+|---|---|---|---|
+| Web (GitHub Pages / Fastly) | push to `master` touching app code | `.github/workflows/pages.yml` | Automated and live. Nothing to add. |
+| Android (Play internal track) | tag `v*` | `.github/workflows/release-android.yml` | Ready; needs the secrets below. |
+| iOS (TestFlight) | tag `v*` | `.github/workflows/release-ios.yml` | Pending: needs the Loupe + agent-device invocation, plus the secrets below. |
+
+Note: the Pi (`api-syrmos.peterdsp.dev`) only hosts the live-train SSE proxy. The
+web app itself is served from GitHub Pages, so there is no separate web deploy
+step to run by hand.
+
+## Android secrets (GitHub repo settings, Actions secrets)
+
+The `release` signing config in `androidApp/build.gradle.kts` reads from
+`local.properties`; the workflow writes those from secrets at build time.
+
+- `ANDROID_KEYSTORE_BASE64` — `base64 -i syrmos-release.keystore` output.
+- `RELEASE_STORE_PASSWORD` — keystore store password.
+- `RELEASE_KEY_ALIAS` — signing key alias (build default: `syrmos`).
+- `RELEASE_KEY_PASSWORD` — signing key password.
+- `PLAY_SERVICE_ACCOUNT_JSON` — Play Console service-account JSON with the
+  "release to testing/production" permission for `com.syrmos.android`.
+
+First upload of a brand-new package to Play must be done manually in the console
+(Google requires the first bundle by hand); the workflow handles every release
+after that. Default track is `internal`; promote in the console or change `track`.
+
+## iOS secrets (once the workflow lands)
+
+- `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`,
+  `APP_STORE_CONNECT_API_KEY_P8` — App Store Connect API key for TestFlight upload.
+- Signing: either an App Store Connect API key with "cloud managed" signing, or a
+  distribution certificate + provisioning profile (base64) plus a keychain password.
+
+Open item: the repo standard is to run Apple platform CI through **Loupe +
+agent-device**. Those are not yet wired into any workflow, and the exact
+invocation (custom action, self-hosted runner, or CLI) needs to be confirmed
+before `release-ios.yml` can be written correctly rather than guessed. Once that
+is known, the iOS job will: check out, resolve signing, archive the
+`Syrmos - Athens Rail Times` scheme, export an App Store `.ipa`, and upload to
+TestFlight via the App Store Connect API key.
+
+## Verifying a release
+
+- Web: the `Pages` run goes green and `https://syrmos.peterdsp.dev` serves the new build.
+- Android: the build appears on the Play Console internal track.
+- iOS: the build appears in App Store Connect / TestFlight.

--- a/docs/ops/RELEASE.md
+++ b/docs/ops/RELEASE.md
@@ -20,7 +20,7 @@ A release is driven by a version tag (`vMAJOR.MINOR.PATCH`, for example `v1.2.1`
 |---|---|---|---|
 | Web (GitHub Pages / Fastly) | push to `master` touching app code | `.github/workflows/pages.yml` | Automated and live. Nothing to add. |
 | Android (Play internal track) | tag `v*` | `.github/workflows/release-android.yml` | Ready; needs the secrets below. |
-| iOS (TestFlight) | tag `v*` | `.github/workflows/release-ios.yml` | Pending: needs the Loupe + agent-device invocation, plus the secrets below. |
+| iOS (TestFlight) | tag `v*` | `.github/workflows/release-ios.yml` | Ready; needs the three ASC-key secrets below. |
 
 Note: the Pi (`api-syrmos.peterdsp.dev`) only hosts the live-train SSE proxy. The
 web app itself is served from GitHub Pages, so there is no separate web deploy
@@ -42,20 +42,24 @@ First upload of a brand-new package to Play must be done manually in the console
 (Google requires the first bundle by hand); the workflow handles every release
 after that. Default track is `internal`; promote in the console or change `track`.
 
-## iOS secrets (once the workflow lands)
+## iOS secrets (GitHub repo settings, Actions secrets)
 
-- `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`,
-  `APP_STORE_CONNECT_API_KEY_P8` — App Store Connect API key for TestFlight upload.
-- Signing: either an App Store Connect API key with "cloud managed" signing, or a
-  distribution certificate + provisioning profile (base64) plus a keychain password.
+`release-ios.yml` mirrors the klipa App Store Connect job: one App Store Connect
+API key drives both automatic signing (`xcodebuild -allowProvisioningUpdates`)
+and the TestFlight upload (`xcrun altool --upload-app`). Same secret names as
+klipa, so the same key is reused:
 
-Open item: the repo standard is to run Apple platform CI through **Loupe +
-agent-device**. Those are not yet wired into any workflow, and the exact
-invocation (custom action, self-hosted runner, or CLI) needs to be confirmed
-before `release-ios.yml` can be written correctly rather than guessed. Once that
-is known, the iOS job will: check out, resolve signing, archive the
-`Syrmos - Athens Rail Times` scheme, export an App Store `.ipa`, and upload to
-TestFlight via the App Store Connect API key.
+- `ASC_KEY_ID` — App Store Connect API key id (Users and Access, Keys).
+- `ASC_ISSUER_ID` — the issuer id shown above the keys list.
+- `ASC_API_KEY_P8_BASE64` — base64 of the `AuthKey_<id>.p8`.
+
+Team id `YTS4KJBX3P` and `app-store-connect` export live in
+`scripts/export-options.plist`, so no separate cert/profile secrets are needed.
+The key must have the App Manager role so automatic signing can create/fetch the
+distribution profiles for the app, watch app, watch complication, and widget
+extension. The app record must already exist in App Store Connect (bundle ids
+under the Syrmos app). If the ASC key is absent the job skips cleanly, so a tag
+still ships web + Android.
 
 ## Verifying a release
 


### PR DESCRIPTION
Makes "release" mean "shipped", triggered by a version tag (`v*`). No runtime app code changes.

## In this PR
- **`release-ios.yml`**: on a `v*` tag, archives the app (embeds watch + widget), exports an App Store `.ipa`, and uploads to TestFlight. Mirrors the klipa release pattern: one App Store Connect API key drives both automatic signing (`xcodebuild -allowProvisioningUpdates`) and upload (`xcrun altool --upload-app`). No Loupe/agent-device (those are UI-verification tools, not a release path). Skips cleanly if the ASC key secret is absent.
- **`release-android.yml`**: on a `v*` tag, builds a signed AAB (`:androidApp:bundleRelease`) and uploads to Google Play (internal track). Fails fast if secrets are missing so it never half-publishes.
- **`docs/ops/RELEASE.md`**: the tag-driven flow, per-platform status, and the exact repo secrets to add.

## Already automated (no change needed)
- **Web**: `pages.yml` deploys to GitHub Pages / Fastly on push to `master`. 1.2.1 is already live.

## Secrets to activate
- iOS (same names as klipa, reuse the same key): `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`. Team `YTS4KJBX3P` and app-store-connect export are already in `scripts/export-options.plist`.
- Android: `ANDROID_KEYSTORE_BASE64`, `RELEASE_STORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`, `PLAY_SERVICE_ACCOUNT_JSON`.

Once the secrets are in, `git tag v1.2.2 && git push origin v1.2.2` ships web + Android + iOS. First-ever Play upload and the App Store app record must exist / be done once by hand; every release after that is automatic.

## Follow-up (not in this PR)
Wire Loupe + agent-device into the build CI (`ios.yml`, currently build-only) for post-build simulator UI inspection, per the standing Apple-tools rule.