### PR TITLE
Mobile: geometry-following train positions (bundled shapes.json → KMP simulator)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
@@ -66,6 +66,7 @@ val featureModule = module {
             stationOffsetsRepo = get(),
             scheduleSyncRepository = get(),
             announcementsRepository = get(),
+            lineGeometryRepository = get(),
         )
     }
     factory { com.syrmos.core.domain.usecase.GetStationDeparturesUseCase(getNextDepartures = get(), transitPatternRepository = get()) }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/di/DataModule.kt
@@ -2,6 +2,7 @@ package com.syrmos.core.data.di
 
 import com.syrmos.core.data.repository.FavoritesRepository
 import com.syrmos.core.data.repository.LineRepositoryImpl
+import com.syrmos.core.data.repository.LineGeometryRepositoryImpl
 import com.syrmos.core.data.repository.ScheduleRepositoryImpl
 import com.syrmos.core.data.repository.StationRepositoryImpl
 import com.syrmos.core.data.repository.TransitPatternRepositoryImpl
@@ -29,4 +30,5 @@ val dataModule = module {
     single { ScheduleRepositoryImpl(database = get()) }
     single { FavoritesRepository(database = get()) }
     single { TransitPatternRepositoryImpl(resourceReader = get()) }
+    single { LineGeometryRepositoryImpl(resourceReader = get()) }
 }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/LineGeometryRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/LineGeometryRepositoryImpl.kt
@@ -1,0 +1,58 @@
+package com.syrmos.core.data.repository
+
+import com.syrmos.core.common.map.LatLng
+import com.syrmos.core.data.seed.ResourceReader
+import com.syrmos.core.data.seed.SeedShapesPayload
+import kotlinx.serialization.json.Json
+
+/**
+ * Loads the bundled per-line OSM route geometry (`schedules-v2/shapes.json`) so
+ * the on-device train simulator can place vehicles ALONG the track instead of on
+ * a straight chord between stations — the same geometry the web map uses. The
+ * file is static, so the parsed result is memoised after the first read.
+ *
+ * The parse step is exposed as a pure [parseShapes] so it is unit-testable
+ * without a platform [ResourceReader].
+ */
+class LineGeometryRepositoryImpl(
+    private val resourceReader: ResourceReader,
+) {
+    private var cached: Map<String, List<LatLng>>? = null
+
+    /** Per-line polyline as (lat,lng) points. Empty map if the seed is missing. */
+    suspend fun getLineGeometry(): Map<String, List<LatLng>> {
+        cached?.let { return it }
+        val parsed = try {
+            parseShapes(resourceReader.readText(SHAPES_PATH))
+        } catch (e: Exception) {
+            // Missing/corrupt seed must never crash the map — the simulator just
+            // falls back to chord positioning (its default when geometry is empty).
+            emptyMap()
+        }
+        cached = parsed
+        return parsed
+    }
+
+    companion object {
+        const val SHAPES_PATH: String = "files/seed/schedules-v2/shapes.json"
+
+        private val json = Json { ignoreUnknownKeys = true }
+
+        /**
+         * Parse shapes.json text into per-line polylines. Each coordinate is a
+         * `[lat, lng]` pair; pairs with fewer than two numbers are dropped, and a
+         * line whose polyline ends up empty is omitted entirely so callers can
+         * treat "present" as "usable".
+         */
+        fun parseShapes(text: String): Map<String, List<LatLng>> {
+            val payload = json.decodeFromString<SeedShapesPayload>(text)
+            return payload.shapes
+                .mapValues { (_, shape) ->
+                    shape.coordinates.mapNotNull { c ->
+                        if (c.size >= 2) LatLng(c[0], c[1]) else null
+                    }
+                }
+                .filterValues { it.isNotEmpty() }
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/SeedDataModels.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/SeedDataModels.kt
@@ -127,3 +127,21 @@ data class SeedServicePattern(
     @SerialName("station_ids") val stationIds: List<String>? = null,
     @SerialName("excluded_station_ids") val excludedStationIds: List<String>? = null,
 )
+
+/**
+ * The generator's `schedules-v2/shapes.json`: OSM route geometry per line, the
+ * same file the web map consumes. Shape: `{version, source, shapes:{lineId:
+ * {coordinates:[[lat,lng], ...]}}}`. Only [coordinates] is needed on device;
+ * the extra keys (osmRelationId/from/to/points) are ignored.
+ */
+@Serializable
+data class SeedShapesPayload(
+    val version: Int = 0,
+    val source: String = "",
+    val shapes: Map<String, SeedShape> = emptyMap(),
+)
+
+@Serializable
+data class SeedShape(
+    @SerialName("coordinates") val coordinates: List<List<Double>> = emptyList(),
+)

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/repository/LineGeometryRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/repository/LineGeometryRepositoryTest.kt
@@ -1,0 +1,65 @@
+package com.syrmos.core.data.repository
+
+import com.syrmos.core.common.map.LatLng
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [LineGeometryRepositoryImpl.parseShapes] — the pure parse step that
+ * turns the bundled `schedules-v2/shapes.json` into per-line (lat,lng) polylines
+ * fed to the on-device train simulator.
+ */
+class LineGeometryRepositoryTest {
+
+    @Test
+    fun parsesRealShapesJsonFormatIntoPolylines() {
+        // Mirrors the actual seed shape: extra keys (osmRelationId/from/to/points)
+        // are present and must be ignored; only `coordinates` matters on device.
+        val json = """
+            {"version":1,"source":"OSM (ODbL)",
+             "shapes":{
+               "M1":{"osmRelationId":445858,"from":"Πειραιάς","to":"Κηφισιά","points":3,
+                     "coordinates":[[38.073395,23.80822],[38.072895,23.808264],[38.072661,23.80825]]},
+               "T6":{"coordinates":[[37.90,23.70],[37.91,23.71]]}
+             }}
+        """.trimIndent()
+
+        val geom = LineGeometryRepositoryImpl.parseShapes(json)
+
+        assertEquals(setOf("M1", "T6"), geom.keys)
+        assertEquals(3, geom.getValue("M1").size)
+        assertEquals(LatLng(38.073395, 23.80822), geom.getValue("M1").first())
+        assertEquals(LatLng(38.072661, 23.80825), geom.getValue("M1").last())
+        assertEquals(LatLng(37.91, 23.71), geom.getValue("T6").last())
+    }
+
+    @Test
+    fun dropsMalformedCoordinatePairsButKeepsValidOnes() {
+        // [37.95] has <2 numbers -> dropped; [38.0,23.8,999] keeps the first two.
+        val json = """{"shapes":{"M2":{"coordinates":[[37.9,23.7],[37.95],[38.0,23.8,999]]}}}"""
+
+        val geom = LineGeometryRepositoryImpl.parseShapes(json)
+
+        assertEquals(2, geom.getValue("M2").size)
+        assertEquals(LatLng(37.9, 23.7), geom.getValue("M2")[0])
+        assertEquals(LatLng(38.0, 23.8), geom.getValue("M2")[1])
+    }
+
+    @Test
+    fun omitsLinesWhosePolylineEndsUpEmpty() {
+        val json = """{"shapes":{"EMPTY":{"coordinates":[]},"OK":{"coordinates":[[1.0,2.0]]}}}"""
+
+        val geom = LineGeometryRepositoryImpl.parseShapes(json)
+
+        assertEquals(setOf("OK"), geom.keys, "a line with no usable points must be omitted")
+    }
+
+    @Test
+    fun ignoresUnknownTopLevelKeysAndEmptyShapes() {
+        val geom = LineGeometryRepositoryImpl.parseShapes(
+            """{"version":2,"source":"x","shapes":{}}""",
+        )
+        assertTrue(geom.isEmpty())
+    }
+}

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
@@ -1,5 +1,7 @@
 package com.syrmos.feature.map
 
+import com.syrmos.core.common.map.LatLng
+import com.syrmos.core.data.repository.LineGeometryRepositoryImpl
 import com.syrmos.core.data.repository.LineRepositoryImpl
 import com.syrmos.core.data.repository.ScheduleRepositoryImpl
 import com.syrmos.core.data.repository.StationRepositoryImpl
@@ -74,6 +76,7 @@ class MapViewModel(
     private val stationOffsetsRepo: StationOffsetsRepository,
     private val scheduleSyncRepository: com.syrmos.core.data.sync.ScheduleSyncRepository,
     private val announcementsRepository: AnnouncementsRepository,
+    private val lineGeometryRepository: LineGeometryRepositoryImpl,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val _uiState = MutableStateFlow(MapUiState())
@@ -223,6 +226,11 @@ class MapViewModel(
 
     private fun runTrainSimulation() {
         scope.launch {
+            // Bundled OSM route geometry (same shapes.json the web map uses). Loaded
+            // once — it is static and memoised — so both simulated and projected
+            // trains ride the real track instead of a straight chord between stops.
+            // Empty map (missing seed) makes the simulator fall back to chords.
+            val geometry: Map<String, List<LatLng>> = lineGeometryRepository.getLineGeometry()
             while (isActive) {
                 val state = _uiState.value
                 if (state.lines.isNotEmpty() && state.lineStations.isNotEmpty()) {
@@ -234,6 +242,7 @@ class MapViewModel(
                         state.lineStations,
                         livePositionsSnapshot,
                         closedStationIds = closedIds,
+                        geometry = geometry,
                     )
                     // Suburban A1-A4 dedupe: railway.gov.gr `liveTrains` carry
                     // raw GPS. Whenever the live feed has a train on a line,
@@ -253,6 +262,7 @@ class MapViewModel(
                         bundles = scheduleSyncRepository.lineBundles.value,
                         today = scheduleDayTypeString(),
                         nowMinutes = now.hour * 60 + now.minute + now.second / 60.0,
+                        geometry = geometry,
                     ).filter { it.lineId !in coveredByLive }
                     val visibleTrains = filtered + projected
                     _uiState.update { current ->

--- a/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/TrainSimulatorTest.kt
+++ b/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/TrainSimulatorTest.kt
@@ -1,5 +1,7 @@
 package com.syrmos.feature.map
 
+import com.syrmos.core.common.map.LatLng
+import com.syrmos.core.common.map.VehicleInterpolation
 import com.syrmos.core.model.transit.Line
 import com.syrmos.core.model.transit.LineColor
 import com.syrmos.core.model.transit.LineStatus
@@ -359,5 +361,63 @@ class TrainSimulatorTest {
             snapshot = snapshotWith(trains = listOf(train), generatedAtEpochSeconds = now),
         )
         assertEquals(1, result.size, "An operational line must still yield trains")
+    }
+
+    // --- geometry wiring --------------------------------------------------
+    //
+    // When per-line track geometry is supplied, a simulated train must ride the
+    // real polyline instead of the straight chord between its two stations (the
+    // chord cuts across bays and put coastal trains in the sea). The arc math
+    // itself is pinned in VehicleInterpolationTest; THIS test proves the
+    // `geometry` argument is actually threaded through simulateTrains().
+
+    @Test
+    fun placesTrainOnLineGeometryNotChordWhenGeometryProvided() {
+        val now = Clock.System.now().epochSeconds
+        // elapsedMinutes 5 -> halfway between Station A (0min) and Station B (10min).
+        val train = SyrmosLivePositionsService.LiveTrain(
+            lineId = "M3",
+            directionKey = "outbound",
+            originDepartureMinute = 0.0,
+            elapsedMinutes = 5.0,
+            totalTravelMinutes = 20,
+            serviceType = "regular",
+        )
+        // L-shaped M3 track: east along lat 37.98 to a corner, then north to B.
+        // The straight chord A->B would cut the corner; arc-following rides it.
+        val m3Polyline = listOf(
+            LatLng(37.98, 23.73),   // Station A (polyline start)
+            LatLng(37.98, 23.75),   // corner
+            LatLng(37.99, 23.74),   // Station B (polyline end)
+        )
+        val snapshot = snapshotWith(trains = listOf(train), generatedAtEpochSeconds = now)
+
+        val chord = simulateTrains(listOf(m3Line), m3LineStations, snapshot).first()
+        val onTrack = simulateTrains(
+            listOf(m3Line),
+            m3LineStations,
+            snapshot,
+            geometry = mapOf("M3" to m3Polyline),
+        ).first()
+
+        // 1) Geometry must MOVE the train off the chord — this is the wiring proof.
+        val delta = VehicleInterpolation.haversineM(
+            LatLng(chord.latitude, chord.longitude),
+            LatLng(onTrack.latitude, onTrack.longitude),
+        )
+        assertTrue(delta > 200.0, "geometry must shift the train off the chord, got ${delta}m")
+
+        // 2) The geometry position must sit ON the polyline, not float beside it.
+        val table = VehicleInterpolation.buildDistanceTable(m3Polyline)
+        val nearest = VehicleInterpolation.pointAtArc(
+            m3Polyline,
+            table,
+            VehicleInterpolation.stationArc(m3Polyline, table, LatLng(onTrack.latitude, onTrack.longitude)),
+        )
+        val offTrack = VehicleInterpolation.haversineM(
+            LatLng(onTrack.latitude, onTrack.longitude),
+            nearest,
+        )
+        assertTrue(offTrack < 50.0, "geometry train must lie on the track, off by ${offTrack}m")
     }
 }


### PR DESCRIPTION
Activates on-device geometry-following train positions for iOS + Android, matching the web map's behaviour.

## What
- **`LineGeometryRepositoryImpl`** (new): parses the bundled `schedules-v2/shapes.json` into per-line `(lat,lng)` polylines. Memoised (static seed) and fail-safe — a missing/corrupt seed yields an empty map, and the simulator then falls back to chord positioning. Pure `parseShapes()` companion for unit-testing.
- Registered in Koin (`DataModule`), threaded through `MapViewModel` into **both** `simulateTrains()` and `projectScheduledTrains()` (which already accept the `geometry` param).
- Seed models `SeedShapesPayload` / `SeedShape`.

## Why
With geometry present, vehicles ride the real OSM track instead of a straight chord between stations. The chord cut across bays and dropped coastal trains in the sea — the same class of bug just fixed on the web map.

## Tests (this PR is gated on CI running them)
- `LineGeometryRepositoryTest` — shapes.json parsing: real format with extra keys ignored, malformed coordinate pairs dropped, empty polylines omitted, empty shapes.
- `TrainSimulatorTest.placesTrainOnLineGeometryNotChordWhenGeometryProvided` — proves the `geometry` arg is actually threaded through `simulateTrains` (train lands on the polyline, >200 m off the chord). The arc math itself is already pinned in `VehicleInterpolationTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)