### PR TITLE
Add typed data-status/freshness contract (orthogonal provenance + per-item freshness)

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -9,5 +9,8 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.datetime)
         }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
     }
 }

--- a/core/model/src/commonMain/kotlin/com/syrmos/core/model/status/DataStatus.kt
+++ b/core/model/src/commonMain/kotlin/com/syrmos/core/model/status/DataStatus.kt
@@ -1,0 +1,86 @@
+package com.syrmos.core.model.status
+
+import com.syrmos.core.model.schedule.SourceConfidence
+
+/**
+ * The full, orthogonal status of an on-screen datum: WHERE it came from
+ * ([provenance], a [SourceConfidence]) and its TEMPORAL condition ([freshness],
+ * a [Freshness]). Both axes are retained together; the display state is DERIVED
+ * via [resolveDataStatusDisplay] and never replaces them — the provenance must
+ * survive so callers can still branch on how the value was produced.
+ */
+data class DataStatus(
+    val provenance: SourceConfidence,
+    val freshness: Freshness,
+) {
+    fun display(): DataStatusDisplay = resolveDataStatusDisplay(this)
+}
+
+/**
+ * The resolved display bucket. Language-free: the platform UI (SwiftUI / Compose
+ * / web) maps each kind to a localized label and formats
+ * [DataStatusDisplay.ageSeconds] with a locale-aware duration formatter.
+ *
+ * [LIVE_UNKNOWN_AGE] is a live source whose recency we cannot vouch for — it is
+ * deliberately distinct from [LIVE] and must never render as a plain "live"
+ * badge.
+ */
+enum class DisplayKind {
+    LIVE,
+    LIVE_UNKNOWN_AGE,
+    SCHEDULED,
+    ESTIMATED,
+    CACHED,
+    OFFLINE,
+    OPERATOR,
+    UNAVAILABLE,
+}
+
+/**
+ * Structured, language-free display state. It carries NO UI copy and NO
+ * preformatted age: [kind] selects the localized label, [ageSeconds] (present
+ * only for [DisplayKind.CACHED]) feeds a platform duration formatter, and
+ * [status] preserves the full provenance + freshness so nothing is discarded.
+ */
+data class DataStatusDisplay(
+    val kind: DisplayKind,
+    val ageSeconds: Long?,
+    val status: DataStatus,
+)
+
+/**
+ * Provenance-first resolution of a [DataStatus] to a [DataStatusDisplay].
+ *
+ * Provenance sets the reading; freshness only refines a LIVE datum:
+ * fresh -> [DisplayKind.LIVE], stale -> [DisplayKind.CACHED] (with the age),
+ * unknown age -> [DisplayKind.LIVE_UNKNOWN_AGE] (never a plain live badge), and
+ * the invalid combinations (live + not-applicable, live + unavailable) ->
+ * [DisplayKind.UNAVAILABLE]. OFFLINE is the bundled-timetable source (a
+ * provenance), not a statement about device connectivity — nothing here inspects
+ * a connectivity flag.
+ *
+ * A [Freshness.Unavailable] means no datum exists and resolves to
+ * [DisplayKind.UNAVAILABLE] for every provenance, never to a usable state.
+ */
+fun resolveDataStatusDisplay(status: DataStatus): DataStatusDisplay {
+    // No datum exists: Unavailable can never read as a usable state, whatever the
+    // provenance. Guarded up front so this holds for every combination.
+    if (status.freshness is Freshness.Unavailable) {
+        return DataStatusDisplay(DisplayKind.UNAVAILABLE, null, status)
+    }
+    val resolved: Pair<DisplayKind, Long?> = when (status.provenance) {
+        SourceConfidence.LIVE -> when (val f = status.freshness) {
+            is Freshness.Fresh -> DisplayKind.LIVE to null
+            is Freshness.Stale -> DisplayKind.CACHED to f.ageSeconds
+            is Freshness.UnknownAge -> DisplayKind.LIVE_UNKNOWN_AGE to null
+            is Freshness.NotApplicable -> DisplayKind.UNAVAILABLE to null
+            is Freshness.Unavailable -> DisplayKind.UNAVAILABLE to null
+        }
+        SourceConfidence.SCHEDULED -> DisplayKind.SCHEDULED to null
+        SourceConfidence.ESTIMATED -> DisplayKind.ESTIMATED to null
+        SourceConfidence.OFFLINE -> DisplayKind.OFFLINE to null
+        SourceConfidence.OPERATOR_LINK -> DisplayKind.OPERATOR to null
+        SourceConfidence.UNKNOWN -> DisplayKind.UNAVAILABLE to null
+    }
+    return DataStatusDisplay(resolved.first, resolved.second, status)
+}

--- a/core/model/src/commonMain/kotlin/com/syrmos/core/model/status/Freshness.kt
+++ b/core/model/src/commonMain/kotlin/com/syrmos/core/model/status/Freshness.kt
@@ -1,0 +1,113 @@
+package com.syrmos.core.model.status
+
+import kotlinx.datetime.Instant
+
+/**
+ * The temporal condition of a datum, kept strictly ORTHOGONAL to its provenance
+ * ([com.syrmos.core.model.schedule.SourceConfidence]). The two axes are never
+ * conflated: a value can be Scheduled + [NotApplicable], Live + [Fresh], or
+ * Live + [Stale]. Connectivity / offline mode is deliberately not modelled here,
+ * and it is not provenance either — a bundled-timetable answer is
+ * `SourceConfidence.OFFLINE` regardless of whether the device happens to be
+ * online at that moment.
+ *
+ * This supersedes the ad-hoc, process-wide `core.common.DataFreshness`
+ * (LIVE / PREDICTED) for per-item use; that legacy enum is left untouched here
+ * and migrating its callers is out of scope for this change.
+ */
+sealed interface Freshness {
+    /** Within the freshness window; no age worth surfacing. */
+    data object Fresh : Freshness
+
+    /** Older than the window; carries its own per-item age, in seconds (never negative). */
+    data class Stale(val ageSeconds: Long) : Freshness {
+        init { require(ageSeconds >= 0) { "Stale.ageSeconds must be >= 0, was $ageSeconds" } }
+    }
+
+    /**
+     * The datum exists but carries no trustworthy timestamp: missing, malformed,
+     * or so far in the future it cannot be believed.
+     */
+    data object UnknownAge : Freshness
+
+    /** Freshness does not apply (e.g. a static timetable minute, not a live feed). */
+    data object NotApplicable : Freshness
+
+    /** There is no datum at all (e.g. an empty live response). */
+    data object Unavailable : Freshness
+}
+
+/** The default staleness window: a live datum older than this is [Freshness.Stale]. */
+const val DEFAULT_FRESHNESS_WINDOW_SECONDS: Long = 90
+
+/**
+ * How far a timestamp may sit in the FUTURE (device clock skew) and still be
+ * treated as just-now. Beyond this, the timestamp is not trusted and the datum
+ * is [Freshness.UnknownAge] rather than silently "fresh".
+ */
+const val DEFAULT_FUTURE_SKEW_TOLERANCE_SECONDS: Long = 120
+
+/**
+ * Per-item freshness derived from that item's OWN timestamp — never a single
+ * process-wide clock, so two items fetched together but stamped differently get
+ * their own verdicts. Pure and clock-injected so it unit-tests without a real
+ * clock.
+ *
+ * @param updatedAtEpochSeconds the item's own updatedAt (epoch seconds), or
+ *   `null` when the item has no usable timestamp -> [Freshness.UnknownAge].
+ * @param nowEpochSeconds the current instant (epoch seconds).
+ * @param windowSeconds the staleness window (default [DEFAULT_FRESHNESS_WINDOW_SECONDS]); must be `>= 0`.
+ * @param futureSkewToleranceSeconds tolerated future offset (default
+ *   [DEFAULT_FUTURE_SKEW_TOLERANCE_SECONDS]); must be `>= 0`.
+ *
+ * Rules: age within `[0, window]` -> [Freshness.Fresh]; age `> window` ->
+ * [Freshness.Stale] carrying the age. A future timestamp within
+ * [futureSkewToleranceSeconds] is treated as just-now ([Freshness.Fresh]); a
+ * timestamp further in the future is [Freshness.UnknownAge].
+ */
+fun freshnessFromEpoch(
+    updatedAtEpochSeconds: Long?,
+    nowEpochSeconds: Long,
+    windowSeconds: Long = DEFAULT_FRESHNESS_WINDOW_SECONDS,
+    futureSkewToleranceSeconds: Long = DEFAULT_FUTURE_SKEW_TOLERANCE_SECONDS,
+): Freshness {
+    require(windowSeconds >= 0) { "windowSeconds must be >= 0, was $windowSeconds" }
+    require(futureSkewToleranceSeconds >= 0) { "futureSkewToleranceSeconds must be >= 0, was $futureSkewToleranceSeconds" }
+    if (updatedAtEpochSeconds == null) return Freshness.UnknownAge
+    val age = nowEpochSeconds - updatedAtEpochSeconds
+    if (age < 0) {
+        // Future timestamp: tolerate small device clock skew as just-now, but do
+        // not trust one that sits far ahead of us.
+        return if (-age <= futureSkewToleranceSeconds) Freshness.Fresh else Freshness.UnknownAge
+    }
+    return if (age <= windowSeconds) Freshness.Fresh else Freshness.Stale(age)
+}
+
+/**
+ * Convenience over [freshnessFromEpoch] that parses an ISO-8601 `updatedAt`
+ * string as the API payloads carry it. A `null`, blank or malformed string
+ * yields [Freshness.UnknownAge]. When an item genuinely has no live datum at
+ * all, the call site should use [Freshness.Unavailable] rather than passing a
+ * null timestamp here.
+ *
+ * [windowSeconds] and [futureSkewToleranceSeconds] are validated up front, so a
+ * bad configuration is rejected even when the timestamp itself is null or
+ * malformed (it is never masked by an early [Freshness.UnknownAge] return).
+ */
+fun freshnessFromIso(
+    updatedAtIso: String?,
+    now: Instant,
+    windowSeconds: Long = DEFAULT_FRESHNESS_WINDOW_SECONDS,
+    futureSkewToleranceSeconds: Long = DEFAULT_FUTURE_SKEW_TOLERANCE_SECONDS,
+): Freshness {
+    require(windowSeconds >= 0) { "windowSeconds must be >= 0, was $windowSeconds" }
+    require(futureSkewToleranceSeconds >= 0) { "futureSkewToleranceSeconds must be >= 0, was $futureSkewToleranceSeconds" }
+    val epoch = parseIsoToEpochSeconds(updatedAtIso) ?: return Freshness.UnknownAge
+    return freshnessFromEpoch(epoch, now.epochSeconds, windowSeconds, futureSkewToleranceSeconds)
+}
+
+/** Parses an ISO-8601 instant to epoch seconds, or `null` if blank or malformed. */
+fun parseIsoToEpochSeconds(iso: String?): Long? {
+    if (iso.isNullOrBlank()) return null
+    return runCatching { Instant.parse(iso.trim()).epochSeconds }.getOrNull()
+}

--- a/core/model/src/commonTest/kotlin/com/syrmos/core/model/status/DataStatusTest.kt
+++ b/core/model/src/commonTest/kotlin/com/syrmos/core/model/status/DataStatusTest.kt
@@ -1,0 +1,174 @@
+package com.syrmos.core.model.status
+
+import com.syrmos.core.model.schedule.SourceConfidence
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+/**
+ * The typed data-status / freshness contract. Provenance ([SourceConfidence])
+ * and temporal condition ([Freshness]) are orthogonal; the resolved
+ * [DataStatusDisplay] is structured (kind + raw ageSeconds) and never discards
+ * provenance, and carries no localizable copy. The timestamps here are synthetic
+ * fixtures for the freshness logic only; production departure times come from the
+ * projector, ordered routes and station offsets, never from these.
+ */
+class DataStatusTest {
+
+    private val now = 1_000_000L // epoch seconds, fixed test clock
+    private val nowInstant = Instant.fromEpochSeconds(now)
+
+    @Test
+    fun freshLiveItem() {
+        val f = freshnessFromEpoch(now - 10, now, windowSeconds = 90)
+        assertIs<Freshness.Fresh>(f)
+        val d = DataStatus(SourceConfidence.LIVE, f).display()
+        assertEquals(DisplayKind.LIVE, d.kind)
+        assertNull(d.ageSeconds)
+    }
+
+    @Test
+    fun exactlyAtNinetySecondBoundaryIsFreshOneMoreIsStale() {
+        assertIs<Freshness.Fresh>(freshnessFromEpoch(now - 90, now, 90))
+        assertIs<Freshness.Stale>(freshnessFromEpoch(now - 91, now, 90))
+    }
+
+    @Test
+    fun staleLiveItemCarriesRawPerItemAgeAndKeepsProvenance() {
+        val stale = assertIs<Freshness.Stale>(freshnessFromEpoch(now - 360, now, 90))
+        assertEquals(360L, stale.ageSeconds)
+        val d = DataStatus(SourceConfidence.LIVE, stale).display()
+        assertEquals(DisplayKind.CACHED, d.kind)
+        assertEquals(360L, d.ageSeconds) // raw seconds, not a preformatted string
+        // Guardrail: provenance + freshness survive the display mapping.
+        assertEquals(SourceConfidence.LIVE, d.status.provenance)
+        assertEquals(stale, d.status.freshness)
+    }
+
+    @Test
+    fun scheduledAndEstimatedStayDistinct() {
+        val sched = DataStatus(SourceConfidence.SCHEDULED, Freshness.NotApplicable).display()
+        val est = DataStatus(SourceConfidence.ESTIMATED, Freshness.NotApplicable).display()
+        assertEquals(DisplayKind.SCHEDULED, sched.kind)
+        assertEquals(DisplayKind.ESTIMATED, est.kind)
+        assertNotEquals(sched.kind, est.kind)
+    }
+
+    @Test
+    fun bundledTimetableIsProvenanceNotConnectivity() {
+        // The mapper consults only provenance — there is no connectivity input,
+        // so "offline" here is the bundled-timetable source, not device state.
+        val d = DataStatus(SourceConfidence.OFFLINE, Freshness.NotApplicable).display()
+        assertEquals(DisplayKind.OFFLINE, d.kind)
+        assertEquals(SourceConfidence.OFFLINE, d.status.provenance)
+    }
+
+    @Test
+    fun missingOrMalformedTimestampIsUnknownAge() {
+        assertIs<Freshness.UnknownAge>(freshnessFromIso(null, nowInstant))
+        assertIs<Freshness.UnknownAge>(freshnessFromIso("", nowInstant))
+        assertIs<Freshness.UnknownAge>(freshnessFromIso("   ", nowInstant))
+        assertIs<Freshness.UnknownAge>(freshnessFromIso("not-a-timestamp", nowInstant))
+        assertNull(parseIsoToEpochSeconds("2026-13-45T99:99:99Z"))
+    }
+
+    @Test
+    fun liveWithUnknownAgeIsNotAPlainLiveBadge() {
+        // A live source whose recency we can't vouch for must be its own state.
+        val d = DataStatus(SourceConfidence.LIVE, Freshness.UnknownAge).display()
+        assertEquals(DisplayKind.LIVE_UNKNOWN_AGE, d.kind)
+        assertNotEquals(DisplayKind.LIVE, d.kind)
+        assertEquals(SourceConfidence.LIVE, d.status.provenance) // provenance intact
+    }
+
+    @Test
+    fun liveWithNotApplicableIsInvalidSoUnavailable() {
+        val d = DataStatus(SourceConfidence.LIVE, Freshness.NotApplicable).display()
+        assertEquals(DisplayKind.UNAVAILABLE, d.kind)
+    }
+
+    @Test
+    fun futureWithinToleranceIsFreshBeyondToleranceIsUnknownAge() {
+        val tol = DEFAULT_FUTURE_SKEW_TOLERANCE_SECONDS
+        assertIs<Freshness.Fresh>(freshnessFromEpoch(now + tol, now, futureSkewToleranceSeconds = tol)) // exactly at tolerance
+        assertIs<Freshness.UnknownAge>(freshnessFromEpoch(now + tol + 1, now, futureSkewToleranceSeconds = tol)) // one past
+        // A timestamp years in the future is never "fresh".
+        assertIs<Freshness.UnknownAge>(freshnessFromEpoch(now + 60L * 60 * 24 * 365, now))
+    }
+
+    @Test
+    fun unknownProviderIsUnavailable() {
+        val d = DataStatus(SourceConfidence.UNKNOWN, Freshness.NotApplicable).display()
+        assertEquals(DisplayKind.UNAVAILABLE, d.kind)
+    }
+
+    @Test
+    fun emptyLiveResponseIsUnavailable() {
+        // A live feed that returned no rows -> Unavailable, never a fake countdown.
+        val d = DataStatus(SourceConfidence.LIVE, Freshness.Unavailable).display()
+        assertEquals(DisplayKind.UNAVAILABLE, d.kind)
+    }
+
+    @Test
+    fun unavailableFreshnessIsAlwaysUnavailableForEveryProvenance() {
+        // "No datum" can never read as Scheduled / Estimated / Offline / Operator.
+        for (prov in SourceConfidence.entries) {
+            val d = DataStatus(prov, Freshness.Unavailable).display()
+            assertEquals(DisplayKind.UNAVAILABLE, d.kind, "$prov + Unavailable must resolve to UNAVAILABLE")
+            assertNull(d.ageSeconds)
+            assertEquals(prov, d.status.provenance) // provenance still retained
+        }
+    }
+
+    @Test
+    fun freshnessIsPerItemNotProcessWide() {
+        // Same clock, different per-item timestamps -> independent verdicts.
+        assertIs<Freshness.Fresh>(freshnessFromEpoch(now - 10, now, 90))
+        val b = assertIs<Freshness.Stale>(freshnessFromEpoch(now - 300, now, 90))
+        assertEquals(300L, b.ageSeconds)
+    }
+
+    @Test
+    fun isoTimestampsResolveToFreshOrStale() {
+        val at = Instant.parse("2026-08-29T12:00:00Z")
+        assertIs<Freshness.Fresh>(freshnessFromIso("2026-08-29T11:59:30Z", at, 90)) // 30s
+        val stale = assertIs<Freshness.Stale>(freshnessFromIso("2026-08-29T11:54:00Z", at, 90)) // 360s
+        assertEquals(360L, stale.ageSeconds)
+    }
+
+    @Test
+    fun negativeWindowOrToleranceIsRejected() {
+        assertFailsWith<IllegalArgumentException> { freshnessFromEpoch(now - 10, now, windowSeconds = -1) }
+        assertFailsWith<IllegalArgumentException> { freshnessFromEpoch(now - 10, now, futureSkewToleranceSeconds = -1) }
+        // The ISO path validates config BEFORE parsing, so a null or malformed
+        // timestamp must not mask a bad window/tolerance behind an UnknownAge return.
+        assertFailsWith<IllegalArgumentException> { freshnessFromIso(null, nowInstant, windowSeconds = -1) }
+        assertFailsWith<IllegalArgumentException> { freshnessFromIso("not-a-timestamp", nowInstant, futureSkewToleranceSeconds = -1) }
+    }
+
+    @Test
+    fun staleAgeCannotBeNegative() {
+        assertFailsWith<IllegalArgumentException> { Freshness.Stale(-1) }
+    }
+
+    @Test
+    fun unknownRawProvenanceFallsBackToScheduledNotUnknown() {
+        // Documents an integration gap deliberately left outside this contract:
+        // SourceConfidence.fromRaw maps unrecognized/absent raw strings to
+        // SCHEDULED, so an "unknown provider" does NOT reach UNKNOWN via the
+        // parser. Producing UNKNOWN is the caller's explicit responsibility
+        // (construct SourceConfidence.UNKNOWN); changing fromRaw's fallback would
+        // alter existing departure parsing and belongs to a later track.
+        assertEquals(SourceConfidence.SCHEDULED, SourceConfidence.fromRaw("garbage"))
+        assertEquals(SourceConfidence.SCHEDULED, SourceConfidence.fromRaw(null))
+        // The contract still maps an explicit UNKNOWN to Unavailable:
+        assertEquals(
+            DisplayKind.UNAVAILABLE,
+            DataStatus(SourceConfidence.UNKNOWN, Freshness.NotApplicable).display().kind,
+        )
+    }
+}


### PR DESCRIPTION
First, narrowest slice of the approved **Transit Command Centre** plan (A-track). Contract + tests only.

## Why
Every on-screen time or position needs to resolve to one status **without conflating WHERE it came from (provenance) with its TEMPORAL condition (freshness)**.

## How
- **`Freshness`** sealed type (temporal): `Fresh` · `Stale(ageSeconds)` · `UnknownAge` · `NotApplicable` · `Unavailable`, with per-item `freshnessFromEpoch` / `freshnessFromIso` / `parseIsoToEpochSeconds`. 90s window; a future timestamp within a **bounded skew tolerance (120s)** is just-now, further ahead is `UnknownAge` (never silently fresh). `windowSeconds`/tolerance must be `>= 0`; `Stale.ageSeconds` cannot be negative.
- **`DataStatus(provenance, freshness)`** pairs the existing `SourceConfidence` (unchanged) with a `Freshness`. `resolveDataStatusDisplay` returns a **structured, language-free `DataStatusDisplay`** (`DisplayKind` + raw `ageSeconds` + the retained `DataStatus`) — **no UI copy, no preformatted age**; platforms localize the kind and format the duration. A live datum with unknown age is `LIVE_UNKNOWN_AGE` (never a plain live badge); `live + not-applicable/unavailable` → `UNAVAILABLE`.
- Connectivity is never consulted: `OFFLINE` is the bundled-timetable **source**, not device state.
- Adds a `commonTest` source set to `core:model`.

## Review fixes folded into this PR
1. **Rebased onto `origin/master`; the Pi-seed commit `8784a82b` and `seed_oasa_airport_bus_stops.py` are removed** — the PR is now exactly the four contract files.
2. **Unknown age is no longer "Live"** — `LIVE + UnknownAge` → `LIVE_UNKNOWN_AGE`, and `LIVE + NotApplicable` → `UNAVAILABLE`.
3. **Bounded future skew** — beyond the tolerance a future timestamp is `UnknownAge`; boundary + far-future tests added.
4. **No English strings / preformatted ages in `core:model`** — the model returns kind + raw `ageSeconds`; localization and duration formatting are the platform UI's job.
5. **`SourceConfidence.fromRaw` gap documented + tested** — it maps unrecognized/absent raw values to `SCHEDULED`, so reaching `UNKNOWN` is the producer's explicit responsibility; changing that fallback touches existing departure parsing and is left to a later track.
6. **Validation added** — negative `windowSeconds`/tolerance and negative `Stale.ageSeconds` are rejected.

## Guardrails
Provenance and freshness stay orthogonal and the display never discards provenance (`DataStatusDisplay.status`). Test timestamps are synthetic fixtures for the freshness logic only — production times come from the projector, ordered routes and station offsets.

## Tests (`DataStatusTest`, 16, all green locally)
fresh · 90s boundary · stale-with-raw-age · scheduled≠estimated · bundled-offline-as-provenance · missing/malformed → UnknownAge · live+unknown-age → LIVE_UNKNOWN_AGE · live+not-applicable → Unavailable · bounded vs far-future skew · unknown provider → Unavailable · empty live → Unavailable · per-item freshness · ISO round-trip · negative-window/tolerance rejected · negative Stale age rejected · fromRaw → SCHEDULED gap.

## Scope
Contract + tests only. **No** `selectedLine`, theme cleanup, route UI, Airport UI, web changes or Pi seeding. Legacy `core.common.DataFreshness{LIVE,PREDICTED}` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)