### PR TITLE
Keep transport chips and status labels atomic across all platforms

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.css
+++ b/composeApp/src/wasmJsMain/resources/web-map.css
@@ -226,7 +226,7 @@ body.dark-mode .nav-item--active {
 }
 
 .answer-hero__actions {
-    display: flex; gap: 8px;
+    display: flex; flex-wrap: wrap; gap: 8px;
 }
 
 .pill-button {
@@ -235,6 +235,11 @@ body.dark-mode .nav-item--active {
     border: none; border-radius: var(--sy-radius-pill);
     font: inherit; font-size: 13px; font-weight: 600;
     cursor: pointer;
+    /* A pill label is a single atomic unit: never wrap it, and never let a
+       flex row compress it below its content width. Rows that hold pills use
+       flex-wrap so whole pills move to the next line instead. */
+    white-space: nowrap;
+    flex-shrink: 0;
     transition: background var(--sy-duration-fast-ms) ease, transform var(--sy-duration-fast-ms) ease;
 }
 .pill-button:active { transform: scale(.97); }
@@ -364,6 +369,11 @@ body.dark-mode .nav-item--active {
     border-radius: var(--sy-radius-pill);
     font-size: 10px; font-weight: 600;
     line-height: 1;
+    /* Status labels such as "Scheduled" or "Live" are atomic: never wrap the
+       word onto a second line, and never let a flex row compress the chip
+       below its content width (which would clip the label). */
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .src-chip__dot {
@@ -417,6 +427,11 @@ body.dark-mode .nav-item--active {
     border-radius: 9px;
     font-size: 13px; font-weight: 700;
     color: #fff;
+    /* Keep short transport codes such as M3, X95 or 24/7 atomic: never wrap
+       the text and never let the flex row compress the badge below its
+       content width. .badge-row already wraps whole badges to the next line. */
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .line-dot {
@@ -648,6 +663,8 @@ body.dark-mode .zoom-stack { background: rgba(27,32,40,.88); }
     backdrop-filter: blur(12px);
     font-size: 12px;
     color: var(--sy-text-secondary);
+    /* Keep the status label on one line; never split or clip it. */
+    white-space: nowrap;
 }
 body.dark-mode .live-status-pill {
     background: rgba(27,32,40,.88);

--- a/feature/schedule/src/commonMain/kotlin/com/syrmos/feature/schedule/AirportHubScreen.kt
+++ b/feature/schedule/src/commonMain/kotlin/com/syrmos/feature/schedule/AirportHubScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -214,6 +216,7 @@ fun AirportHubScreen(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun AirportHero(hub: AirportHubData, lang: AppLanguage) {
     val shape = RoundedCornerShape(28.dp)
@@ -251,11 +254,32 @@ private fun AirportHero(hub: AirportHubData, lang: AppLanguage) {
                 Text(hub.code, color = Color.White, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp))
             }
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            hub.pills.forEach { (label, icon) -> HeroPill(label, icon) }
-            Spacer(Modifier.weight(1f))
-            Box(Modifier.size(8.dp).clip(CircleShape).background(Color(0xFF63E6A6)))
-            Text(airportText(lang, "Schedules", "Ωράρια", "Oraret", "Orari"), color = Color.White, style = MaterialTheme.typography.labelMedium)
+        // Mode pills wrap as complete units so a label like "M3" or "24/7" is
+        // never compressed and split across lines. The schedule-status chip
+        // sits on its own trailing line, so it never competes with the pills
+        // for width and can never clip at the card edge.
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                hub.pills.forEach { (label, icon) -> HeroPill(label, icon) }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(Modifier.size(8.dp).clip(CircleShape).background(Color(0xFF63E6A6)))
+                Spacer(Modifier.width(5.dp))
+                Text(
+                    airportText(lang, "Schedules", "Ωράρια", "Oraret", "Orari"),
+                    color = Color.White,
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+            }
         }
     }
 }
@@ -385,7 +409,14 @@ private fun HeroPill(label: String, icon: ImageVector) {
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Icon(icon, null, tint = Color.White, modifier = Modifier.size(13.dp))
-        Text(label, color = Color.White, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+        Text(
+            label,
+            color = Color.White,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            softWrap = false,
+        )
     }
 }
 

--- a/iosApp/iosApp/Features/Timetables/TimetablesView.swift
+++ b/iosApp/iosApp/Features/Timetables/TimetablesView.swift
@@ -299,15 +299,23 @@ private struct AirportHeroCard: View {
                     .background(.white.opacity(0.16), in: Capsule())
             }
 
-            HStack(spacing: 10) {
-                ForEach(Array(hub.pills.enumerated()), id: \.offset) { _, pill in
-                    airportHeroPill(pill.title, pill.icon)
+            // Mode pills wrap as complete units, so a label like "M3" or "24/7"
+            // can never be compressed and split across two lines. The schedule
+            // status chip sits on its own trailing line, so it never competes
+            // with the pills for width and can never clip at the card edge.
+            VStack(alignment: .leading, spacing: 10) {
+                FlowLayout(spacing: 8) {
+                    ForEach(Array(hub.pills.enumerated()), id: \.offset) { _, pill in
+                        airportHeroPill(pill.title, pill.icon)
+                    }
                 }
-                Spacer()
                 HStack(spacing: 5) {
+                    Spacer(minLength: 0)
                     Circle().fill(Color(hex: 0x63E6A6)).frame(width: 8, height: 8)
                     Text(airportText(language, "Schedules", "Ωράρια", "Oraret", "Orari"))
                         .font(.caption.weight(.semibold))
+                        .lineLimit(1)
+                        .fixedSize()
                 }
             }
         }
@@ -328,9 +336,54 @@ private struct AirportHeroCard: View {
     private func airportHeroPill(_ title: String, _ icon: String) -> some View {
         Label(title, systemImage: icon)
             .font(.caption2.weight(.bold))
+            .lineLimit(1)
+            .fixedSize()
             .padding(.horizontal, 9)
             .padding(.vertical, 6)
             .background(.white.opacity(0.14), in: Capsule())
+    }
+}
+
+/// Lays out chips left to right, wrapping each one to the next line as a
+/// complete unit instead of compressing it. Keeps short transport labels such
+/// as "M3", "X95" or "24/7" atomic, so they can never be split across lines.
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth, x > 0 {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        return CGSize(width: maxWidth, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+        let maxX = bounds.maxX
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if x + size.width > maxX, x > bounds.minX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            sub.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

The Airport hero laid its mode pills and the schedule status chip in a single row with a flexible spacer. On a narrow card that row compressed its children below their content width, so:

- short transport codes wrapped mid-token: `M3` became `M` / `3`, `X95` became `X9` / `5`, `24/7` became `24/` / `7`;
- the status label `Schedules` split into `Sched-ules` and clipped at the card edge, with the green dot misaligned.

The same class of defect lived in the web chip and status CSS, which never declared those labels as non-wrapping, non-shrinking units.

## Fix (shared components, all three platforms)

A chip or status label is now always one atomic line; whole chips wrap or move to their own line instead of being split or clipped.

**iOS** (`TimetablesView.swift`): `airportHeroPill` gets `lineLimit(1)` + `fixedSize`; the pills move into a `FlowLayout` that wraps complete pills; the `Schedules` status chip moves to its own trailing line, single-line.

**Android** (`AirportHubScreen.kt`): `HeroPill` label gets `maxLines = 1, softWrap = false`; the pills move into a `FlowRow`; the status chip moves to its own trailing row. Mirrors the `FlowRow` pattern already shipping in `StationDetailScreen`.

**Web** (`web-map.css`): `.line-badge`, `.pill-button`, `.src-chip` get `white-space: nowrap` + `flex-shrink: 0`; `.answer-hero__actions` gets `flex-wrap`; `.live-status-pill` gets `white-space: nowrap`.

## Verification

Built the iOS app on the iPhone 17 Simulator both before and after the change. The pre-fix build reproduces the exact reported defect (`M3` -> `M`/`3`, `X95` -> `X9`/`5`, `24/7` -> `24/`/`7`, `Schedules` -> `Sched`/`ules`); the fixed build renders every code atomic and the status label readable on its own trailing line. Verified the web CSS the same way in a 240px-wide harness: badges wrap as complete units (`M3 X3 X95 24/7` then `X93 X96 X97`) and `Scheduled` stays on one line. Android compiles the same `FlowRow` API already in the tree; JDK is unavailable on the build host, so the Android compile is left to CI.

Text is never shrunk to illegibility and never clipped to conceal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)