### PR TITLE
Web: deep-linkable workspace URLs via static GitHub Pages entry points

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -13,9 +13,9 @@
     <meta name="theme-color" content="#0072CE">
 
     <!-- Icons + PWA -->
-    <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="apple-touch-icon" href="favicon.png">
-    <link rel="manifest" href="manifest.webmanifest">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="apple-touch-icon" href="/favicon.png">
+    <link rel="manifest" href="/manifest.webmanifest">
     <meta name="application-name" content="Syrmos">
     <meta name="apple-mobile-web-app-title" content="Syrmos">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -114,8 +114,8 @@
         integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
         crossorigin=""
     >
-    <link rel="stylesheet" href="design-tokens.css">
-    <link rel="stylesheet" href="web-map.css">
+    <link rel="stylesheet" href="/design-tokens.css">
+    <link rel="stylesheet" href="/web-map.css">
 </head>
 <body>
 <script>
@@ -128,8 +128,8 @@
     '<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">' +
     '<title>Syrmos - Download the App</title>' +
     '<meta name="theme-color" content="#0072CE">' +
-    '<link rel="icon" type="image/png" href="favicon.png">' +
-    '<link rel="stylesheet" href="design-tokens.css">' +
+    '<link rel="icon" type="image/png" href="/favicon.png">' +
+    '<link rel="stylesheet" href="/design-tokens.css">' +
     '<style>' +
     '*{margin:0;padding:0;box-sizing:border-box}' +
     'body{font-family:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI",sans-serif;' +
@@ -159,7 +159,7 @@
     '.m-footer a{color:var(--sy-brand);text-decoration:none;font-weight:500}' +
     '</style></head><body>' +
     '<div class="m-card">' +
-    '<img class="m-logo" src="favicon.png" alt="Syrmos">' +
+    '<img class="m-logo" src="/favicon.png" alt="Syrmos">' +
     '<div class="m-name">Syrmos</div>' +
     '<div class="m-tagline">Greece Rail Times</div>' +
     '<p class="m-desc">Live departures, offline schedules, and maps for Metro, Tram, Suburban, and Intercity trains across Greece.</p>' +
@@ -208,7 +208,7 @@
 
     <!-- ===== Nav Rail (72px, left) ===== -->
     <nav class="nav-rail" aria-label="Main navigation">
-        <img class="nav-rail__logo" src="favicon.png" alt="Syrmos" width="40" height="40">
+        <img class="nav-rail__logo" src="/favicon.png" alt="Syrmos" width="40" height="40">
         <!-- Five workspace roots (Now / Plan / Explore / Departures / Tickets).
              The map is the canvas, not a nav root; More is a utility pinned to
              the rail footer. web-nav.js wires these to window.syrmosRouter. -->
@@ -460,13 +460,13 @@
 
     <!-- ===== Ariadne Assistant ===== -->
     <button id="ariadneLauncher" class="ariadne-launcher" type="button" aria-label="Ask Ariadne" title="Ask Ariadne">
-        <img class="ariadne-launcher__img" src="ariadne-mark.png" alt="Ask Ariadne" width="40" height="40">
+        <img class="ariadne-launcher__img" src="/ariadne-mark.png" alt="Ask Ariadne" width="40" height="40">
     </button>
 
     <aside id="ariadnePanel" class="ariadne-panel ariadne-panel--hidden" aria-hidden="true">
         <header class="ariadne-panel__head">
             <div class="ariadne-panel__title">
-                <img class="ariadne-panel__lockup" src="ariadne-lockup.png" alt="Ariadne">
+                <img class="ariadne-panel__lockup" src="/ariadne-lockup.png" alt="Ariadne">
             </div>
             <button id="ariadneBrain" class="chrome-button" type="button"
                     aria-label="Smarter answers"
@@ -501,11 +501,11 @@
     crossorigin=""
 ></script>
 <script src="https://cdn.jsdelivr.net/npm/hls.js@1/dist/hls.min.js"></script>
-<script src="web-ariadne-rag.js"></script>
-<script src="web-ariadne.js"></script>
-<script src="llm/ariadne-wllama.js?v=3"></script>
-<script src="web-router.js"></script>
-<script src="web-nav.js"></script>
-<script src="web-map.js"></script>
+<script src="/web-ariadne-rag.js"></script>
+<script src="/web-ariadne.js"></script>
+<script src="/llm/ariadne-wllama.js?v=3"></script>
+<script src="/web-router.js"></script>
+<script src="/web-nav.js"></script>
+<script src="/web-map.js"></script>
 </body>
 </html>

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -525,20 +525,20 @@
     });
 
     const [stations, lines, routes, servicePatterns, vehicleManifest] = await Promise.all([
-        fetch("files/seed/stations.json").then((r) => r.json()),
+        fetch("/files/seed/stations.json").then((r) => r.json()),
         // schedules-v2 is the generator's payload and the single source of truth
         // for lines. The legacy flat seed/lines.json was transcribed from
         // hardcoded Swift by a script broken since June 2026, so it carries
         // neither region nor status. Falls back to it only if the payload cannot
         // be read, so a bad deploy degrades rather than renders an empty map. See
         // docs/plans/2026-07-17-server-as-single-source-for-lines.md.
-        fetch("files/seed/schedules-v2/lines.json")
+        fetch("/files/seed/schedules-v2/lines.json")
             .then((r) => r.json())
             .then((d) => (Array.isArray(d?.lines) && d.lines.length ? d.lines : Promise.reject()))
-            .catch(() => fetch("files/seed/lines.json").then((r) => r.json())),
-        fetch("files/seed/routes.json").then((r) => r.json()),
-        fetch("files/seed/service_patterns.json").then((r) => r.json()),
-        fetch("icons/vehicles/manifest.json").then((r) => r.json()).catch(() => ({ directional_icons: [] })),
+            .catch(() => fetch("/files/seed/lines.json").then((r) => r.json())),
+        fetch("/files/seed/routes.json").then((r) => r.json()),
+        fetch("/files/seed/service_patterns.json").then((r) => r.json()),
+        fetch("/icons/vehicles/manifest.json").then((r) => r.json()).catch(() => ({ directional_icons: [] })),
     ]);
 
     const lineMap = new Map(lines.map((line) => [line.id, line]));
@@ -664,7 +664,7 @@
         for (const [sid, url] of Object.entries(apiIcons.stations)) stationIconBySid.set(sid, url);
         for (const [sid, url] of Object.entries(apiIcons.interchanges || {})) stationIconBySid.set(sid, url);
     }
-    const stationIconManifest = await fetch("icons/stations/manifest.json").then((r) => r.json()).catch(() => ({}));
+    const stationIconManifest = await fetch("/icons/stations/manifest.json").then((r) => r.json()).catch(() => ({}));
     const lineToManifestDir = { M1: "metro/M1", M2: "metro/M2", M3: "metro/M3", T6: "tram/T6", T7: "tram/T7", A1: "train/P1", A2: "train/P1", A3: "train/P3", A4: "train/P2" };
     for (const route of routes) {
         const mDir = lineToManifestDir[route.line_id];
@@ -1039,7 +1039,7 @@
     //   3. Catmull-Rom spline through station coords as last-resort fallback.
     const geoCache = new Map();
     try {
-        const bundled = await fetch("./shapes.json").then((r) => (r.ok ? r.json() : null)).catch(() => null);
+        const bundled = await fetch("/shapes.json").then((r) => (r.ok ? r.json() : null)).catch(() => null);
         if (bundled && bundled.shapes) {
             for (const [lid, shape] of Object.entries(bundled.shapes)) {
                 if (shape && Array.isArray(shape.coordinates) && shape.coordinates.length > 1) {
@@ -1874,7 +1874,7 @@
             ask.className = "search-result search-result--ariadne";
             const owl = document.createElement("img");
             owl.className = "search-result__owl";
-            owl.src = "ariadne-mark.png";
+            owl.src = "/ariadne-mark.png";
             owl.alt = "";
             owl.setAttribute("aria-hidden", "true");
             const txt = document.createElement("div");
@@ -3368,14 +3368,13 @@
     // scrolling context panel for its workspace. The map is the canvas, not a
     // nav root.
     //
-    // In-session routing only, on purpose: the live host (GitHub Pages) has no
-    // SPA fallback, so a path like /plan 404s on reload, and <base href> would
-    // break the inline SVG <use href="#ic-..."> icons. So we drive the same
-    // subscribe/active-state machinery but do NOT push path URLs yet. We still
-    // read the INITIAL workspace from the URL (so a host that later serves deep
-    // links initialises correctly). Flip URL_ROUTING to true once the host
-    // serves an SPA fallback and the built wasm loader is verified on deep
-    // paths; nothing else here needs to change.
+    // Full URL routing. The Pages build emits a static entry point per
+    // workspace (/now/, /plan/, /explore/, /departures/, /tickets/, plus /line/
+    // and /station/), each a copy of this document that returns HTTP 200 and
+    // loads assets by root-absolute path, so deep links and reloads work with
+    // no SPA fallback and no <base href> (which would break the inline SVG
+    // <use href="#ic-..."> icons). See scripts/prepare-pages-web-release.sh and
+    // docs/adr/0001-web-url-model.md.
     (function wireNavRail() {
         const nav = document.querySelector(".nav-rail");
         if (!nav || !window.SyrmosNav) return;
@@ -3395,20 +3394,18 @@
             return list ? (list.closest(".panel-card") || list) : null;
         };
 
-        // Router shape (web-router.js API) with pushState guarded off for now.
-        const URL_ROUTING = false;
-        const base = window.syrmosRouter;
-        let workspace = (base && base.current && base.current().workspace) || "now";
-        const subs = [];
-        const router = {
-            current: () => ({ workspace }),
-            navigate: (state) => {
-                workspace = (state && state.workspace) || "now";
-                if (URL_ROUTING && base) base.navigate(state);
-                subs.forEach((fn) => { try { fn({ workspace }); } catch (_) {} });
-            },
-            subscribe: (fn) => { subs.push(fn); return () => { const i = subs.indexOf(fn); if (i >= 0) subs.splice(i, 1); }; },
-        };
+        // Consume the real URL router (web-router.js). Clicks push the
+        // workspace path; Back/Forward and deep-link loads flow back through
+        // subscribe(). Falls back to an in-session shim if the router is absent.
+        const router = window.syrmosRouter || (function () {
+            let workspace = "now";
+            const subs = [];
+            return {
+                current: () => ({ workspace }),
+                navigate: (state) => { workspace = (state && state.workspace) || "now"; subs.forEach((fn) => { try { fn({ workspace }); } catch (_) {} }); },
+                subscribe: (fn) => { subs.push(fn); return () => { const i = subs.indexOf(fn); if (i >= 0) subs.splice(i, 1); }; },
+            };
+        })();
 
         window.SyrmosNav.wire(nav, router, {
             now() { clearSelection(); fitAthensCore(); panelTop(); },              // Athens now view

--- a/composeApp/src/wasmJsMain/resources/web-router.js
+++ b/composeApp/src/wasmJsMain/resources/web-router.js
@@ -31,16 +31,18 @@
 
   var WORKSPACES = ['now', 'plan', 'explore', 'departures', 'tickets'];
 
-  // Which query keys are meaningful per workspace shape, in canonical order.
+  // Which query keys are meaningful per entry point, in canonical order. Every
+  // dynamic identifier or selection travels as a query parameter so each route
+  // is a single static entry point on GitHub Pages (/plan/, /line/, ...), never
+  // an unbounded path like /line/M3 that would need a directory per line.
   var QUERY_KEYS = {
     now: ['station'],
     plan: ['from', 'to', 'when'],
-    'explore.discover': ['region'],
-    'explore.network': ['region', 'mode'],
-    line: ['direction', 'stop'],
-    station: [],
+    explore: ['view', 'region', 'mode'],
     departures: ['station'],
     tickets: ['from', 'to', 'rider'],
+    line: ['id', 'direction', 'stop'],
+    station: ['id'],
   };
 
   function trimSlashes(p) {
@@ -65,26 +67,24 @@
     var head = (seg[0] || 'now').toLowerCase();
 
     if (head === 'line') {
-      var state = { workspace: 'explore', line: seg[1] || null };
+      var state = { workspace: 'explore', line: q.id || null };
       put(state, 'direction', q.direction);
       put(state, 'stop', q.stop);
       return state;
     }
     if (head === 'station') {
-      return { workspace: 'now', station: seg[1] || null, view: 'station' };
+      return { workspace: 'now', view: 'station', station: q.id || null };
     }
     if (head === 'explore') {
-      var mode = (seg[1] || 'discover').toLowerCase();
-      if (mode !== 'discover' && mode !== 'network') mode = 'discover';
-      var es = { workspace: 'explore', mode: mode };
+      var view = (q.view || 'discover').toLowerCase();
+      if (view !== 'discover' && view !== 'network') view = 'discover';
+      var es = { workspace: 'explore', mode: view };
       put(es, 'region', q.region);
-      if (mode === 'network') put(es, 'netMode', q.mode);
+      if (view === 'network') put(es, 'netMode', q.mode);
       return es;
     }
     if (head === 'plan') {
-      if ((seg[1] || '').toLowerCase() === 'journey' && seg[2]) {
-        return { workspace: 'plan', journey: seg[2] };
-      }
+      if (q.journey) return { workspace: 'plan', journey: q.journey };
       var ps = { workspace: 'plan' };
       put(ps, 'from', q.from); put(ps, 'to', q.to); put(ps, 'when', q.when);
       return ps;
@@ -113,28 +113,30 @@
     var keys;
 
     if (ws === 'explore' && state.line) {
-      path = '/line/' + encodeURIComponent(state.line);
+      path = '/line/';
       keys = QUERY_KEYS.line;
     } else if (ws === 'now' && state.view === 'station' && state.station) {
-      path = '/station/' + encodeURIComponent(state.station);
+      path = '/station/';
       keys = QUERY_KEYS.station;
     } else if (ws === 'plan' && state.journey) {
-      path = '/plan/journey/' + encodeURIComponent(state.journey);
-      keys = [];
-    } else if (ws === 'explore') {
-      var mode = state.mode === 'network' ? 'network' : 'discover';
-      path = '/explore/' + mode;
-      keys = QUERY_KEYS['explore.' + mode];
+      path = '/plan/';
+      keys = ['journey'];
+    } else if (ws === 'now') {
+      path = '/'; // the root document IS the Now workspace
+      keys = QUERY_KEYS.now;
     } else {
-      path = '/' + ws;
+      path = '/' + ws + '/';
       keys = QUERY_KEYS[ws] || [];
     }
 
     var qs = new URLSearchParams();
     keys.forEach(function (k) {
-      // `mode` in the network URL is sourced from state.netMode.
-      var srcKey = (ws === 'explore' && state.mode === 'network' && k === 'mode') ? 'netMode' : k;
-      var v = state[srcKey];
+      var v;
+      if (path === '/line/' && k === 'id') v = state.line;
+      else if (path === '/station/' && k === 'id') v = state.station;
+      else if (ws === 'explore' && k === 'view') v = (state.mode === 'network') ? 'network' : '';
+      else if (ws === 'explore' && k === 'mode') v = state.netMode;
+      else v = state[k];
       if (v !== undefined && v !== null && v !== '') qs.set(k, String(v));
     });
     var query = qs.toString();
@@ -188,36 +190,37 @@ if (typeof require !== 'undefined' && typeof module !== 'undefined' && require.m
   var assert = require('assert');
   var eq = function (a, b, m) { assert.deepStrictEqual(a, b, m); };
 
-  // parse
-  eq(R.parseRoute('/now', '?station=ATH'), { workspace: 'now', station: 'ATH' });
+  // parse: workspaces are directory entry points, dynamic ids are query params
   eq(R.parseRoute('/', ''), { workspace: 'now' });
-  eq(R.parseRoute('/plan', '?from=SYNTAGMA&to=AIRPORT'), { workspace: 'plan', from: 'SYNTAGMA', to: 'AIRPORT' });
-  eq(R.parseRoute('/plan/journey/abc', ''), { workspace: 'plan', journey: 'abc' });
-  eq(R.parseRoute('/explore/network', '?region=athens&mode=metro'), { workspace: 'explore', mode: 'network', region: 'athens', netMode: 'metro' });
-  eq(R.parseRoute('/explore', ''), { workspace: 'explore', mode: 'discover' });
-  eq(R.parseRoute('/line/M3', '?direction=airport&stop=SYN'), { workspace: 'explore', line: 'M3', direction: 'airport', stop: 'SYN' });
-  eq(R.parseRoute('/station/PIRAEUS', ''), { workspace: 'now', station: 'PIRAEUS', view: 'station' });
-  eq(R.parseRoute('/departures', '?station=PIRAEUS'), { workspace: 'departures', station: 'PIRAEUS' });
-  eq(R.parseRoute('/tickets', '?from=SYNTAGMA&to=AIRPORT&rider=adult'), { workspace: 'tickets', from: 'SYNTAGMA', to: 'AIRPORT', rider: 'adult' });
-  // trailing slash + unknown head fall back to Now
   eq(R.parseRoute('/now/', '?station=ATH'), { workspace: 'now', station: 'ATH' });
+  eq(R.parseRoute('/', '?station=ATH'), { workspace: 'now', station: 'ATH' });
+  eq(R.parseRoute('/plan/', '?from=SYNTAGMA&to=AIRPORT'), { workspace: 'plan', from: 'SYNTAGMA', to: 'AIRPORT' });
+  eq(R.parseRoute('/plan/', '?journey=abc'), { workspace: 'plan', journey: 'abc' });
+  eq(R.parseRoute('/explore/', '?view=network&region=athens&mode=metro'), { workspace: 'explore', mode: 'network', region: 'athens', netMode: 'metro' });
+  eq(R.parseRoute('/explore/', ''), { workspace: 'explore', mode: 'discover' });
+  eq(R.parseRoute('/line/', '?id=M3&direction=airport&stop=SYN'), { workspace: 'explore', line: 'M3', direction: 'airport', stop: 'SYN' });
+  eq(R.parseRoute('/station/', '?id=PIRAEUS'), { workspace: 'now', view: 'station', station: 'PIRAEUS' });
+  eq(R.parseRoute('/departures/', '?station=PIRAEUS'), { workspace: 'departures', station: 'PIRAEUS' });
+  eq(R.parseRoute('/tickets/', '?from=SYNTAGMA&to=AIRPORT&rider=adult'), { workspace: 'tickets', from: 'SYNTAGMA', to: 'AIRPORT', rider: 'adult' });
+  // unknown head falls back to Now
   eq(R.parseRoute('/bogus', ''), { workspace: 'now' });
 
   // build (canonical URLs)
-  eq(R.buildRoute({ workspace: 'now', station: 'ATH' }), '/now?station=ATH');
-  eq(R.buildRoute({ workspace: 'now' }), '/now');
-  eq(R.buildRoute({ workspace: 'plan', from: 'SYNTAGMA', to: 'AIRPORT' }), '/plan?from=SYNTAGMA&to=AIRPORT');
-  eq(R.buildRoute({ workspace: 'plan', journey: 'abc' }), '/plan/journey/abc');
-  eq(R.buildRoute({ workspace: 'explore', mode: 'network', region: 'athens', netMode: 'metro' }), '/explore/network?region=athens&mode=metro');
-  eq(R.buildRoute({ workspace: 'explore', line: 'M3', direction: 'airport', stop: 'SYN' }), '/line/M3?direction=airport&stop=SYN');
-  eq(R.buildRoute({ workspace: 'now', view: 'station', station: 'PIRAEUS' }), '/station/PIRAEUS');
-  eq(R.buildRoute({ workspace: 'departures', station: 'PIRAEUS' }), '/departures?station=PIRAEUS');
-  eq(R.buildRoute({ workspace: 'tickets', from: 'SYNTAGMA', to: 'AIRPORT', rider: 'adult' }), '/tickets?from=SYNTAGMA&to=AIRPORT&rider=adult');
-  // unknown workspace falls back to Now
-  eq(R.buildRoute({ workspace: 'zzz' }), '/now');
+  eq(R.buildRoute({ workspace: 'now' }), '/');
+  eq(R.buildRoute({ workspace: 'now', station: 'ATH' }), '/?station=ATH');
+  eq(R.buildRoute({ workspace: 'plan', from: 'SYNTAGMA', to: 'AIRPORT' }), '/plan/?from=SYNTAGMA&to=AIRPORT');
+  eq(R.buildRoute({ workspace: 'plan', journey: 'abc' }), '/plan/?journey=abc');
+  eq(R.buildRoute({ workspace: 'explore', mode: 'network', region: 'athens', netMode: 'metro' }), '/explore/?view=network&region=athens&mode=metro');
+  eq(R.buildRoute({ workspace: 'explore', line: 'M3', direction: 'airport', stop: 'SYN' }), '/line/?id=M3&direction=airport&stop=SYN');
+  eq(R.buildRoute({ workspace: 'now', view: 'station', station: 'PIRAEUS' }), '/station/?id=PIRAEUS');
+  eq(R.buildRoute({ workspace: 'departures', station: 'PIRAEUS' }), '/departures/?station=PIRAEUS');
+  eq(R.buildRoute({ workspace: 'tickets', from: 'SYNTAGMA', to: 'AIRPORT', rider: 'adult' }), '/tickets/?from=SYNTAGMA&to=AIRPORT&rider=adult');
+  // unknown workspace falls back to Now (root)
+  eq(R.buildRoute({ workspace: 'zzz' }), '/');
 
   // round-trip: parse(build(x)) === x for representative states
   [
+    { workspace: 'now' },
     { workspace: 'now', station: 'ATH' },
     { workspace: 'plan', from: 'SYNTAGMA', to: 'AIRPORT' },
     { workspace: 'plan', journey: 'abc' },

--- a/docs/adr/0001-web-url-model.md
+++ b/docs/adr/0001-web-url-model.md
@@ -1,0 +1,87 @@
+# ADR 0001: Web URL model on GitHub Pages
+
+Status: Accepted (2026-08-29)
+Scope: web app (`composeApp/src/wasmJsMain/resources`), GitHub Pages deploy.
+
+## Context
+
+The web redesign introduces five workspace roots (Now, Plan, Explore,
+Departures, Tickets) plus line and station views. These must be deep-linkable:
+a shared URL, a reload, and Back/Forward all have to land on the right
+workspace and selection.
+
+Hard constraints discovered:
+
+- The site is hosted on **GitHub Pages** with a custom domain
+  (`syrmos.peterdsp.dev`). Verified `GET /plan` returns **HTTP 404**
+  (`Page not found - GitHub Pages`): Pages has **no SPA fallback**, so an
+  unknown path is a real 404, not the app.
+- The map page is a **pure static site** (Leaflet + hand-written JS/CSS); there
+  is no Wasm bundle in the served page. So there is no framework router and no
+  Wasm loader path behaviour to work around.
+- Icons are inline SVG referenced with `<use href="#ic-...">` fragments. A
+  `<base href="/">` (the usual way to make relative assets resolve from any
+  path depth) **breaks these fragment refs** in Chrome and Safari, so it is not
+  an option.
+- Runtime data (`/files/seed/*.json`, `/icons/*/manifest.json`, `/shapes.json`)
+  and images were fetched with relative URLs, which only work at the site root.
+
+## Decision
+
+Serve each route as a **static entry-point directory** and carry every dynamic
+identifier as a **query parameter**:
+
+- Workspaces: `/now/`, `/plan/`, `/explore/`, `/departures/`, `/tickets/`
+- Views: `/line/`, `/station/`
+- Dynamic ids and selections in the query string:
+  `/line/?id=M3&direction=airport`, `/station/?id=SYNTAGMA`,
+  `/plan/?from=SYNTAGMA&to=AIRPORT`, `/departures/?station=PIRAEUS`
+- The Now workspace is the site root `/` (its document is the canonical entry).
+
+Implementation:
+
+1. `scripts/prepare-pages-web-release.sh` copies the finished, asset-versioned
+   `index.html` into each route directory and into `404.html`.
+2. All asset references in `index.html` and all runtime fetches/images in
+   `web-map.js` are **root-absolute** (`/web-map.js`, `/files/seed/...`), so
+   every route copy loads the exact same content-hashed assets from the root.
+   SVG `<use href="#ic-...">` fragments are left untouched.
+3. `web-router.js` builds and parses these URLs (workspace directory + query),
+   and `web-nav.js` restores the workspace on load and on Back/Forward.
+4. `404.html` is **recovery only**: it lets a stale or mistyped deep path still
+   boot and route client-side, but because the canonical entry points return
+   200, a custom 404 (which stays an HTTP 404 on Pages) is never the primary
+   routing mechanism. This keeps indexing, link previews and uptime checks
+   honest.
+
+## Alternatives considered
+
+- `<base href="/">` + single index: rejected, breaks the inline SVG icons.
+- Custom `404.html` as the sole SPA fallback: rejected as the primary
+  mechanism, it returns HTTP 404 and weakens indexing, previews and monitoring.
+- Hash routing (`/#/plan`): kept as a **documented fallback** only. If static
+  route generation is proven incompatible after three materially different
+  attempts, switch to hash routing so development is not blocked, record the
+  limitation here, and plan a migration back.
+
+## Consequences
+
+- Deep links, reloads and Back/Forward work with no SPA-fallback dependency.
+- `/<workspace>` without a trailing slash gets a single 301 to `/<workspace>/`
+  from Pages, then 200. Canonical links use the trailing slash.
+- New workspaces require a one-line addition to the route list in the deploy
+  script.
+- Asset paths are absolute, so the app must remain served from the domain root
+  (true for the custom domain).
+
+## Verification
+
+- `node web-router.js` and `node web-nav.js` self-tests pass (parse/build
+  round-trips for every route shape; nav click/restore/utility behaviour).
+- Local simulation of the Pages bundle (the site is pure static, so no JDK is
+  needed): every entry point returns 200, `/plan` returns 301 to `/plan/`, and
+  loading `/plan/` and `/tickets/` boots the full app, loads all assets from the
+  root, restores the workspace and its nav highlight, pushes the path on click,
+  and restores state on Back.
+- Post-deploy: direct-load and reload each workspace URL on the live custom
+  domain and confirm 200 + asset loading. (Run after this change deploys.)

--- a/scripts/prepare-pages-web-release.sh
+++ b/scripts/prepare-pages-web-release.sh
@@ -32,6 +32,27 @@ version_asset "composeApp.js"
 version_asset "web-map.js"
 version_asset "web-map.css"
 
+# --- Static workspace entry points (GitHub Pages has no SPA fallback) ---------
+# Each workspace is a directory whose index.html is a byte-for-byte copy of the
+# finished root document. Because every asset reference in index.html is
+# root-absolute, each copy loads the exact same (content-hashed) assets, and the
+# in-page router (web-router.js) restores the workspace from the path on load.
+# The result is real HTTP 200 deep links, reloads and shareable URLs with no
+# SPA-fallback dependency and no <base href> (which would break the inline SVG
+# <use href="#ic-..."> icons). Dynamic identifiers travel as query parameters
+# (e.g. /line/?id=M3), so every route is a single fixed directory rather than an
+# unbounded path. See docs/adr/0001-web-url-model.md.
+for route in now plan explore departures tickets line station; do
+    mkdir -p "$TARGET_DIR/$route"
+    cp "$TARGET_DIR/index.html" "$TARGET_DIR/$route/index.html"
+done
+
+# 404.html is recovery only. It lets a mistyped or stale deep path still boot
+# the app and route client-side, but the canonical entry points above already
+# return 200, so a custom 404 (which stays an HTTP 404 on GitHub Pages) is never
+# the primary routing mechanism.
+cp "$TARGET_DIR/index.html" "$TARGET_DIR/404.html"
+
 if [[ -f "$ROOT_DIR/docs/press.html" ]]; then
     cp "$ROOT_DIR/docs/press.html" "$TARGET_DIR/press.html"
     mkdir -p "$TARGET_DIR/assets" "$TARGET_DIR/screenshots"


### PR DESCRIPTION
Activates real URL routing for the workspace nav (built in #22) on GitHub Pages, which has **no SPA fallback** (`GET /plan` returns a real 404). Decision recorded in [docs/adr/0001-web-url-model.md](docs/adr/0001-web-url-model.md).

## Model
Each route is a **static entry-point directory** and every dynamic id is a **query parameter**, so each route is one fixed directory, never an unbounded path:
- `/now/` (root), `/plan/`, `/explore/`, `/departures/`, `/tickets/`, `/line/`, `/station/`
- `/line/?id=M3&direction=airport`, `/station/?id=SYNTAGMA`, `/plan/?from=SYNTAGMA&to=AIRPORT`, `/departures/?station=PIRAEUS`

## Why not the obvious alternatives
- `<base href="/">` would make relative assets resolve from any depth **but breaks the inline SVG `<use href="#ic-...">` icons** in Chrome/Safari. Rejected. Assets are made root-absolute instead.
- A custom `404.html` as the *sole* SPA fallback stays an HTTP 404 and weakens indexing/previews/monitoring. Kept as **recovery only**; canonical entry points return 200.
- Hash routing (`/#/plan`) kept as a documented fallback if static generation is ever proven incompatible.

## Changes
- **prepare-pages-web-release.sh**: after asset versioning, copy the finished `index.html` into each route directory and `404.html`.
- **index.html**: all asset refs root-absolute; SVG `<use>` fragments untouched.
- **web-map.js**: runtime fetches/images root-absolute (`/files/seed/...`, `/icons/...`, `/shapes.json`, `/ariadne-mark.png`); nav consumes the real `window.syrmosRouter` (clicks push the path, Back/Forward + deep-link restore).
- **web-router.js**: uniform build/parse for directory+query (`/line/?id=M3`), self-test updated.

## Verification
- `node web-router.js` + `node web-nav.js` self-tests pass.
- Local Pages-bundle simulation (site is pure static, no JDK needed): every entry point returns **200**, `/plan` → **301** `/plan/`, and loading `/plan/` and `/tickets/` **boots the full app**, loads all assets from root, restores the workspace + nav highlight, pushes the path on click, and restores on Back. Screenshot of `/tickets/` deep-load rendering the full map + panel captured during review.
- Live custom-domain curl verification runs after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)