### PR TITLE
Project suburban A1-A4 on the map offline (+ fix inbound trip ordering) on all clients

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -3197,14 +3197,44 @@
     // the clock lands in and interpolate along the line's track. This is the "else
     // interpolate from the timetable" path; if the Pi ever serves their live
     // positions it flows through connectLiveTrainStream and wins per line.
+    // Pair each stop with its minute-of-day in CHRONOLOGICAL order. The seed
+    // stores stops in canonical (outbound) stop_sequence order, so an INBOUND
+    // trip's departureTimes run high->low and a naive monotonic check would drop
+    // it. Sort by time; and if the whole trip spans > 12h it genuinely crosses
+    // midnight, so early-morning stops (< 05:00) belong to the next day (+24h).
+    // Mirrors the Pi projector._project_scheduled_trip_active. Returns null if
+    // any time is unparseable.
+    function chronologicalStops(stops) {
+        const arr = stops.map((s) => ({ s, m: minutesOfDay(s.departureTime) }));
+        if (arr.some((x) => x.m == null)) return null;
+        const mins = arr.map((x) => x.m);
+        if (Math.max(...mins) - Math.min(...mins) > 12 * 60) {
+            for (const x of arr) if (x.m < 5 * 60) x.m += 24 * 60;
+        }
+        arr.sort((a, b) => a.m - b.m);
+        return arr;
+    }
+
     function projectScheduledTrains() {
         if (!apiSchedules || apiSchedules.size === 0) return [];
         const out = [];
         const now = athensNow();
         const today = dayTypeFor(now, resolveHolidayDayType(now));
         const nowMin = now.getHours() * 60 + now.getMinutes() + now.getSeconds() / 60;
+        const snapshotHasLine = (id) =>
+            !!(livePositionsSnapshot && livePositionsSnapshot.trains &&
+               livePositionsSnapshot.trains.some((t) => t.lineId === id));
         for (const line of lines) {
-            if (LIVE_POSITION_LINES.has(line.id)) continue;          // handled above
+            if (LIVE_POSITION_LINES.has(line.id)) {
+                // Metro/tram (M1/M2/M3/M3_AIR/T6/T7) are always drawn by
+                // simulateAllTrains (online feed OR offline band projection).
+                // Suburban A1-A4 are drawn there too WHEN the live snapshot
+                // carries them (online); OFFLINE the snapshot lacks them, so
+                // project A1-A4 from the bundled trips here so they still appear
+                // with zero network. Gated on snapshot coverage to never double-draw.
+                const suburban = line.id === "A1" || line.id === "A2" || line.id === "A3" || line.id === "A4";
+                if (!suburban || snapshotHasLine(line.id)) continue;
+            }
             if ((line.status || "operational") === "under_construction") continue;
             const bundle = apiSchedules.get(line.id);
             if (!bundle || !Array.isArray(bundle.trips)) continue;
@@ -3222,24 +3252,27 @@
                 }
                 const stops = trip.stops;
                 if (!Array.isArray(stops) || stops.length < 2) continue;
-                const times = stops.map((s) => minutesOfDay(s.departureTime));
-                if (times.some((t) => t == null)) continue;
-                // Skip trips that wrap past midnight (non-monotonic) - rare on these lines.
-                let monotonic = true;
-                for (let i = 1; i < times.length; i++) if (times[i] < times[i - 1]) { monotonic = false; break; }
-                if (!monotonic) continue;
-                if (nowMin < times[0] || nowMin > times[times.length - 1]) continue;
+                const chrono = chronologicalStops(stops);
+                if (!chrono || chrono.length < 2) continue;
+                const first = chrono[0].m;
+                const last = chrono[chrono.length - 1].m;
+                // A midnight-crossing trip's window can sit in the 24-30h range
+                // while the wall clock is small (e.g. 00:20); shift now forward a
+                // day to test membership.
+                let nm = nowMin;
+                if (nm < first && nm + 24 * 60 <= last) nm += 24 * 60;
+                if (nm < first || nm > last) continue;
                 let seg = 0;
-                for (let i = 0; i < stops.length - 1; i++) {
-                    if (times[i] <= nowMin && nowMin < times[i + 1]) { seg = i; break; }
+                for (let i = 0; i < chrono.length - 1; i++) {
+                    if (chrono[i].m <= nm && nm < chrono[i + 1].m) { seg = i; break; }
                 }
-                const from = stationMap.get(stops[seg].stationId);
-                const to = stationMap.get(stops[seg + 1].stationId);
+                const from = stationMap.get(chrono[seg].s.stationId);
+                const to = stationMap.get(chrono[seg + 1].s.stationId);
                 if (!from || !to) continue;
-                const dur = times[seg + 1] - times[seg];
-                const frac = dur > 0 ? stationAwareEase(Math.min(Math.max((nowMin - times[seg]) / dur, 0), 1)) : 0;
+                const dur = chrono[seg + 1].m - chrono[seg].m;
+                const frac = dur > 0 ? stationAwareEase(Math.min(Math.max((nm - chrono[seg].m) / dur, 0), 1)) : 0;
                 const [lat, lng] = trainPosition(line.id, from, to, frac);
-                const dest = stationMap.get(stops[stops.length - 1].stationId);
+                const dest = stationMap.get(chrono[chrono.length - 1].s.stationId);
                 out.push({
                     id: `${line.id}_${trip.trainNo || seg}_${trip.direction || ""}`,
                     line,

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/TrainSimulator.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/TrainSimulator.kt
@@ -137,9 +137,13 @@ fun simulateTrains(
 }
 
 
-/// Metro/tram/M3_AIR/suburban-A1-A4 come from the offsets-based [simulateTrains].
-private val LIVE_POSITION_LINES =
-    setOf("M1", "M2", "M3", "M3_AIR", "T6", "T7", "A1", "A2", "A3", "A4")
+/// Metro/tram + M3_AIR come from the offsets-based [simulateTrains] (band grid,
+/// online OR offline); they carry no trips[] and are never trip-projected here.
+/// Athens suburban A1-A4 ARE trip-projected here (from bundled trips) so they
+/// still appear on the map offline; online the MapViewModel dedupes them per
+/// line against the real-GPS liveTrains feed, so there is never a double marker.
+private val BAND_PROJECTED_LINES =
+    setOf("M1", "M2", "M3", "M3_AIR", "T6", "T7")
 
 /// Project moving vehicles for NATIONAL rail + rail-replacement BUS lines, which
 /// have no live-position feed and no station-offsets on the Pi. For every trip
@@ -167,31 +171,42 @@ fun projectScheduledTrains(
         geometry.mapValues { (_, poly) -> poly to VehicleInterpolation.buildDistanceTable(poly) }
 
     for (line in lineById.values) {
-        if (line.id in LIVE_POSITION_LINES) continue
+        if (line.id in BAND_PROJECTED_LINES) continue
         val bundle = bundles[line.id] ?: continue
         for (trip in bundle.trips) {
             // dayType is authoritative; an empty dayType runs every day.
             val td = trip.dayType.lowercase()
             if (td.isNotEmpty() && td != today) continue
-            val stops = trip.stops
-            if (stops.size < 2) continue
-            val times = stops.map { toMinutesOfDay(it.departureTime) }
-            if (times.any { it == null }) continue
-            val t = times.map { it!! }
-            // Skip trips that wrap past midnight (non-monotonic) - rare on these lines.
-            var monotonic = true
-            for (i in 1 until t.size) if (t[i] < t[i - 1]) { monotonic = false; break }
-            if (!monotonic) continue
-            if (nowMinutes < t.first() || nowMinutes > t.last()) continue
+            val rawStops = trip.stops
+            if (rawStops.size < 2) continue
+            // Chronological stop order. The seed stores stops in canonical
+            // (outbound) stop_sequence order, so INBOUND trips run time-descending
+            // and a naive monotonic check silently drops them. If the trip spans
+            // > 12h it genuinely crosses midnight, so pre-05:00 stops belong to the
+            // next day (+24h); then sort by time. Mirrors the Pi
+            // scheduled_trip_active and the web chronologicalStops.
+            val paired0 = rawStops.map { it to toMinutesOfDay(it.departureTime) }
+            if (paired0.any { it.second == null }) continue
+            var paired = paired0.map { it.first to it.second!! }
+            if (paired.maxOf { it.second } - paired.minOf { it.second } > 12 * 60) {
+                paired = paired.map { if (it.second < 5 * 60) it.first to (it.second + 1440) else it }
+            }
+            paired = paired.sortedBy { it.second }
+            val stops = paired.map { it.first }
+            val t = paired.map { it.second }
+            // Membership: try today's clock, and now+1440 for an after-midnight leg.
+            var nm = nowMinutes
+            if (nm < t.first() && nm + 1440 <= t.last()) nm += 1440.0
+            if (nm < t.first() || nm > t.last()) continue
 
             var seg = 0
             for (i in 0 until stops.size - 1) {
-                if (t[i] <= nowMinutes && nowMinutes < t[i + 1]) { seg = i; break }
+                if (t[i] <= nm && nm < t[i + 1]) { seg = i; break }
             }
             val from = stationById[stops[seg].stationId] ?: continue
             val to = stationById[stops[seg + 1].stationId] ?: continue
             val dur = (t[seg + 1] - t[seg]).toDouble()
-            val linearFrac = if (dur > 0) ((nowMinutes - t[seg]) / dur).coerceIn(0.0, 1.0) else 0.0
+            val linearFrac = if (dur > 0) ((nm - t[seg]) / dur).coerceIn(0.0, 1.0) else 0.0
             val frac = stationAwareEase(linearFrac)
             val pos = geoTables[line.id]?.takeIf { it.first.size >= 2 }?.let { (poly, table) ->
                 VehicleInterpolation.positionBetween(

--- a/iosApp/iosApp/Core/Schedule/NationalVehicleProjector.swift
+++ b/iosApp/iosApp/Core/Schedule/NationalVehicleProjector.swift
@@ -25,11 +25,14 @@ import CoreLocation
 final class NationalVehicleProjector: @unchecked Sendable {
     static let shared = NationalVehicleProjector()
 
-    /// Lines already served by the live feed / offsets projector. These are
-    /// projected by `TrainSimulatorService.projectTrains` and must not be
-    /// double-projected here.
+    /// Metro/tram lines projected from the band grid + offsets by
+    /// `TrainSimulatorService.projectTrains`; they carry no `trips[]` and must
+    /// never be trip-projected here. Athens suburban A1-A4 ARE projected here
+    /// now (from their bundled trips) so they still appear on the map offline;
+    /// online the map dedupes them per line against the real-GPS LiveTrainService
+    /// feed (MapView `coveredLines`), so there is never a double marker.
     private static let liveFeedLineIds: Set<String> = [
-        "M1", "M2", "M3", "M3_AIR", "T6", "T7", "A1", "A2", "A3", "A4",
+        "M1", "M2", "M3", "M3_AIR", "T6", "T7",
     ]
 
     private struct Trip: Decodable {
@@ -105,19 +108,26 @@ final class NationalVehicleProjector: @unchecked Sendable {
     }
 
     private func projectTrip(_ trip: Trip, line: TransitLine, nowMinutes: Int, nowEpoch: TimeInterval) -> SimulatedTrain? {
-        let stops = trip.stops.sorted { $0.stopSequence < $1.stopSequence }
-        guard stops.count >= 2 else { return nil }
+        guard trip.stops.count >= 2 else { return nil }
 
-        // Absolute minute of each stop, unwrapped past midnight so a train that
-        // departs 23:50 and arrives 01:10 has monotonically increasing times.
-        var mins: [Int] = []
-        var prev = Int.min
-        for s in stops {
-            guard var m = Self.minutesOfDay(s.departureTime) else { return nil }
-            if prev != Int.min { while m < prev { m += 1440 } }
-            mins.append(m)
-            prev = m
+        // Pair each stop with its minute-of-day in CHRONOLOGICAL order. The seed
+        // stores stops in canonical (outbound) stop_sequence order, so an INBOUND
+        // trip runs time-descending; sorting by stop_sequence + unwrapping would
+        // corrupt it. Instead: if the trip spans > 12h it genuinely crosses
+        // midnight, so pre-05:00 stops belong to the next day (+24h); then sort by
+        // time. Mirrors the Pi projector._project_scheduled_trip_active and the
+        // web chronologicalStops.
+        var paired: [(stop: Trip.Stop, m: Int)] = []
+        for s in trip.stops {
+            guard let m = Self.minutesOfDay(s.departureTime) else { return nil }
+            paired.append((s, m))
         }
+        if let mx = paired.map(\.m).max(), let mn = paired.map(\.m).min(), mx - mn > 12 * 60 {
+            paired = paired.map { $0.m < 5 * 60 ? (stop: $0.stop, m: $0.m + 1440) : $0 }
+        }
+        paired.sort { $0.m < $1.m }
+        let stops = paired.map(\.stop)
+        let mins = paired.map(\.m)
 
         let originMin = mins[0]
         let lastMin = mins[mins.count - 1]


### PR DESCRIPTION
## Why
Follow-up on "ALL TRAINS should show offline." After the offline metro/tram projection, Athens suburban A1-A4 still showed NO map dots with no Pi — they were treated as "live-feed-only" lines and excluded from the client trip projection (while metro/tram and national/IC did show). This projects A1-A4 offline on all three clients.

## What
On each client, A1-A4 are now trip-projected from the bundled `trips[]` when the live feed doesn't cover the line (offline / Pi down); online they are deduped per line against the real-GPS feed, so there's never a double marker:
- **Web** (`web-map.js`): `projectScheduledTrains` projects A1-A4 when `livePositionsSnapshot` lacks the line.
- **iOS** (`NationalVehicleProjector`): A1-A4 dropped from `liveFeedLineIds`; existing MapView `coveredLines` dedup hides them online.
- **Android** (`TrainSimulator.projectScheduledTrains`): skip narrowed to metro/tram (`BAND_PROJECTED_LINES`); MapViewModel already dedupes projected output against `liveTrains`.

Also fixes a **latent inbound bug** on all three: the seed stores stops in canonical (outbound) `stop_sequence` order, so inbound trips run time-descending and the naive monotonic check silently dropped them (half of every trip line). Each client now orders stops chronologically (sort by time; unwrap a genuine >12h midnight crossing), mirroring the Pi `projector._project_scheduled_trip_active`. So A1-A4 **and** national/IC now show BOTH directions offline.

Projected dots keep flowing through the existing "Estimated position / not a live position" sheet — never implied to be live GPS.

## Verification
- **Web**: node harness against the real bundles — A1-A4 both directions at Sun 22:05 / 12:00 and Mon 08:00 peak; empty at 03:00; skipped when the snapshot carries the line. Live offline browser (all `/api/*` -> 503): map populated, no JS errors.
- **iOS**: full `xcodebuild` **BUILD SUCCEEDED**; app relaunched, renders without regression.
- **Android**: compiles via CI (no local JDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
