### PR TITLE
Web redesign Phase 0: §19 nav amendment + URL-state router foundation

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -589,6 +589,20 @@ The same architecture applies on all platforms:
 | Entity details | Page or bottom sheet | Context rail beside map or content |
 | Full inventory | Full-screen list | Split view or data table |
 
+**Web amendment (v1.2.11, approved 2026-08-29).** On web only, the primary
+navigation is refined to five task workspaces — **Now, Plan, Explore,
+Departures, Tickets** — around a permanent map canvas. Map is the canvas, not a
+navigation item; the former **More** contents move to rail-bottom utility
+controls (settings, language, theme, offline data, about) with a persistent
+service-health indicator on the rail; **Tickets** and **Plan** are promoted to
+workspaces (see §19.11, §19.12). iOS and Android keep Model A's bottom-tab set
+(Home, Network, Map, Departures, More). Ariadne remains a global action, never a
+workspace, on every platform. Rationale: on web the map is always present as the
+canvas, so a Map tab is redundant; a "More" drawer hid Tickets and settings; and
+promoting Plan and Tickets matches the two most common web tasks. Each web
+workspace must be a genuinely different panel task with its own deep-linkable
+URL, never a scroll anchor on one long document.
+
 ### 19.4 Responsive shell
 
 | Width | Navigation | Content model |
@@ -850,6 +864,13 @@ estimated price.
 Tickets and fares lives in More and appears contextually on route, line,
 station, and Ariadne answers.
 
+**Web amendment (v1.2.11).** On web, Tickets is a top-level workspace: a fare
+finder that leads with the most relevant product (From / To / rider type), states
+airport exclusions and operator restrictions prominently, keeps the full
+catalogue behind operator/category filters, and moves long rules into a
+searchable Guide. It still appears contextually (two or three relevant rules)
+beside a selected route, line, station, and Ariadne answer.
+
 ### 19.12 More and settings
 
 Settings becomes the **More** destination with traveler-focused groups:
@@ -863,6 +884,11 @@ Settings becomes the **More** destination with traveler-focused groups:
 
 Developer diagnostics remain available behind an explicit developer entry.
 They do not sit among common traveler settings.
+
+**Web amendment (v1.2.11).** On web there is no "More" workspace. These groups
+relocate to rail-bottom utility controls (settings, language, theme, offline
+data) plus a persistent service-health indicator on the rail; Tickets is its own
+workspace (§19.11). iOS and Android keep the More destination unchanged.
 
 ### 19.13 Alerts, weather, and service notices
 

--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -494,6 +494,7 @@
 <script src="web-ariadne-rag.js"></script>
 <script src="web-ariadne.js"></script>
 <script src="llm/ariadne-wllama.js?v=3"></script>
+<script src="web-router.js"></script>
 <script src="web-map.js"></script>
 </body>
 </html>

--- a/composeApp/src/wasmJsMain/resources/web-router.js
+++ b/composeApp/src/wasmJsMain/resources/web-router.js
@@ -1,0 +1,239 @@
+/*
+ * Syrmos web URL <-> workspace-state router (Command Panel redesign, Phase 0).
+ *
+ * The redesign replaces the single endless left panel with five deep-linkable
+ * task workspaces around the permanent map canvas (Now, Plan, Explore,
+ * Departures, Tickets). This module is the foundation: it maps the browser URL
+ * to a workspace-state object and back, and drives Back/reload. It is additive
+ * and deliberately touches no DOM yet - Phase 1 (nav + panel state) subscribes
+ * to `window.syrmosRouter` and renders the workspaces. See DESIGN_SYSTEM.md
+ * §19.3 "Web amendment (v1.2.11)" and §19.4.
+ *
+ * URL model (dossier §03):
+ *   /now?station=ATH
+ *   /plan?from=SYNTAGMA&to=AIRPORT            /plan/journey/<id>
+ *   /explore/discover?region=athens
+ *   /explore/network?region=athens&mode=metro
+ *   /line/M3?direction=airport&stop=SYN
+ *   /station/PIRAEUS
+ *   /departures?station=PIRAEUS
+ *   /tickets?from=SYNTAGMA&to=AIRPORT&rider=adult
+ *
+ * Pure `parseRoute` / `buildRoute` round-trip so state survives Back and reload.
+ * No personal data or precise location is ever placed in the URL.
+ *
+ * Browser: exposes `window.SyrmosRouter` (the module) and a live singleton
+ * `window.syrmosRouter`. Node: `module.exports` + a self-test (run
+ * `node web-router.js`), which the browser never executes.
+ */
+(function (global) {
+  'use strict';
+
+  var WORKSPACES = ['now', 'plan', 'explore', 'departures', 'tickets'];
+
+  // Which query keys are meaningful per workspace shape, in canonical order.
+  var QUERY_KEYS = {
+    now: ['station'],
+    plan: ['from', 'to', 'when'],
+    'explore.discover': ['region'],
+    'explore.network': ['region', 'mode'],
+    line: ['direction', 'stop'],
+    station: [],
+    departures: ['station'],
+    tickets: ['from', 'to', 'rider'],
+  };
+
+  function trimSlashes(p) {
+    return String(p || '').replace(/\/+$/, '').replace(/^\/+/, '');
+  }
+
+  function readQuery(search) {
+    var out = {};
+    var qs = new URLSearchParams(search || '');
+    qs.forEach(function (v, k) { if (v !== '') out[k] = v; });
+    return out;
+  }
+
+  function put(state, key, val) {
+    if (val !== undefined && val !== null && val !== '') state[key] = val;
+  }
+
+  /** Pure: parse a location (pathname + search) into a workspace-state object. */
+  function parseRoute(pathname, search) {
+    var seg = trimSlashes(pathname).split('/').filter(Boolean);
+    var q = readQuery(search);
+    var head = (seg[0] || 'now').toLowerCase();
+
+    if (head === 'line') {
+      var state = { workspace: 'explore', line: seg[1] || null };
+      put(state, 'direction', q.direction);
+      put(state, 'stop', q.stop);
+      return state;
+    }
+    if (head === 'station') {
+      return { workspace: 'now', station: seg[1] || null, view: 'station' };
+    }
+    if (head === 'explore') {
+      var mode = (seg[1] || 'discover').toLowerCase();
+      if (mode !== 'discover' && mode !== 'network') mode = 'discover';
+      var es = { workspace: 'explore', mode: mode };
+      put(es, 'region', q.region);
+      if (mode === 'network') put(es, 'netMode', q.mode);
+      return es;
+    }
+    if (head === 'plan') {
+      if ((seg[1] || '').toLowerCase() === 'journey' && seg[2]) {
+        return { workspace: 'plan', journey: seg[2] };
+      }
+      var ps = { workspace: 'plan' };
+      put(ps, 'from', q.from); put(ps, 'to', q.to); put(ps, 'when', q.when);
+      return ps;
+    }
+    if (head === 'departures') {
+      var ds = { workspace: 'departures' };
+      put(ds, 'station', q.station);
+      return ds;
+    }
+    if (head === 'tickets') {
+      var ts = { workspace: 'tickets' };
+      put(ts, 'from', q.from); put(ts, 'to', q.to); put(ts, 'rider', q.rider);
+      return ts;
+    }
+    // Default / unknown -> Now.
+    var ns = { workspace: 'now' };
+    put(ns, 'station', q.station);
+    return ns;
+  }
+
+  /** Pure: build a canonical URL string ("/path?query") from a state object. */
+  function buildRoute(state) {
+    state = state || {};
+    var ws = WORKSPACES.indexOf(state.workspace) >= 0 ? state.workspace : 'now';
+    var path;
+    var keys;
+
+    if (ws === 'explore' && state.line) {
+      path = '/line/' + encodeURIComponent(state.line);
+      keys = QUERY_KEYS.line;
+    } else if (ws === 'now' && state.view === 'station' && state.station) {
+      path = '/station/' + encodeURIComponent(state.station);
+      keys = QUERY_KEYS.station;
+    } else if (ws === 'plan' && state.journey) {
+      path = '/plan/journey/' + encodeURIComponent(state.journey);
+      keys = [];
+    } else if (ws === 'explore') {
+      var mode = state.mode === 'network' ? 'network' : 'discover';
+      path = '/explore/' + mode;
+      keys = QUERY_KEYS['explore.' + mode];
+    } else {
+      path = '/' + ws;
+      keys = QUERY_KEYS[ws] || [];
+    }
+
+    var qs = new URLSearchParams();
+    keys.forEach(function (k) {
+      // `mode` in the network URL is sourced from state.netMode.
+      var srcKey = (ws === 'explore' && state.mode === 'network' && k === 'mode') ? 'netMode' : k;
+      var v = state[srcKey];
+      if (v !== undefined && v !== null && v !== '') qs.set(k, String(v));
+    });
+    var query = qs.toString();
+    return query ? path + '?' + query : path;
+  }
+
+  /** Browser wiring: reflect state to the URL and notify subscribers on Back. */
+  function createRouter(win) {
+    win = win || global;
+    var listeners = [];
+    function current() { return parseRoute(win.location.pathname, win.location.search); }
+    function emit(st) {
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](st); } catch (e) { /* a subscriber must not break routing */ }
+      }
+    }
+    function navigate(state, opts) {
+      var url = buildRoute(state);
+      var replace = !!(opts && opts.replace);
+      if (win.history && win.history.pushState) {
+        win.history[replace ? 'replaceState' : 'pushState'](state, '', url);
+      }
+      emit(current());
+    }
+    if (win.addEventListener) {
+      win.addEventListener('popstate', function () { emit(current()); });
+    }
+    return {
+      current: current,
+      navigate: navigate,
+      subscribe: function (fn) {
+        listeners.push(fn);
+        return function () { var i = listeners.indexOf(fn); if (i >= 0) listeners.splice(i, 1); };
+      },
+    };
+  }
+
+  var api = { WORKSPACES: WORKSPACES, parseRoute: parseRoute, buildRoute: buildRoute, create: createRouter };
+  global.SyrmosRouter = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  // Live singleton in the browser (tracks URL state; no DOM changes yet).
+  if (global.document && !global.syrmosRouter) {
+    try { global.syrmosRouter = createRouter(global); } catch (e) { /* non-fatal */ }
+  }
+})(typeof window !== 'undefined' ? window : globalThis);
+
+/* ------------------------------- self-test -------------------------------- *
+ * Runs only under `node web-router.js`; the browser never enters this block. */
+if (typeof require !== 'undefined' && typeof module !== 'undefined' && require.main === module) {
+  var R = module.exports;
+  var assert = require('assert');
+  var eq = function (a, b, m) { assert.deepStrictEqual(a, b, m); };
+
+  // parse
+  eq(R.parseRoute('/now', '?station=ATH'), { workspace: 'now', station: 'ATH' });
+  eq(R.parseRoute('/', ''), { workspace: 'now' });
+  eq(R.parseRoute('/plan', '?from=SYNTAGMA&to=AIRPORT'), { workspace: 'plan', from: 'SYNTAGMA', to: 'AIRPORT' });
+  eq(R.parseRoute('/plan/journey/abc', ''), { workspace: 'plan', journey: 'abc' });
+  eq(R.parseRoute('/explore/network', '?region=athens&mode=metro'), { workspace: 'explore', mode: 'network', region: 'athens', netMode: 'metro' });
+  eq(R.parseRoute('/explore', ''), { workspace: 'explore', mode: 'discover' });
+  eq(R.parseRoute('/line/M3', '?direction=airport&stop=SYN'), { workspace: 'explore', line: 'M3', direction: 'airport', stop: 'SYN' });
+  eq(R.parseRoute('/station/PIRAEUS', ''), { workspace: 'now', station: 'PIRAEUS', view: 'station' });
+  eq(R.parseRoute('/departures', '?station=PIRAEUS'), { workspace: 'departures', station: 'PIRAEUS' });
+  eq(R.parseRoute('/tickets', '?from=SYNTAGMA&to=AIRPORT&rider=adult'), { workspace: 'tickets', from: 'SYNTAGMA', to: 'AIRPORT', rider: 'adult' });
+  // trailing slash + unknown head fall back to Now
+  eq(R.parseRoute('/now/', '?station=ATH'), { workspace: 'now', station: 'ATH' });
+  eq(R.parseRoute('/bogus', ''), { workspace: 'now' });
+
+  // build (canonical URLs)
+  eq(R.buildRoute({ workspace: 'now', station: 'ATH' }), '/now?station=ATH');
+  eq(R.buildRoute({ workspace: 'now' }), '/now');
+  eq(R.buildRoute({ workspace: 'plan', from: 'SYNTAGMA', to: 'AIRPORT' }), '/plan?from=SYNTAGMA&to=AIRPORT');
+  eq(R.buildRoute({ workspace: 'plan', journey: 'abc' }), '/plan/journey/abc');
+  eq(R.buildRoute({ workspace: 'explore', mode: 'network', region: 'athens', netMode: 'metro' }), '/explore/network?region=athens&mode=metro');
+  eq(R.buildRoute({ workspace: 'explore', line: 'M3', direction: 'airport', stop: 'SYN' }), '/line/M3?direction=airport&stop=SYN');
+  eq(R.buildRoute({ workspace: 'now', view: 'station', station: 'PIRAEUS' }), '/station/PIRAEUS');
+  eq(R.buildRoute({ workspace: 'departures', station: 'PIRAEUS' }), '/departures?station=PIRAEUS');
+  eq(R.buildRoute({ workspace: 'tickets', from: 'SYNTAGMA', to: 'AIRPORT', rider: 'adult' }), '/tickets?from=SYNTAGMA&to=AIRPORT&rider=adult');
+  // unknown workspace falls back to Now
+  eq(R.buildRoute({ workspace: 'zzz' }), '/now');
+
+  // round-trip: parse(build(x)) === x for representative states
+  [
+    { workspace: 'now', station: 'ATH' },
+    { workspace: 'plan', from: 'SYNTAGMA', to: 'AIRPORT' },
+    { workspace: 'plan', journey: 'abc' },
+    { workspace: 'explore', mode: 'network', region: 'athens', netMode: 'metro' },
+    { workspace: 'explore', mode: 'discover', region: 'athens' },
+    { workspace: 'explore', line: 'M3', direction: 'airport', stop: 'SYN' },
+    { workspace: 'now', view: 'station', station: 'PIRAEUS' },
+    { workspace: 'departures', station: 'PIRAEUS' },
+    { workspace: 'tickets', from: 'SYNTAGMA', to: 'AIRPORT', rider: 'adult' },
+  ].forEach(function (s) {
+    var url = R.buildRoute(s);
+    var i = url.indexOf('?');
+    var path = i < 0 ? url : url.slice(0, i);
+    var search = i < 0 ? '' : url.slice(i);
+    eq(R.parseRoute(path, search), s, 'round-trip: ' + url);
+  });
+
+  console.log('web-router self-test: OK (' + R.WORKSPACES.length + ' workspaces)');
+}


### PR DESCRIPTION
First slice of the approved web **Command Panel** redesign (design dossier approved). **Contract + foundation only — no live-UI change.**

## What
- **`DESIGN_SYSTEM.md` §19 amendment (v1.2.11).** §19.3 / §19.11 / §19.12 now document the approved web nav: five task workspaces **Now · Plan · Explore · Departures · Tickets** around the permanent map canvas; the former **More** contents move to rail-bottom utility controls + a persistent service-health indicator; **Tickets** and **Plan** are promoted to workspaces. iOS and Android keep Model A (Home/Network/Map/Departures/More). Ariadne stays a global action, never a workspace.
- **`web-router.js`** — additive URL ⇄ workspace-state router: pure `parseRoute` / `buildRoute` that round-trip, plus Back/reload wiring via a live `window.syrmosRouter` singleton. Deep-link model per the dossier (`/now?station=`, `/plan?from=&to=`, `/explore/network?region=&mode=`, `/line/M3?direction=`, `/departures?station=`, `/tickets?from=&to=`). No personal data in URLs. **Touches no DOM yet** — Phase 1 subscribes to it. Loaded before `web-map.js`.

## Tests
`node web-router.js` runs a self-test asserting parse / build / round-trip for every workspace URL (the browser never enters that block). Passes locally: `web-router self-test: OK (5 workspaces)`.

## Scope
Phase 0 of 6. **No** workspace content, nav rip-out, panel changes, theme cleanup, or other product code. Phase 1 (nav + panel state) will consume `syrmosRouter` and render the workspace shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)