### PR TITLE
De-emphasize position_only vehicle map markers (grey/faded) on all clients

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -2397,17 +2397,23 @@
 
         for (const train of trains) {
             const line = lineMap.get(train.lineId);
-            const lineColor = line ? line.color : "#7C4DFF";
+            // A vehicle the feed could not assign to a passenger route
+            // (status "position_only" / inService false) is a real GPS dot but
+            // NOT a boardable service. Draw it de-emphasized (grey, no pulse,
+            // faded) so it never reads as a normal boardable train, matching the
+            // detail sheet. Parked/yard vehicles are withheld server-side.
+            const notInService = train.inService === false || train.status === "position_only";
+            const lineColor = notInService ? "#9CA3AF" : (line ? line.color : "#7C4DFF");
             // Custom divIcon so suburban trains are clearly distinguishable
             // from simulated metro/tram dots: pulsing ring + line-id badge.
             const icon = L.divIcon({
-                className: "live-train-marker",
+                className: notInService ? "live-train-marker live-train-marker--muted" : "live-train-marker",
                 html: `
-                    <span class="live-train-marker__pulse" style="border-color:${lineColor}"></span>
-                    <span class="live-train-marker__core" style="background:${lineColor}">
-                        <span class="live-train-marker__glyph">🚆</span>
+                    ${notInService ? "" : `<span class="live-train-marker__pulse" style="border-color:${lineColor}"></span>`}
+                    <span class="live-train-marker__core" style="background:${lineColor}${notInService ? ";opacity:0.55" : ""}">
+                        <span class="live-train-marker__glyph">${notInService ? "⏸" : "🚆"}</span>
                     </span>
-                    <span class="live-train-marker__badge" style="background:${lineColor}">${train.lineId}</span>
+                    <span class="live-train-marker__badge" style="background:${lineColor}${notInService ? ";opacity:0.7" : ""}">${train.lineId}</span>
                 `,
                 iconSize: [44, 56],
                 iconAnchor: [22, 22],
@@ -2419,7 +2425,7 @@
             const marker = L.marker([train.lat, train.lng], {
                 icon,
                 keyboard: false,
-                zIndexOffset: 1000,
+                zIndexOffset: notInService ? 400 : 1000,
             }).addTo(liveTrainLayer);
             marker.bindTooltip(
                 `${line ? line.name : train.lineId} ${train.trainNumber}<br>${train.origin || "?"} → ${train.destination || "?"}`,

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -525,19 +525,24 @@ internal actual fun PlatformMapView(
         }
 
         uiState.liveTrains.forEach { train ->
-            val color = uiState.lines.find { it.id == train.lineId }?.color?.toComposeColor()?.toArgb()
-                ?: 0xFF7C4DFF.toInt()
+            // A "position only" / not-in-service live vehicle is a real GPS dot
+            // but NOT boardable, so draw it de-emphasized (grey, faded) to match
+            // its detail card. Assigned trains keep the line colour.
+            val notInService = !train.inService || train.status == "position_only"
+            val color = if (notInService) 0xFF9CA3AF.toInt()
+                else uiState.lines.find { it.id == train.lineId }?.color?.toComposeColor()?.toArgb()
+                    ?: 0xFF7C4DFF.toInt()
             val snappedPos = snapToPolyline(train.latitude, train.longitude, train.lineId, routeShapes)
             val existing = liveTrainMarkers[train.id]
             if (existing != null) {
                 existing.position = snappedPos
-                existing.icon = buildLiveTrainBitmap(res, color = color, lineId = train.lineId)
+                existing.icon = buildLiveTrainBitmap(res, color = color, lineId = train.lineId, muted = notInService)
             } else {
                 val trainId = train.id
                 val marker = Marker(mapView).apply {
                     position = snappedPos
                     setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
-                    icon = buildLiveTrainBitmap(res, color = color, lineId = train.lineId)
+                    icon = buildLiveTrainBitmap(res, color = color, lineId = train.lineId, muted = notInService)
                     title = "${train.lineId} ${train.trainNumber}"
                     setOnMarkerClickListener { _, _ ->
                         onTrainSelected(trainId)
@@ -825,11 +830,19 @@ private fun buildAirportTrainBitmap(res: android.content.res.Resources): android
     return BitmapDrawable(res, bitmap)
 }
 
-private fun buildLiveTrainBitmap(res: android.content.res.Resources, color: Int, lineId: String): android.graphics.drawable.Drawable {
+private fun buildLiveTrainBitmap(
+    res: android.content.res.Resources,
+    color: Int,
+    lineId: String,
+    muted: Boolean = false,
+): android.graphics.drawable.Drawable {
     // Bigger marker with halo, line-color core, and a line-id badge underneath
     // so suburban trains stand out clearly against the simulated metro/tram
     // dots. Static (no animation here — osmdroid markers don't redraw on tick)
     // but the size + badge already deliver the visibility the user asked for.
+    // `muted` = a non-boardable "position only" vehicle: faded core/halo/badge
+    // (and the caller passes a grey colour) so it reads as secondary, matching
+    // the web/iOS markers + the detail card.
     val width = 88
     val height = 116
     val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
@@ -837,17 +850,19 @@ private fun buildLiveTrainBitmap(res: android.content.res.Resources, color: Int,
     val cx = width / 2f
     val cy = 44f
 
-    val haloColor = (color and 0x00FFFFFF) or 0x33000000
+    val coreAlpha = if (muted) 140 else 255
+    val badgeAlpha = if (muted) 180 else 255
+    val haloColor = (color and 0x00FFFFFF) or (if (muted) 0x1A000000 else 0x33000000)
     val halo = Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = haloColor }
-    val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = color }
-    val white = Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = 0xFFFFFFFF.toInt() }
+    val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = color; this.alpha = coreAlpha }
+    val white = Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = 0xFFFFFFFF.toInt(); this.alpha = if (muted) 190 else 255 }
     val badgeText = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         this.color = 0xFFFFFFFF.toInt()
         this.textSize = 22f
         this.isFakeBoldText = true
         this.textAlign = Paint.Align.CENTER
     }
-    val badge = Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = color }
+    val badge = Paint(Paint.ANTI_ALIAS_FLAG).apply { this.color = color; this.alpha = badgeAlpha }
 
     canvas.drawCircle(cx, cy, 36f, halo)
     canvas.drawCircle(cx, cy, 24f, fill)

--- a/iosApp/iosApp/Views/Map/MapView.swift
+++ b/iosApp/iosApp/Views/Map/MapView.swift
@@ -1743,7 +1743,7 @@ struct SyrmosMKMapView: UIViewRepresentable {
         /// fixed GPS pin, so a suburban train reported off any drawn line — e.g.
         /// the generic "P" Proastiakos, which has no single polyline to snap to —
         /// looks intentional instead of a capsule stranded off the track.
-        static func liveTrainRingImage(color: UIColor) -> UIImage {
+        static func liveTrainRingImage(color: UIColor, muted: Bool = false) -> UIImage {
             let core: CGFloat = 16
             let ring: CGFloat = 28
             let pad: CGFloat = 5
@@ -1754,13 +1754,16 @@ struct SyrmosMKMapView: UIViewRepresentable {
                 let c = canvas / 2
                 let ringPath = UIBezierPath(ovalIn: CGRect(x: c - ring / 2, y: c - ring / 2, width: ring, height: ring))
                 ringPath.lineWidth = 2.5
-                color.withAlphaComponent(0.30).setStroke(); ringPath.stroke()
-                cg.setShadow(offset: CGSize(width: 0, height: 2), blur: 6, color: UIColor(white: 0.08, alpha: 0.3).cgColor)
+                // Muted = a non-boardable "position only" vehicle: fainter ring,
+                // faded core, softer border, so it reads as secondary (matches
+                // the web marker + the detail sheet).
+                color.withAlphaComponent(muted ? 0.18 : 0.30).setStroke(); ringPath.stroke()
+                cg.setShadow(offset: CGSize(width: 0, height: 2), blur: 6, color: UIColor(white: 0.08, alpha: muted ? 0.15 : 0.3).cgColor)
                 let coreRect = CGRect(x: c - core / 2, y: c - core / 2, width: core, height: core)
-                color.setFill(); UIBezierPath(ovalIn: coreRect).fill()
+                color.withAlphaComponent(muted ? 0.55 : 1.0).setFill(); UIBezierPath(ovalIn: coreRect).fill()
                 cg.setShadow(offset: .zero, blur: 0, color: nil)
                 let border = UIBezierPath(ovalIn: coreRect.insetBy(dx: 1, dy: 1))
-                border.lineWidth = 2; UIColor.white.setStroke(); border.stroke()
+                border.lineWidth = 2; UIColor.white.withAlphaComponent(muted ? 0.7 : 1.0).setStroke(); border.stroke()
             }
         }
 
@@ -1773,8 +1776,14 @@ struct SyrmosMKMapView: UIViewRepresentable {
                 let color = UIColor(SyrmosData.line(for: t.lineId)?.color ?? SyrmosData.lineColor(for: t.lineId))
                 return Self.capsuleTrainImage(color: color, bearing: t.bearing)
             case .live(let t):
-                let color = UIColor(SyrmosData.line(for: t.lineId)?.color ?? SyrmosData.lineColor(for: t.lineId))
-                return Self.liveTrainRingImage(color: color)
+                // A "position only" / not-in-service live vehicle is a real GPS
+                // dot but NOT boardable, so draw it de-emphasized (grey, faded)
+                // to match its detail sheet. Assigned trains keep the line colour.
+                let notInService = !t.inService || t.status == "position_only"
+                let color = notInService
+                    ? UIColor(red: 0.61, green: 0.64, blue: 0.69, alpha: 1.0)   // ~#9CA3AF, matches web
+                    : UIColor(SyrmosData.line(for: t.lineId)?.color ?? SyrmosData.lineColor(for: t.lineId))
+                return Self.liveTrainRingImage(color: color, muted: notInService)
             }
         }
     }


### PR DESCRIPTION
## Why
The server withholds parked_yard/not_in_service vehicles from `/api/trains`, so the only non-boardable status reaching clients is `position_only` (a moving, unassigned live vehicle). Its detail sheet already reads "Position only, not in service", but the MAP MARKER still drew the same full-colour boardable pin. This de-emphasizes the marker to match — the last of the overhaul follow-ups.

## What
- **Web** (`renderLiveTrains`): grey `#9CA3AF`, no pulse ring, faded core (0.55 opacity), a ⏸ glyph, lower z-index so in-service trains draw on top.
- **iOS** (`liveTrainRingImage` gains a `muted` variant): grey, fainter ring/border, faded core.
- **Android** (`buildLiveTrainBitmap` gains a `muted` param): grey, faded core/halo/badge.

Assigned in-service trains (A1-A4, IC, metro/tram) are unchanged.

## Verification
- **Web**: local harness with a synthetic feed — the `position_only` "P" renders grey / ⏸ / no-pulse / 0.55 opacity (muted class), while the in-service "A1" stays red / 🚆 / pulsing. Confirmed via DOM inspection.
- **iOS**: full `xcodebuild` **BUILD SUCCEEDED**.
- **Android**: compiles via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)