### PR TITLE
Ariadne: cleverer rule parser (trilingual coverage + weather fix) + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The long-range product roadmap by version (1.1 through 2.0, with quarterly targe
 
 Product direction: Syrmos is a companion, not a schedule. Every feature is measured against the answer-first / proactive / reassuring / low-decision rules in [docs/PRODUCT_PRINCIPLES.md](docs/PRODUCT_PRINCIPLES.md).
 
+## Unreleased
+
+Headline: Ariadne gets a **real on-device LLM** (one model, every platform) plus a **cleverer rule parser**. The model does the understanding step only (messy message to an approved intent and quoted slots); it never generates a transit fact, and the deterministic rule parser stays the offline floor, so nothing regresses when the model is absent.
+
+- One model everywhere via **llama.cpp** (GGUF), replacing the old per-platform "smart" tiers (Apple Intelligence on iOS, Gemini Nano on Android, nothing on Web) that lit up on almost no devices. Model: **Qwen2.5-1.5B-Instruct (Q4_K_M)**, chosen after a real browser benchmark on messy trilingual queries where 0.5B scored 3/9 (failing every Greek and Albanian case) and 1.5B scored 9/9. Albanian and Greek stay first-class.
+- **On-demand, not bundled**: only the small runtime ships with the app; the ~1.1 GB model is downloaded in-app on explicit opt-in and cached, so first install stays lightweight. Single shared manifest (`AriadneModelManifest`, pinned URL + SHA-256); the binary is fetched + verified by CI, never committed.
+- **Web (shipped, browser-verified)**: `@wllama/wllama` (llama.cpp to WASM) runs the model in the browser, cached in OPFS, multi-threaded under COOP/COEP with a single-thread fallback. A GBNF grammar locks output to the exact intent JSON, so an invalid intent is impossible. Output is grounded by the existing `IntentGrounder` and dispatched to the same deterministic use cases.
+- **Cleverer rule parser**: expanded EN/EL/SQ cue coverage (departures, last train, plan, find, fare, help) so more natural phrasings resolve without the model, and fixed a bug where a weather question about a place we do not serve ("what's the weather in London") answered with Athens weather instead of declining.
+- Shared `IntentGrounder.classificationPrompt` rewritten as a few-shot trilingual prompt (also improves the native paths).
+- **iOS + Android native runtimes**: in progress (llama.cpp via Swift/JNI, same on-demand model). Rule parser is the floor on both until the model is downloaded.
+
 ## 1.2.1 (2026-07-08, in review)
 
 Headline: the **Ariadne co-pilot** (Phases 1 to 4) plus first-class Albanian coverage. Ariadne now keeps session context ("I'm at Syntagma" then "go airport faster"), answers honest station status backed by live STASY advisories, ranks routes by preference with a weather tilt, reasons about live-vs-seasonal weather, and drives a live Apple Watch app + widgets with voiced (TTS) read-back. Details below.

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AthensTransitParser.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/assistant/AthensTransitParser.kt
@@ -67,6 +67,13 @@ class AthensTransitParser(
                 TO_MARKERS.any { text.contains(it) } ||
                 mentionedStations.size >= 2
             if (!planning) {
+                // "weather in London": the user named a place we do not serve
+                // (no Athens station resolved, yet a location was clearly given),
+                // so decline instead of answering with Athens weather. A bare
+                // "what's the weather" with no place still answers locally.
+                if (mentionedStations.isEmpty() && namesUnservedPlace(text)) {
+                    return AssistantIntent.OutOfScope
+                }
                 return AssistantIntent.WeatherAt(stationId = mentionedStations.firstOrNull())
             }
         }
@@ -451,6 +458,18 @@ class AthensTransitParser(
         needles.any { containsToken(text, fold(it)) }
 
     /**
+     * True when [text] introduces a place with a location preposition
+     * ("weather IN London", "καιρός ΣΤΟ Λονδίνο"). Used by the weather branch to
+     * decline a weather question about a place that resolved to no Athens
+     * station, instead of silently answering with Athens weather. [text] is
+     * already folded (lowercased, accents stripped).
+     */
+    private fun namesUnservedPlace(text: String): Boolean {
+        val markers = listOf(" in ", " at ", " στο ", " στη ", " στην ", " σε ")
+        return markers.any { text.contains(fold(it)) }
+    }
+
+    /**
      * Word-ish containment: matches [needle] as a substring but guards the
      * common false positive where a short token sits inside a longer word.
      * Multi-word needles match as plain substrings.
@@ -527,30 +546,35 @@ class AthensTransitParser(
         )
         private val DEPARTURE_WORDS = listOf(
             "next", "departure", "departures", "when", "trains", "leave", "leaving", "schedule",
-            "επομεν", "αναχωρη", "ποτε", "δρομολογ", "φευγει", "τρεν",
-            "ardhsh", "kur", "nisje", "tren", "trena",
+            "coming", "upcoming", "due",
+            "επομεν", "αναχωρη", "ποτε", "δρομολογ", "φευγει", "τρεν", "ερχεται",
+            "ardhsh", "kur", "nisje", "tren", "trena", "vjen",
         )
         private val LAST_TRAIN_PHRASES = listOf(
-            "last train", "last metro", "last one", "leave by",
-            "τελευται", "τελευταιο τρεν", "τελευταιος",
-            "treni i fundit", "fundit", "i fundit", "tren i fundit",
+            "last train", "last metro", "last one", "leave by", "final train", "last departure",
+            "τελευται", "τελευταιο τρεν", "τελευταιος", "τελευταιο δρομολογιο",
+            "treni i fundit", "fundit", "i fundit", "tren i fundit", "nisja e fundit",
         )
         // Strong trip cues only. Bare "from" / "από" / "nga" are deliberately
         // excluded: "trains from Syntagma" is a departures query, not a trip.
         // Two named stations or an explicit "to" frame trigger planning instead.
         private val PLAN_PHRASES = listOf(
-            "how do i get", "how to get", "get to", "get me to", "route",
+            "how do i get", "how to get", "get to", "get me to", "route", "directions",
             "how do i go", "how to go", "go to", "can i go", "can i still", "can i reach",
+            "take me to", "best way", "fastest way", "quickest way",
             "πως πα", "πως πη", "πως φτα", "διαδρομη", "για να πα", "προλαβαινω", "μπορω να παω",
+            "πως θα παω", "καλυτερος τροπος", "πιο γρηγορα",
             "si shkoj", "si te shkoj", "rruga", "udhetim", "a mund te shkoj", "a arrij",
+            "si te vij", "rruga me e mire", "rruga me e shpejte",
         )
         private val TO_MARKERS = listOf(
             " to ", " for ", "->", "→", " προς ", " για ", " te ", " per ", " ne ",
         )
         private val FIND_WORDS = listOf(
             "where is", "find", "locate", "nearest", "near me", "closest",
-            "που ειναι", "βρες", "κοντιν", "κοντα μου", "πλησιεστερ",
-            "ku eshte", "gjej", "me afert", "afer meje",
+            "which station", "what station", "where's",
+            "που ειναι", "βρες", "κοντιν", "κοντα μου", "πλησιεστερ", "ποιος σταθμος",
+            "ku eshte", "gjej", "me afert", "afer meje", "cili stacion",
         )
         private val LINE_WORDS = listOf(
             "line", "about", "tell me about",
@@ -559,8 +583,9 @@ class AthensTransitParser(
         )
         private val FARE_WORDS = listOf(
             "fare", "fares", "ticket", "tickets", "how much", "price", "cost", "cheap",
-            "εισιτηρι", "ποσο κανει", "ποσο κοστιζει", "τιμη", "κοστος",
-            "bilete", "sa kushton", "kushton", "cmim", "cmimi",
+            "ticket price", "how much does it cost", "how much is",
+            "εισιτηρι", "ποσο κανει", "ποσο κοστιζει", "τιμη", "κοστος", "τιμη εισιτηριου",
+            "bilete", "sa kushton", "kushton", "cmim", "cmimi", "cmimi i biletes",
         )
         private val FAVORITE_WORDS = listOf(
             "favorite", "favourite", "save this", "bookmark", "add to favorites", "pin",
@@ -582,8 +607,9 @@ class AthensTransitParser(
         )
         private val HELP_PHRASES = listOf(
             "what can you do", "help", "how do you work", "what do you do", "who are you",
-            "τι μπορεις", "βοηθεια", "πως δουλευ", "ποιος εισαι",
-            "si funksionon", "ndihme", "cfare mund", "kush je",
+            "what is ariadne", "who is ariadne", "what are you",
+            "τι μπορεις", "βοηθεια", "πως δουλευ", "ποιος εισαι", "τι εισαι", "τι ειναι η αριαδνη",
+            "si funksionon", "ndihme", "cfare mund", "kush je", "cfare eshte ariadne", "cfare je",
         )
         private val WEATHER_WORDS = listOf(
             "rain", "raining", "rainy", "weather", "storm", "wet",

--- a/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/assistant/AthensTransitParserTest.kt
+++ b/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/assistant/AthensTransitParserTest.kt
@@ -241,4 +241,41 @@ class AthensTransitParserTest {
         assertEquals("M1_PIR", plan.fromStationId)
         assertEquals("M2_SYN", plan.toStationId)
     }
+
+    // --- Expanded trilingual cue coverage (cleverer rule parser) ---
+
+    @Test
+    fun final_train_english_synonym() {
+        assertIs<AssistantIntent.LastTrain>(parser.parse("final train from Syntagma"))
+    }
+
+    @Test
+    fun last_departure_albanian_synonym() {
+        assertIs<AssistantIntent.LastTrain>(parser.parse("nisja e fundit nga Pireas"))
+    }
+
+    @Test
+    fun take_me_to_is_plan_trip() {
+        assertIs<AssistantIntent.PlanTrip>(parser.parse("take me to the Airport from Monastiraki"))
+    }
+
+    @Test
+    fun fastest_way_greek_is_plan_trip() {
+        assertIs<AssistantIntent.PlanTrip>(parser.parse("ποιος ειναι ο καλυτερος τροπος απο Μοναστηρακι στο Αεροδρομιο"))
+    }
+
+    @Test
+    fun ticket_price_greek_is_fare() {
+        assertIs<AssistantIntent.ExplainFare>(parser.parse("τιμη εισιτηριου για το αεροδρομιο"))
+    }
+
+    @Test
+    fun what_is_ariadne_is_help() {
+        assertIs<AssistantIntent.Help>(parser.parse("what is ariadne"))
+    }
+
+    @Test
+    fun cfare_eshte_ariadne_is_help() {
+        assertIs<AssistantIntent.Help>(parser.parse("cfare eshte ariadne"))
+    }
 }


### PR DESCRIPTION
Follow-up to the web LLM PR (#11).

- Expand EN/EL/SQ rule-parser cue coverage (departures, last train, plan, find, fare, help) so more natural phrasings resolve without the model.
- Fix a pre-existing bug: 'what's the weather in London' returned Athens weather instead of OutOfScope. Now declines when a location preposition names a place that resolves to no Athens station; bare 'what's the weather' still answers locally.
- 7 new trilingual parser tests; full :core:domain unit suite green.
- CHANGELOG: Unreleased section for the on-device LLM + parser work.

iOS + Android native llama.cpp runtimes are the remaining piece (need a device/CI to verify inference).