### PR TITLE
Prevent iOS and Android release cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # Reusable CI is called by both release workflows for the same tag. Include
+  # the caller workflow name so iOS and Android cannot cancel each other.
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- include the caller workflow name in reusable CI concurrency keys
- prevent simultaneous iOS and Android tag releases from cancelling each other

## Verification

- workflow YAML parses successfully
- failure reproduced on beta 7 tag run before this fix