### PR TITLE
Fix Saturday 24h service vanishing from the map after midnight

### DIFF
--- a/ops/syrmos-api/syrmos_admin/projector.py
+++ b/ops/syrmos-api/syrmos_admin/projector.py
@@ -849,8 +849,16 @@ def active_trains(
         yesterday_weekday = 7 if weekday == 1 else weekday - 1
         yesterday_dt = _day_type(yesterday_weekday, None)
         descriptors.append((yesterday_dt, -24 * 60, False))
+        # Overnight continuation: yesterday's early-morning (< 05:00) bands
+        # projected at TODAY's clock. This is how Saturday-night 24h service
+        # (M2/M3/T6/T7) that runs past midnight into Sunday shows as active
+        # trains on the map. Mirrors _project_line's next-day extension so the
+        # map and the departures list agree; without it active_trains went dark
+        # after midnight even though weekend all-night trains were running.
+        if now_minutes < 6 * 60 and yesterday_dt != today_dt:
+            descriptors.append((yesterday_dt, 0, True))
 
-        for dt, shift, _next_day_only in descriptors:
+        for dt, shift, next_day_only in descriptors:
             rule = next((r for r in bundle["rules"] if r["dayType"] == dt), None)
             if rule is None:
                 continue
@@ -886,8 +894,12 @@ def active_trains(
                     effective_now = now_minutes - shift
                     # 2-hour slack on either side so a train that departed
                     # right before service open or right after close is still
-                    # found when interpolating its tail end.
-                    if effective_now < open_min - 120 or effective_now > effective_close + 120:
+                    # found when interpolating its tail end. The next-day
+                    # extension descriptor deliberately runs BEFORE the day's
+                    # open time (it is the overnight tail), so skip the lower
+                    # bound for it and only reject bands fully past close.
+                    too_early = (not next_day_only) and effective_now < open_min - 120
+                    if too_early or effective_now > effective_close + 120:
                         continue
 
             open_min_rule_at = _minutes_of_day(rule["openTime"]) if rule else None
@@ -895,8 +907,13 @@ def active_trains(
             for b in bundle["bands"]:
                 if b["dayType"] != dt:
                     continue
-                if shift == 0 and rule is not None and not rule["is247"]:
-                    rs = _minutes_of_day(b["timeStart"])
+                rs = _minutes_of_day(b["timeStart"])
+                if next_day_only:
+                    # Only the overnight-extension bands (before ~05:00) belong
+                    # to the next civil day; skip everything else.
+                    if rs is None or rs >= NEXT_DAY_EXTENSION_CUTOFF_MIN:
+                        continue
+                elif shift == 0 and rule is not None and not rule["is247"]:
                     if (rs is not None and open_min_rule_at is not None
                             and rs < open_min_rule_at
                             and rs < NEXT_DAY_EXTENSION_CUTOFF_MIN):

--- a/ops/syrmos-api/tests/test_projector.py
+++ b/ops/syrmos-api/tests/test_projector.py
@@ -2,7 +2,7 @@ import sqlite3
 import unittest
 from datetime import datetime
 
-from syrmos_admin.projector import ATHENS, project_next_departures
+from syrmos_admin.projector import ATHENS, active_trains, project_next_departures
 
 
 def make_conn() -> sqlite3.Connection:
@@ -139,6 +139,143 @@ class ProjectorTest(unittest.TestCase):
         self.assertEqual(rows[0]["serviceType"], "airport")
         self.assertEqual(rows[0]["time"], "05:54")
         self.assertEqual(rows[0]["minutesAway"], 14)
+
+
+def make_overnight_conn() -> sqlite3.Connection:
+    """Fixture that mirrors the official Saturday overnight truth: M2 / M3
+    (city) / T6 / T7 run 24h, so their Saturday service continues past midnight
+    into Sunday. M1 is NOT 24h (last train ~01:00). The M3 airport branch is
+    excluded from the 24h service, so M3_AIR has no overnight band."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE lines (id TEXT PRIMARY KEY, terminal_a TEXT NOT NULL, terminal_b TEXT NOT NULL);
+        CREATE TABLE schedule_rules (line_id TEXT, day_type TEXT, open_time TEXT, close_time TEXT, is_24_7 INTEGER DEFAULT 0);
+        CREATE TABLE frequency_bands (line_id TEXT, day_type TEXT, time_start TEXT, time_end TEXT, headway_minutes REAL, label TEXT, direction TEXT DEFAULT 'both');
+        CREATE TABLE station_offsets (line_id TEXT, direction TEXT, station_id TEXT, minutes_from_origin INTEGER);
+        """
+    )
+    conn.executemany(
+        "INSERT INTO lines(id, terminal_a, terminal_b) VALUES (?,?,?)",
+        [("M2", "Anthoupoli", "Elliniko"), ("M3", "Dimotiko Theatro", "Airport"),
+         ("T6", "Syntagma", "Pikrodafni"), ("T7", "Syntagma", "SEF"), ("M1", "Piraeus", "Kifisia")],
+    )
+    conn.executemany(
+        "INSERT INTO schedule_rules(line_id, day_type, open_time, close_time, is_24_7) VALUES (?,?,?,?,?)",
+        [
+            ("M2", "sat", "05:30", "05:28", 0), ("M2", "sun", "05:30", "00:30", 0),
+            ("M3", "sat", "05:30", "05:28", 0), ("M3", "sun", "05:30", "00:30", 0),
+            ("M3_AIR", "sat", "05:30", "00:30", 0), ("M3_AIR", "sun", "05:30", "23:00", 0),
+            ("T6", "sat", "05:30", "05:28", 0), ("T6", "sun", "05:30", "01:00", 0),
+            ("T7", "sat", "05:30", "05:28", 0),
+            ("M1", "sat", "05:00", "01:00", 0),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO frequency_bands(line_id, day_type, time_start, time_end, headway_minutes, label) VALUES (?,?,?,?,?,?)",
+        [
+            # 24h Saturday service as three continuous bands: overnight tail
+            # (00:xx -> 05:30, flows into Sunday), daytime, and the evening wrap
+            # (22:00 -> 00:20 next day). Together they cover a full 24 hours.
+            ("M2", "sat", "00:20", "05:30", 15.0, "sat_24mmm"),
+            ("M2", "sat", "05:30", "22:00", 10.0, "saturday_day"),
+            ("M2", "sat", "22:00", "00:20", 12.0, "sat_24mmm"),
+            ("M2", "sun", "05:30", "00:30", 12.5, "sunday_all_day"),
+            ("M3", "sat", "00:20", "05:30", 15.0, "sat_24mmm"),
+            ("M3", "sat", "05:30", "22:00", 9.0, "saturday_day"),
+            ("M3", "sat", "22:00", "00:20", 10.0, "sat_24mmm"),
+            ("T6", "sat", "00:30", "05:30", 25.0, "sat_24mmm"),
+            ("T6", "sat", "05:30", "22:00", 12.0, "saturday_day"),
+            ("T6", "sat", "22:00", "00:30", 15.0, "sat_24mmm"),
+            ("T7", "sat", "00:30", "05:30", 25.0, "sat_24mmm"),
+            ("T7", "sat", "05:30", "22:00", 12.0, "saturday_day"),
+            ("T7", "sat", "22:00", "00:30", 15.0, "sat_24mmm"),
+            # Airport branch is NOT 24h: last overnight run ends 00:30, nothing after.
+            ("M3_AIR", "sat", "22:00", "00:30", 36.0, "airport"),
+            # M1 is NOT 24h: last saturday_late train ~01:00, nothing overnight.
+            ("M1", "sat", "23:30", "01:00", 15.0, "saturday_late"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO station_offsets(line_id, direction, station_id, minutes_from_origin) VALUES (?,?,?,?)",
+        [
+            ("M2", "outbound", "M2_END", 40), ("M2", "inbound", "M2_END", 40),
+            ("M3", "outbound", "M3_END", 33), ("M3", "inbound", "M3_END", 33),
+            ("M3_AIR", "outbound", "M3_END", 55), ("M3_AIR", "inbound", "M3_END", 55),
+            ("T6", "outbound", "T6_END", 45), ("T6", "inbound", "T6_END", 45),
+            ("T7", "outbound", "T7_END", 30), ("T7", "inbound", "T7_END", 30),
+            ("M1", "outbound", "M1_END", 44), ("M1", "inbound", "M1_END", 44),
+        ],
+    )
+    return conn
+
+
+class ActiveTrainsOvernightTest(unittest.TestCase):
+    """Saturday 24h service (M2/M3/T6/T7) must stay visible on the map after
+    midnight into Sunday; M1 and the M3 airport branch must not."""
+
+    def _lines(self, now):
+        conn = make_overnight_conn()
+        trains = active_trains(conn, ["M1", "M2", "M3", "M3_AIR", "T6", "T7"], now=now)
+        return trains, {t["lineId"] for t in trains}
+
+    def test_saturday_2359_all_night_lines_running(self):
+        trains, lines = self._lines(datetime(2026, 8, 29, 23, 59, tzinfo=ATHENS))
+        for lid in ("M2", "M3", "T6", "T7"):
+            self.assertIn(lid, lines, f"{lid} should run at Sat 23:59")
+
+    def test_sunday_0001_continues_saturday_service(self):
+        # 00:01 Sunday belongs to the Saturday operating day.
+        trains, lines = self._lines(datetime(2026, 8, 30, 0, 1, tzinfo=ATHENS))
+        for lid in ("M2", "M3", "T6", "T7"):
+            self.assertIn(lid, lines, f"{lid} should still run at Sun 00:01")
+
+    def test_sunday_0153_regression_map_not_empty(self):
+        # The exact defect: 01:53 Sunday returned zero metro/tram vehicles.
+        trains, lines = self._lines(datetime(2026, 8, 30, 1, 53, tzinfo=ATHENS))
+        self.assertTrue(trains, "map must not be empty at Sun 01:53")
+        for lid in ("M2", "M3", "T6", "T7"):
+            self.assertIn(lid, lines, f"{lid} 24h service must show at Sun 01:53")
+        # Route identity + direction + provenance, not just a count.
+        m2 = [t for t in trains if t["lineId"] == "M2"]
+        self.assertTrue(m2)
+        self.assertIn(m2[0]["directionKey"], {"outbound", "inbound"})
+        self.assertIn(m2[0]["serviceType"], {"regular", "late_night"})
+        self.assertIn("originDepartureMinute", m2[0])
+        self.assertIn("totalTravelMinutes", m2[0])
+
+    def test_sunday_0153_m1_not_24h(self):
+        # M1 is not 24h: its last saturday_late train (~01:00) has finished by 01:53.
+        _trains, lines = self._lines(datetime(2026, 8, 30, 1, 53, tzinfo=ATHENS))
+        self.assertNotIn("M1", lines, "M1 must not be treated as 24h")
+
+    def test_sunday_0153_airport_branch_excluded(self):
+        # M3 city runs 24h but the airport branch does not.
+        trains, _lines = self._lines(datetime(2026, 8, 30, 1, 53, tzinfo=ATHENS))
+        airport = [t for t in trains if t["serviceType"] == "airport"]
+        self.assertEqual(airport, [], "airport branch must not run overnight")
+
+    def test_sunday_0459_last_overnight_window(self):
+        _trains, lines = self._lines(datetime(2026, 8, 30, 4, 59, tzinfo=ATHENS))
+        for lid in ("M2", "M3", "T6", "T7"):
+            self.assertIn(lid, lines, f"{lid} should still run at Sun 04:59")
+
+    def test_sunday_0530_daytime_service_starts(self):
+        _trains, lines = self._lines(datetime(2026, 8, 30, 5, 30, tzinfo=ATHENS))
+        self.assertIn("M2", lines)
+
+    def test_missing_timetable_data_is_safe(self):
+        # A line with no rules/bands must not crash and must contribute nothing.
+        conn = make_overnight_conn()
+        trains = active_trains(conn, ["ZZ_UNKNOWN"], now=datetime(2026, 8, 30, 1, 53, tzinfo=ATHENS))
+        self.assertEqual(trains, [])
+
+    def test_dst_spring_forward_boundary(self):
+        # Last Sunday of March 2026 (29th), 03:xx local: zoneinfo handles the
+        # skipped hour; the projector must not raise.
+        trains, _lines = self._lines(datetime(2026, 3, 29, 3, 30, tzinfo=ATHENS))
+        self.assertIsInstance(trains, list)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Defect
At 01:53 on a Sunday the live-vehicle map showed **zero** metro/tram trains, even though Athens **M2, M3 (city), T6, T7 run 24h every Saturday** (official OASA/STASY), so 01:53 Sunday is still Saturday-night service.

## Root cause (logic, not data)
`project_next_departures` already handles after-midnight via a next-day-extension descriptor (yesterday's early bands projected at today's clock). But `active_trains` (the layer feeding the map) never mirrored it, it only looked at today's bands + yesterday shifted -24h, so a Saturday overnight band (00:20→05:30) mapped entirely into the past and produced 0 trains.

## Fix
`active_trains` gets the same overnight-continuation descriptor, with the lower service-window bound skipped for it (it deliberately runs before open) and the band filter restricted to the overnight extension. Pure map-layer catch-up; **no data changes**.

## Tests (new `ActiveTrainsOvernightTest`, 9 cases, all green)
Sat 23:59; Sun 00:01 as Saturday continuation; **Sun 01:53 (the defect)**; 04:59; 05:30; **M1 NOT 24h** (last ~01:00 finished by 01:53); **M3 airport branch excluded** overnight; missing timetable data; DST boundary. Assertions verify line identity, direction, service type and interpolation fields, not just counts. Verified locally: was 0, now shows M2/M3/T6/T7.

## Follow-ups (tracked)
- The seed's real M3/T6 Saturday overnight bands are truncated (M3→02:00, T6→01:40) vs 24h; completing them is a 24mmm-scraper/re-seed task on the Pi.
- Deploying this projector change and re-seeding run on the Pi (not reachable from CI); idempotent re-seed to follow.
- Parked/yard suburban vehicles need an honest status distinction on the map (separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)