### PR TITLE
Web Phase 1: workspace nav rail (Now/Plan/Explore/Departures/Tickets)

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -200,6 +200,8 @@
             <symbol id="ic-map" viewBox="0 0 24 24"><path d="M3 7l6-3 6 3 6-3v14l-6 3-6-3-6 3V7z"/><line x1="9" y1="4" x2="9" y2="18"/><line x1="15" y1="6" x2="15" y2="20"/></symbol>
             <symbol id="ic-departures" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><polyline points="12,7 12,12 15.5,14"/></symbol>
             <symbol id="ic-more" viewBox="0 0 24 24"><circle cx="12" cy="6" r="1.2"/><circle cx="12" cy="12" r="1.2"/><circle cx="12" cy="18" r="1.2"/></symbol>
+            <symbol id="ic-plan" viewBox="0 0 24 24"><circle cx="6.5" cy="6.5" r="2.2"/><path d="M6.5 8.7v4.3a4 4 0 0 0 4 4h4.6"/><polyline points="13,14.5 15.8,17 13,19.5"/></symbol>
+            <symbol id="ic-tickets" viewBox="0 0 24 24"><rect x="3" y="6.5" width="18" height="11" rx="2.5"/><line x1="13" y1="6.5" x2="13" y2="17.5" stroke-dasharray="1.5 2"/></symbol>
             <symbol id="ic-wifi-off" viewBox="0 0 24 24"><path d="M1 1l22 22"/><path d="M9.2 16.8a3.5 3.5 0 015.6 0"/><circle cx="12" cy="20" r="1"/><path d="M6.3 13.7a7.9 7.9 0 014.3-2.4M17.7 13.7a7.9 7.9 0 00-2.4-1.6"/><path d="M3.4 10.5A12.3 12.3 0 017 8.2M20.6 10.5a12.3 12.3 0 00-5.3-3.2"/></symbol>
         </defs>
     </svg>
@@ -207,19 +209,27 @@
     <!-- ===== Nav Rail (72px, left) ===== -->
     <nav class="nav-rail" aria-label="Main navigation">
         <img class="nav-rail__logo" src="favicon.png" alt="Syrmos" width="40" height="40">
+        <!-- Five workspace roots (Now / Plan / Explore / Departures / Tickets).
+             The map is the canvas, not a nav root; More is a utility pinned to
+             the rail footer. web-nav.js wires these to window.syrmosRouter. -->
         <div class="nav-rail__items">
-            <button class="nav-item nav-item--active" type="button" data-nav="home" aria-label="Home" title="Home">
+            <button class="nav-item nav-item--active" type="button" data-nav="now" aria-label="Now" title="Now" aria-current="page">
                 <svg class="ic" aria-hidden="true"><use href="#ic-home"/></svg>
+            </button>
+            <button class="nav-item" type="button" data-nav="plan" aria-label="Plan a trip" title="Plan">
+                <svg class="ic" aria-hidden="true"><use href="#ic-plan"/></svg>
             </button>
             <button class="nav-item" type="button" data-nav="explore" aria-label="Explore" title="Explore">
                 <svg class="ic" aria-hidden="true"><use href="#ic-explore"/></svg>
             </button>
-            <button class="nav-item" type="button" data-nav="map" aria-label="Map" title="Map">
-                <svg class="ic" aria-hidden="true"><use href="#ic-map"/></svg>
-            </button>
             <button class="nav-item" type="button" data-nav="departures" aria-label="Departures" title="Departures">
                 <svg class="ic" aria-hidden="true"><use href="#ic-departures"/></svg>
             </button>
+            <button class="nav-item" type="button" data-nav="tickets" aria-label="Tickets and fares" title="Tickets">
+                <svg class="ic" aria-hidden="true"><use href="#ic-tickets"/></svg>
+            </button>
+        </div>
+        <div class="nav-rail__footer">
             <button class="nav-item" type="button" data-nav="more" aria-label="More" title="More">
                 <svg class="ic" aria-hidden="true"><use href="#ic-more"/></svg>
             </button>
@@ -495,6 +505,7 @@
 <script src="web-ariadne.js"></script>
 <script src="llm/ariadne-wllama.js?v=3"></script>
 <script src="web-router.js"></script>
+<script src="web-nav.js"></script>
 <script src="web-map.js"></script>
 </body>
 </html>

--- a/composeApp/src/wasmJsMain/resources/web-map.css
+++ b/composeApp/src/wasmJsMain/resources/web-map.css
@@ -47,6 +47,16 @@ html, body {
     gap: 4px; flex: 1;
 }
 
+/* Utilities (More) pinned to the rail bottom, below the workspace roots and
+   separated from them. .nav-rail__items has flex: 1, so it pushes this down. */
+.nav-rail__footer {
+    display: flex; flex-direction: column; align-items: center;
+    gap: 4px;
+    width: 48px;
+    padding-top: 8px; margin-top: 8px;
+    border-top: 1px solid var(--sy-border-subtle);
+}
+
 .nav-item {
     display: flex; align-items: center; justify-content: center;
     width: 48px; height: 48px;

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -3362,40 +3362,61 @@
         }
     })();
 
-    // Left nav rail: the five icons were inert placeholders from the redesign.
-    // Wire each to a real, DISTINCT action. The app is one map + one scrolling
-    // context panel, so "navigation" means framing the map and jumping the
-    // panel. Clicking also moves the active highlight.
+    // Left nav rail: five workspace roots (Now / Plan / Explore / Departures /
+    // Tickets) plus a footer "More" utility. The workspace is a real app state
+    // via web-nav.js + the Phase 0 router shape; each hook frames the one map +
+    // scrolling context panel for its workspace. The map is the canvas, not a
+    // nav root.
+    //
+    // In-session routing only, on purpose: the live host (GitHub Pages) has no
+    // SPA fallback, so a path like /plan 404s on reload, and <base href> would
+    // break the inline SVG <use href="#ic-..."> icons. So we drive the same
+    // subscribe/active-state machinery but do NOT push path URLs yet. We still
+    // read the INITIAL workspace from the URL (so a host that later serves deep
+    // links initialises correctly). Flip URL_ROUTING to true once the host
+    // serves an SPA fallback and the built wasm loader is verified on deep
+    // paths; nothing else here needs to change.
     (function wireNavRail() {
-        const items = document.querySelector(".nav-rail__items");
-        if (!items) return;
+        const nav = document.querySelector(".nav-rail");
+        if (!nav || !window.SyrmosNav) return;
         const contextRail = document.getElementById("contextRail");
         const panelTop = () => { if (contextRail) contextRail.scrollTo({ top: 0, behavior: "smooth" }); };
-        const jumpTo = (sel) => {
-            const el = document.querySelector(sel);
+        const jumpTo = (target) => {
+            const el = typeof target === "string" ? document.querySelector(target) : target;
             if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
         };
-        // Frame the ENTIRE network (all of Greece), distinct from Home's Athens core.
-        const fitAll = () => {
-            try {
-                const b = L.latLngBounds(stationNodes.map((s) => [s.latitude, s.longitude]));
-                if (b.isValid()) map.fitBounds(b.pad(0.1)); else fitAthensCore();
-            } catch (_) { fitAthensCore(); }
+        const openAriadne = () => {
+            const panel = document.getElementById("ariadnePanel");
+            const launcher = document.getElementById("ariadneLauncher");
+            if (panel && launcher && panel.classList.contains("ariadne-panel--hidden")) launcher.click();
         };
-        const actions = {
-            home() { clearSelection(); fitAthensCore(); panelTop(); },       // reset to the Athens home view
-            explore() { panelTop(); if (stationSearch) stationSearch.focus(); }, // start searching a station
-            map() { clearSelection(); fitAll(); },                           // see the whole network on the map
-            departures() { jumpTo(".departures-card"); },                    // jump to next departures + live trains
-            more() { jumpTo("#infoLinksList"); },                            // jump to useful info / links
+        const faresCard = () => {
+            const list = document.getElementById("faresList");
+            return list ? (list.closest(".panel-card") || list) : null;
         };
-        items.querySelectorAll(".nav-item").forEach((btn) => {
-            btn.addEventListener("click", () => {
-                items.querySelectorAll(".nav-item").forEach((b) => b.classList.remove("nav-item--active"));
-                btn.classList.add("nav-item--active");
-                const run = actions[btn.getAttribute("data-nav")];
-                if (run) run();
-            });
+
+        // Router shape (web-router.js API) with pushState guarded off for now.
+        const URL_ROUTING = false;
+        const base = window.syrmosRouter;
+        let workspace = (base && base.current && base.current().workspace) || "now";
+        const subs = [];
+        const router = {
+            current: () => ({ workspace }),
+            navigate: (state) => {
+                workspace = (state && state.workspace) || "now";
+                if (URL_ROUTING && base) base.navigate(state);
+                subs.forEach((fn) => { try { fn({ workspace }); } catch (_) {} });
+            },
+            subscribe: (fn) => { subs.push(fn); return () => { const i = subs.indexOf(fn); if (i >= 0) subs.splice(i, 1); }; },
+        };
+
+        window.SyrmosNav.wire(nav, router, {
+            now() { clearSelection(); fitAthensCore(); panelTop(); },              // Athens now view
+            plan() { panelTop(); openAriadne(); },                                 // journey planning via Ariadne
+            explore() { panelTop(); if (stationSearch) stationSearch.focus(); },   // search / discover stations
+            departures() { jumpTo(".departures-card"); },                          // next departures + live trains
+            tickets() { const c = faresCard(); if (c) jumpTo(c); },                // OASA fares
+            more() { jumpTo("#infoLinksList"); },                                  // footer utility: useful info
         });
     })();
 

--- a/composeApp/src/wasmJsMain/resources/web-nav.js
+++ b/composeApp/src/wasmJsMain/resources/web-nav.js
@@ -1,0 +1,192 @@
+/* =========================================================================
+ * web-nav.js  ---  Workspace nav-rail controller (Phase 1)
+ *
+ * Turns the left nav rail into a URL-addressable workspace switcher on top of
+ * the Phase 0 router (window.syrmosRouter, see web-router.js). Clicking a
+ * workspace button navigates the router (which updates the URL and history);
+ * the router's emitted state drives the active highlight and an optional
+ * per-workspace "frame" hook (frame the map, scroll the panel, focus search).
+ *
+ * The five workspace roots are Now / Plan / Explore / Departures / Tickets
+ * (DESIGN_SYSTEM.md web amendment v1.2.11). Buttons whose data-nav is NOT a
+ * workspace (e.g. the footer "more") are treated as plain utilities: they run
+ * their hook but never change the workspace or the active highlight.
+ *
+ * This module is deliberately DOM-light and Leaflet-free so it unit-tests
+ * under node with tiny stubs (run `node web-nav.js`), the same pattern as
+ * web-router.js. web-map.js supplies the real map/panel hooks at runtime.
+ * ========================================================================= */
+(function (global) {
+  'use strict';
+
+  var WORKSPACES =
+    (global.SyrmosRouter && global.SyrmosRouter.WORKSPACES) ||
+    ['now', 'plan', 'explore', 'departures', 'tickets'];
+
+  function isWorkspace(id) {
+    return WORKSPACES.indexOf(id) >= 0;
+  }
+
+  /* Pure: which workspace nav item should be active for a router state.
+   * Unknown / missing workspaces fall back to Now, matching the router. */
+  function activeWorkspace(state) {
+    var ws = state && state.workspace;
+    return isWorkspace(ws) ? ws : 'now';
+  }
+
+  /* Wire a nav-rail element to a router.
+   *   navEl  - element containing [data-nav] buttons (workspaces + utilities)
+   *   router - { current(), navigate(state), subscribe(fn) } from web-router.js
+   *   hooks  - { <workspace|utility>: function(state) } run when that id
+   *            becomes active (workspace) or is clicked (utility)
+   * Returns an unsubscribe function. Safe to call with a missing nav/router. */
+  function wire(navEl, router, hooks) {
+    hooks = hooks || {};
+    if (!navEl || !router) return function () {};
+
+    var buttons = navEl.querySelectorAll('[data-nav]');
+
+    function setActive(ws) {
+      for (var i = 0; i < buttons.length; i++) {
+        var btn = buttons[i];
+        // Only workspace buttons carry the active state; utilities never do.
+        var isWs = isWorkspace(btn.getAttribute('data-nav'));
+        var on = isWs && btn.getAttribute('data-nav') === ws;
+        if (btn.classList) btn.classList.toggle('nav-item--active', on);
+        if (btn.setAttribute) btn.setAttribute('aria-current', on ? 'page' : 'false');
+      }
+    }
+
+    function apply(state) {
+      var ws = activeWorkspace(state);
+      setActive(ws);
+      var hook = hooks[ws];
+      if (typeof hook === 'function') {
+        try { hook(state); } catch (e) { /* a hook must not break routing */ }
+      }
+    }
+
+    for (var i = 0; i < buttons.length; i++) {
+      bindClick(buttons[i]);
+    }
+    function bindClick(btn) {
+      btn.addEventListener('click', function () {
+        var id = btn.getAttribute('data-nav');
+        if (isWorkspace(id)) {
+          // Router emits -> apply() sets the highlight and runs the hook, so
+          // there is exactly one code path that updates the UI.
+          router.navigate({ workspace: id });
+        } else if (typeof hooks[id] === 'function') {
+          try { hooks[id](); } catch (e) { /* utility hook is best-effort */ }
+        }
+      });
+    }
+
+    var unsubscribe = router.subscribe(apply);
+    apply(router.current()); // initialise the rail from the current URL
+    return unsubscribe;
+  }
+
+  var api = {
+    WORKSPACES: WORKSPACES,
+    isWorkspace: isWorkspace,
+    activeWorkspace: activeWorkspace,
+    wire: wire,
+  };
+  global.SyrmosNav = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);
+
+/* ------------------------------- self-test -------------------------------- *
+ * Runs only under `node web-nav.js`; the browser never enters this block.
+ * Uses tiny DOM/router stubs so the wiring is verified with no browser. */
+if (typeof require !== 'undefined' && typeof module !== 'undefined' && require.main === module) {
+  var N = module.exports;
+  var assert = require('assert');
+
+  // --- pure activeWorkspace ---
+  assert.strictEqual(N.activeWorkspace({ workspace: 'plan' }), 'plan');
+  assert.strictEqual(N.activeWorkspace({ workspace: 'tickets' }), 'tickets');
+  assert.strictEqual(N.activeWorkspace({ workspace: 'bogus' }), 'now', 'unknown -> now');
+  assert.strictEqual(N.activeWorkspace({}), 'now', 'missing -> now');
+  assert.strictEqual(N.isWorkspace('more'), false, 'more is a utility, not a workspace');
+
+  // --- DOM + router stubs ---
+  function fakeButton(nav) {
+    var classes = {};
+    var attrs = { 'data-nav': nav };
+    var handlers = [];
+    return {
+      _classes: classes,
+      _handlers: handlers,
+      getAttribute: function (k) { return attrs[k]; },
+      setAttribute: function (k, v) { attrs[k] = v; },
+      classList: {
+        toggle: function (c, on) { classes[c] = !!on; },
+        contains: function (c) { return !!classes[c]; },
+      },
+      addEventListener: function (_evt, fn) { handlers.push(fn); },
+      click: function () { handlers.forEach(function (h) { h(); }); },
+    };
+  }
+  function fakeNav(navIds) {
+    var buttons = navIds.map(fakeButton);
+    return {
+      buttons: buttons,
+      querySelectorAll: function () { return buttons; },
+    };
+  }
+  function fakeRouter(initial) {
+    var state = initial;
+    var subs = [];
+    return {
+      _state: function () { return state; },
+      current: function () { return state; },
+      navigate: function (s) { state = s; subs.forEach(function (fn) { fn(state); }); },
+      subscribe: function (fn) { subs.push(fn); return function () {}; },
+    };
+  }
+  function activeIds(nav) {
+    return nav.buttons
+      .filter(function (b) { return b.classList.contains('nav-item--active'); })
+      .map(function (b) { return b.getAttribute('data-nav'); });
+  }
+
+  var nav = fakeNav(['now', 'plan', 'explore', 'departures', 'tickets', 'more']);
+  var router = fakeRouter({ workspace: 'now' });
+  var framed = [];
+  N.wire(nav, router, {
+    now: function () { framed.push('now'); },
+    plan: function () { framed.push('plan'); },
+    explore: function () { framed.push('explore'); },
+    departures: function () { framed.push('departures'); },
+    tickets: function () { framed.push('tickets'); },
+    more: function () { framed.push('more'); },
+  });
+
+  // initialises from the current URL (now)
+  assert.deepStrictEqual(activeIds(nav), ['now'], 'initial active = now');
+  assert.deepStrictEqual(framed, ['now'], 'now hook ran on init');
+
+  // clicking a workspace navigates the router and moves the highlight
+  nav.buttons[1].click(); // plan
+  assert.strictEqual(router._state().workspace, 'plan', 'click navigates router to plan');
+  assert.deepStrictEqual(activeIds(nav), ['plan'], 'plan is the only active item');
+  assert.strictEqual(framed[framed.length - 1], 'plan', 'plan hook ran');
+
+  nav.buttons[4].click(); // tickets
+  assert.strictEqual(router._state().workspace, 'tickets');
+  assert.deepStrictEqual(activeIds(nav), ['tickets']);
+
+  // clicking the "more" utility runs its hook but changes neither URL nor active
+  nav.buttons[5].click(); // more
+  assert.strictEqual(router._state().workspace, 'tickets', 'utility does not change workspace');
+  assert.deepStrictEqual(activeIds(nav), ['tickets'], 'utility does not steal the highlight');
+  assert.strictEqual(framed[framed.length - 1], 'more', 'more utility hook ran');
+
+  // popstate / external router change is reflected in the rail
+  router.navigate({ workspace: 'explore' });
+  assert.deepStrictEqual(activeIds(nav), ['explore'], 'external nav updates the rail');
+
+  console.log('web-nav self-test: OK (' + N.WORKSPACES.length + ' workspaces)');
+}


### PR DESCRIPTION
Builds on the Phase 0 router foundation (#20). Restructures the left nav rail to the five approved workspace roots and wires it through a small, testable controller.

## What changes
- **index.html**: nav roots are now **Now / Plan / Explore / Departures / Tickets**. Map is dropped as a root (it is the canvas); **More** moves to a rail **footer** utility. Adds two stroke icons (`ic-plan`, `ic-tickets`) and includes `web-nav.js`.
- **web-nav.js** (new): `SyrmosNav.wire(navEl, router, hooks)` maps clicks to the router and router state back to the active highlight + a per-workspace frame hook. Workspace buttons carry `nav-item--active` and `aria-current`; footer utilities run their hook without changing the workspace or stealing the highlight. DOM-light, Leaflet-free, with a `node web-nav.js` self-test mirroring `web-router.js`.
- **web-map.js**: `wireNavRail` delegates to `SyrmosNav.wire` with real hooks (Now frames Athens, Plan opens Ariadne, Explore focuses search, Departures/Tickets scroll to their cards, More jumps to info links).
- **web-map.css**: `.nav-rail__footer` pins More to the bottom with a separator.

## Why in-session routing only (URL_ROUTING flag held off)
The live site is **GitHub Pages with no SPA fallback**: I verified `GET /plan` returns **404** (`Page not found · GitHub Pages`). Pushing path URLs like `/plan` would therefore 404 on reload/deep-link, and a `<base href>` would break the inline SVG `<use href="#ic-...">` icons. So the controller drives the same subscribe/active-state machinery and reads the initial workspace from the URL, but a single guarded flag (`URL_ROUTING`, off) holds back `pushState` until the host serves an SPA fallback and the built wasm loader is verified on deep paths. Flipping that one flag activates full URL routing with no other change here.

## Verification
- `node web-nav.js` and `node web-router.js` self-tests pass.
- Static browser harness (linking the real `design-tokens.css` + `web-map.css`, loading `web-router.js` + `web-nav.js`): the five icons render, the footer More sits below a separator, clicking switches the active workspace and runs its hook, and clicking More leaves the workspace and highlight unchanged. `aria-current="page"` tracks exactly the active workspace.

Note: local build of the Compose/Wasm web app is not possible on this host (no JDK), so the full running app is verified by CI's "KMP tests + Web build" job; the DOM wiring and visuals are verified by the node self-test and the static harness above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)