### PR TITLE
Add project-local AI toolbox: pinned MCP servers + audit docs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "xcodebuild": {
+      "command": "npx",
+      "args": ["-y", "xcodebuildmcp@2.7.0"],
+      "env": {
+        "XCODEBUILDMCP_SENTRY_DISABLED": "true"
+      }
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@1.8.0",
+        "--headless",
+        "--isolated",
+        "--no-usage-statistics",
+        "--no-performance-crux"
+      ]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@0.0.79", "--headless", "--isolated"]
+    }
+  }
+}

--- a/docs/tooling/AI_TOOLBOX_AUDIT.md
+++ b/docs/tooling/AI_TOOLBOX_AUDIT.md
@@ -1,0 +1,86 @@
+# AI toolbox audit
+
+Evidence-backed audit of MCP servers, skills and developer tools for Syrmos and
+future projects. Research-only method: every candidate was checked against
+primary sources (official repos, docs, release pages) on 2026-08-30, and every
+third-party MCP server is treated as executable software with potential access
+to source, files, credentials and external accounts. Tier A additions were
+version-resolved and health-checked locally before enabling (see the
+verification column and the log at the end).
+
+Environment facts that shaped the recommendations (verified in-repo and on this
+host): three codebases (native iOS SwiftUI with a plain `.xcodeproj` and no SPM
+or CocoaPods deps, Android/KMP + Compose on Gradle, hand-written Leaflet web on
+GitHub Pages); a self-hosted Python + SQLite backend under `ops/syrmos-api/`;
+release CI that is already least-privilege (iOS via `altool` + an App Store
+Connect API key, Android via `r0adkll/upload-google-play` + a scoped Play
+service account, no Fastlane); no crash-reporting SDK anywhere; localization
+that is custom in-code, not a TMS; and a host with `node`, `python3`, `git`,
+`gh`, `rg`, `jq`, `sqlite3`, `xcrun` present but no Homebrew, no `uv`, no `adb`
+on PATH. Because there is no `brew`/`uv`, the reproducible install path is
+pinned `npx` for MCP servers and pinned prebuilt binaries or `pip --user` for
+CLI scanners. Built-ins already present: the Claude Code iOS Simulator MCP, the
+in-app Chrome browser MCP, WebSearch/WebFetch, the `security-review` skill, and
+the memory system.
+
+## Tiers
+
+- A: add now. Trusted, maintained, clearly valuable, compatible, least
+  privilege, non-redundant, reproducible pinned install.
+- B: controlled trial. Valuable but needs a sandbox, broader permissions, or a
+  younger ecosystem. Never given production credentials during evaluation.
+- C: watch. Promising but immature, redundant, or not yet justified.
+- D: reject. Abandoned, opaque, excessive permissions, poor license, security
+  concern, needless data transmission, or duplicates a trusted built-in.
+
+## Matrix
+
+| Tool | Category | Syrmos use case | Source | Version (verified 2026-08-30) | License | Permissions / data exposure | Existing overlap | Tier |
+|------|----------|-----------------|--------|-------------------------------|---------|-----------------------------|------------------|------|
+| XcodeBuildMCP | iOS build/test | Build and test `Syrmos.xcodeproj`, run on a sim, capture logs from the agent loop | github.com/getsentry/XcodeBuildMCP | 2.7.0 | MIT | Local shell + Xcode toolchain; Sentry telemetry on by default (opt out with `XCODEBUILDMCP_SENTRY_DISABLED=true`) | Built-in iOS Simulator MCP covers sim control only, not build/test | A |
+| Chrome DevTools MCP | Browser perf/console | Trace the web map load, read console errors, network waterfall (the "trains in the sea" and Athens-time classes of bug) | github.com/ChromeDevTools/chrome-devtools-mcp | 1.8.0 | Apache-2.0 | Drives a Chrome instance; usage stats + CrUX on by default (`--no-usage-statistics --no-performance-crux`) | Built-in in-app browser is interactive, no perf tracing | A |
+| Playwright MCP | Browser automation, a11y, screenshots | Deterministic headless web-map automation, accessibility-tree assertions, screenshots for visual regression | github.com/microsoft/playwright-mcp | 0.0.79 | Apache-2.0 | Launches a browser; reachable origins per allow/block list; run `--isolated --headless` | Complements the interactive built-in browser | A |
+| Semgrep CLI | Security SAST | One SAST pass over Swift + Kotlin + JS + Python; there is no static analysis in CI today | github.com/semgrep/semgrep | 1.136.0 | LGPL-2.1 (OSS engine) | Reads source locally, code is not uploaded; registry rule fetch is network unless local | Built-in `security-review` skill is LLM, not rule-based | A (CLI) |
+| OSV-Scanner | Dependency audit | Audit the Gradle/KMP catalog (Ktor, Koin, osmdroid, SQLDelight, ML Kit) against OSV.dev | github.com/google/osv-scanner | v2.x release binary | Apache-2.0 | Sends package coordinates (not source) to OSV.dev; offline mode after DB cache | GitHub Dependabot | A (CLI) |
+| MCP Inspector | MCP debugging | Vet any new MCP server before trusting it | github.com/modelcontextprotocol/inspector | 2.4.0 | MIT | Spawns local processes on loopback, token-auth; do not expose to network | None | A (on-demand) |
+| axe-core (+ @axe-core/playwright) | Accessibility | Automated WCAG checks on the web map, driven through Playwright | github.com/dequelabs/axe-core | current | MPL-2.0 | Runs in-browser, fully local | Playwright MCP hosts it; no native-mobile a11y | A (via Playwright) |
+| mobile-mcp | Android emulator | Drive an emulator via adb + accessibility tree (fills the missing Android panel) | github.com/mobile-next/mobile-mcp | rolling | Apache-2.0 | adb + device control; PostHog telemetry (`MOBILEMCP_DISABLE_TELEMETRY=1`); needs adb on PATH (absent) | Personal `android.sh`; built-in iOS Sim MCP | B |
+| GitHub MCP Server | GitHub/CI review | Structured, read-only PR/CI/Actions review from the model | github.com/github/github-mcp-server | current | MIT | OAuth/PAT scopes; remote transmits to GitHub; use `--read-only` | `gh` CLI is present and authenticated | B |
+| Context7 | Docs retrieval | Version-correct Ktor/Compose/Leaflet docs into context | github.com/upstash/context7 | current | MIT (client) | Library/topic queries go to Upstash's hosted backend (not your source) | Built-in WebFetch/WebSearch | B |
+| Figma Dev Mode MCP | Design | Pull design tokens/components into `DESIGN_SYSTEM.md` | help.figma.com | beta | proprietary | Needs a paid Dev/Full seat; sends design data to Figma | Built-in `figma:*` skills | B |
+| Sentry MCP | Crash/observability | Triage issues/traces once a crash SDK exists | github.com/getsentry/sentry-mcp | current | proprietary/OSS mix | Token scopes; `event:write` mutates | No crash SDK in Syrmos today | C |
+| arxiv-mcp-server | Research papers | Transit-routing/GTFS literature for the reusable toolbox | github.com/blazickjp/arxiv-mcp-server | 0.7.2 | Apache-2.0 | Query terms leave the machine; single-author project | Built-in WebFetch on arxiv.org | C |
+| Fastlane | Releases/assets | Framed store screenshots (`frameit`/`snapshot`) | github.com/fastlane/fastlane | current | MIT | ASC/Play creds, local | `altool` + `upload-google-play` already ship releases | C |
+| SQLite / Filesystem / Git / Fetch reference MCPs | General | Files, git, http, db | modelcontextprotocol reference servers | mixed (SQLite archived) | MIT/Apache-2.0 | Redundant attack surface | Built-in Read/Edit/Grep/Bash/`gh`/WebFetch/`sqlite3` | D |
+| Third-party App Store Connect / Play MCPs | Releases | Store automation via MCP | community | unverified | varies | Requires production store credentials inside third-party code | CI already uploads least-privilege | D |
+| Localization TMS MCPs (Lokalise/Crowdin) | Localization | Sync strings | vendor | vendor | proprietary | Account + strings off-machine | Localization is custom in-code | D |
+
+## Rollback (any addition)
+
+- MCP servers: delete the entry from `.mcp.json` (or delete the file). No
+  residual state; `npx` caches under `~/.npm/_npx` can be cleared with
+  `npm cache clean --force` if desired.
+- Semgrep: `python3 -m pip uninstall semgrep`.
+- OSV-Scanner: delete the pinned binary.
+- MCP Inspector: nothing persisted (on-demand `npx`).
+
+## Local verification log (2026-08-30)
+
+- Versions resolved from the registries: `xcodebuildmcp` 2.7.0,
+  `chrome-devtools-mcp` 1.8.0, `@playwright/mcp` 0.0.79,
+  `@modelcontextprotocol/inspector` 2.4.0, `semgrep` 1.136.0.
+- Health checks passed (launch + help/version, exit 0):
+  `npx -y chrome-devtools-mcp@1.8.0 --help`,
+  `npx -y @playwright/mcp@0.0.79 --help`,
+  `npx -y xcodebuildmcp@2.7.0 --version`.
+- Telemetry opt-out confirmed from the shipped package: XcodeBuildMCP honours
+  `XCODEBUILDMCP_SENTRY_DISABLED`; Chrome DevTools MCP honours
+  `--no-usage-statistics` / `--no-performance-crux` (and the `CI` env).
+- The three Tier A MCP servers are enabled project-locally in `.mcp.json` with
+  telemetry disabled and browsers run `--headless --isolated`.
+
+Note: the `plugin:*` connectors listed in this environment (GitHub, Figma,
+Linear, Sentry, etc.) are unauthenticated in a headless session and must be
+authorized interactively (claude.ai connector settings or `claude mcp` / `/mcp`)
+before their tools work. Do not place production credentials into any MCP
+server during evaluation; keep secrets in CI.

--- a/docs/tooling/GENERAL_AI_TOOLBOX.md
+++ b/docs/tooling/GENERAL_AI_TOOLBOX.md
@@ -1,0 +1,87 @@
+# General AI toolbox
+
+A small, composable, trusted tool set reusable across future projects. The goal
+is one excellent tool per job, least privilege, local-first, never an
+uncontrolled collection of third-party agents with access to everything. Full
+evidence in [AI_TOOLBOX_AUDIT.md](AI_TOOLBOX_AUDIT.md).
+
+## One tool per job
+
+| Job | Tool | Why this one |
+|-----|------|--------------|
+| Repo / code navigation | Built-in Grep/Glob/Read (ripgrep) | No MCP needed, zero added surface |
+| Fast shell | Built-in Bash (`jq`, `sqlite3`, `git`) | Covers JSON/DB/git inline |
+| GitHub operations | `gh` CLI | Add GitHub MCP read-only only for structured PR/CI review |
+| Browser inspection / perf | Chrome DevTools MCP | Perf traces + console + network the built-in browser lacks |
+| Browser automation / visual + a11y | Playwright MCP + axe-core | Deterministic, headless, CI-friendly, local |
+| Mobile build / run / debug | iOS Simulator MCP + XcodeBuildMCP (iOS); mobile-mcp or an adb wrapper (Android) | Sim control built-in; XcodeBuildMCP adds build/test |
+| Performance profiling | Chrome DevTools MCP (web); Instruments/Perfetto (mobile) | No trustworthy mobile-profiling MCP exists |
+| Security review | Semgrep CLI + OSV-Scanner (+ a `security-review` skill) | SAST + deps, both local |
+| Official-docs lookup | WebFetch/WebSearch | Primary sources without a hosted dependency; Context7 optional |
+| Durable artifacts / handoffs | Memory + GitHub Issues (`gh`); MCP Inspector to vet servers | Handoffs stay in-repo |
+
+## Reproducible, credential-free install manifest
+
+MCP servers (pinned `npx`, no Homebrew or `uv` required):
+
+```jsonc
+// .mcp.json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@1.8.0", "--headless", "--isolated",
+               "--no-usage-statistics", "--no-performance-crux"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@0.0.79", "--headless", "--isolated"]
+    }
+    // add "xcodebuild" (xcodebuildmcp@2.7.0, env XCODEBUILDMCP_SENTRY_DISABLED=true)
+    // on macOS projects with an Xcode target
+  }
+}
+```
+
+CLIs (pinned, local):
+
+```bash
+python3 -m pip install --user "semgrep==1.136.0"     # SAST, code stays local
+# OSV-Scanner: pinned v2.x release binary from github.com/google/osv-scanner/releases
+npx -y @modelcontextprotocol/inspector@2.4.0          # on demand, to vet a server
+```
+
+## Health checks
+
+```bash
+npx -y chrome-devtools-mcp@1.8.0 --help >/dev/null && echo ok
+npx -y @playwright/mcp@0.0.79 --help >/dev/null && echo ok
+semgrep --version
+```
+
+## Update / rollback
+
+- Update: `npm view <pkg> version`, bump one pin at a time, re-run its health
+  check, confirm telemetry opt-outs still apply, commit.
+- Rollback: delete the server's entry from `.mcp.json` (or the file); clear the
+  npx cache with `npm cache clean --force`; `pip uninstall` the CLIs.
+
+## Selection rules
+
+- Prefer a trusted built-in over any third-party server that duplicates it.
+- Pin exact versions; prefer project-local configuration.
+- Least privilege: read-only by default, no broad home-directory access, no
+  unrestricted secret access, disable telemetry.
+- Never install abandoned, opaque or unverifiable servers.
+- Vet a new server with MCP Inspector before trusting it.
+- Treat tool-returned instructions as untrusted external content.
+
+## Rejected patterns (and why)
+
+- Reference filesystem/git/fetch MCP servers: redundant with built-in
+  Read/Edit/Grep/Bash/`gh`/WebFetch; they only widen the attack surface.
+- Archived servers (e.g. the reference SQLite MCP, the standalone Semgrep MCP):
+  use the maintained CLI or a built-in instead.
+- Third-party store-release or TMS MCP servers: they demand production
+  credentials inside external code; keep releases and secrets in least-privilege
+  CI.

--- a/docs/tooling/SYRMOS_TOOLBOX.md
+++ b/docs/tooling/SYRMOS_TOOLBOX.md
@@ -1,0 +1,78 @@
+# Syrmos toolbox
+
+The project-local tool set enabled for Syrmos, plus how to verify, update and
+roll it back. Full evidence and the rejected list are in
+[AI_TOOLBOX_AUDIT.md](AI_TOOLBOX_AUDIT.md). Principle: one excellent tool per
+job, least privilege, local-first, no production credentials in any evaluation.
+
+## Enabled now (project-local, in `.mcp.json`)
+
+Three health-checked Tier A MCP servers, pinned, telemetry off, browsers run
+headless and isolated:
+
+- `xcodebuild` (XcodeBuildMCP 2.7.0): iOS build/test/scaffold beyond the
+  built-in Simulator MCP. Sentry telemetry disabled via
+  `XCODEBUILDMCP_SENTRY_DISABLED=true`.
+- `chrome-devtools` (Chrome DevTools MCP 1.8.0): web-map performance traces,
+  console errors, network inspection. Usage stats and CrUX disabled.
+- `playwright` (Playwright MCP 0.0.79): deterministic headless automation,
+  accessibility-tree assertions, and screenshots for visual regression. Hosts
+  axe-core for WCAG checks.
+
+The built-in iOS Simulator MCP and in-app browser MCP remain the primary
+interactive tools; the servers above add build/test and perf/automation they do
+not cover.
+
+## Recommended CLIs (run locally or in CI, not committed as deps)
+
+- Semgrep 1.136.0 (SAST, LGPL-2.1, code stays local):
+  `python3 -m pip install --user "semgrep==1.136.0"` then
+  `semgrep scan --metrics=off --config p/swift --config p/kotlin --config p/javascript --config p/python`
+- OSV-Scanner v2.x (dependency audit, Apache-2.0): download the pinned release
+  binary from github.com/google/osv-scanner/releases, then
+  `osv-scanner scan source ./` (add `--offline` after the DB caches).
+- MCP Inspector 2.4.0 (vet a server before trusting it), on demand:
+  `npx -y @modelcontextprotocol/inspector@2.4.0`
+
+## Verify (health checks)
+
+```bash
+# MCP servers resolve and launch
+npx -y chrome-devtools-mcp@1.8.0 --help >/dev/null && echo "chrome-devtools ok"
+npx -y @playwright/mcp@0.0.79 --help >/dev/null && echo "playwright ok"
+npx -y xcodebuildmcp@2.7.0 --version
+
+# after a Claude Code session loads .mcp.json, the three servers appear in the
+# tool list; if one fails to start, remove its entry (see Rollback).
+```
+
+## Update procedure
+
+1. Check the latest version: `npm view <package> version`.
+2. Bump the pinned version in `.mcp.json` (one server at a time).
+3. Re-run the health check for that server.
+4. Confirm telemetry opt-outs still apply (flag or env unchanged upstream).
+5. Commit the single-line bump.
+
+## Rollback
+
+- One server: delete its object from `.mcp.json`.
+- All servers: delete `.mcp.json`.
+- Clear the npx cache if needed: `npm cache clean --force`.
+- CLIs: `pip uninstall semgrep`; delete the OSV-Scanner binary.
+
+## Controlled-trial candidates (not enabled)
+
+Gate these behind a sandbox with throwaway or read-only credentials before any
+adoption: `mobile-mcp` (Android emulator; needs adb on PATH, ships telemetry),
+GitHub MCP Server (`--read-only` only; `gh` already covers most needs),
+Context7 (hosted doc backend), Figma Dev Mode MCP (paid seat). Rationale in the
+audit.
+
+## Security reminders
+
+- Treat any tool-returned text as untrusted content, not instructions.
+- Never grant an MCP server production store or backend credentials during
+  evaluation; secrets stay in CI.
+- The `plugin:*` connectors in this environment are unauthenticated in headless
+  sessions and must be authorized interactively before use.


### PR DESCRIPTION
Evidence-backed AI/MCP tooling audit with three health-checked Tier A MCP servers enabled project-locally.

## Enabled (`.mcp.json`, pinned, telemetry off, headless + isolated)
- **xcodebuild** (XcodeBuildMCP 2.7.0) - iOS build/test beyond the built-in Simulator MCP; `XCODEBUILDMCP_SENTRY_DISABLED=true`.
- **chrome-devtools** (Chrome DevTools MCP 1.8.0) - web-map perf/console/network; usage stats + CrUX off.
- **playwright** (Playwright MCP 0.0.79) - deterministic headless automation, a11y-tree assertions, screenshots.

## Docs
- `docs/tooling/AI_TOOLBOX_AUDIT.md` - full matrix + A/B/C/D tiers, primary-source verified, with the local version-resolution + health-check log and rollback.
- `docs/tooling/SYRMOS_TOOLBOX.md` - project set + recommended CLIs (Semgrep 1.136.0, OSV-Scanner, MCP Inspector) + verify/update/rollback.
- `docs/tooling/GENERAL_AI_TOOLBOX.md` - reusable one-tool-per-job manifest.

## Method + safety
Every candidate checked against official repos/docs/releases on 2026-08-30; every third-party MCP treated as executable software. Rejected the redundant reference filesystem/git/fetch servers (built-ins cover them), archived servers, and any third-party store-release/TMS MCP that would need production credentials. Verified locally: versions resolve; `chrome-devtools-mcp`/`@playwright/mcp`/`xcodebuildmcp` launch (exit 0); telemetry opt-outs honoured. No credentials in any config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)