### PR TITLE
Ariadne: offline-provider reply no longer shadows the local engine

### DIFF
--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/AriadneChatService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/AriadneChatService.kt
@@ -27,8 +27,7 @@ class AriadneChatService(
                 setBody(json.encodeToString(AriadneChatRequest.serializer(), payload))
             }
             val body = response.bodyAsText()
-            val result = json.decodeFromString<AriadneChatResponse>(body)
-            if (result.ok) result.reply else null
+            json.decodeFromString<AriadneChatResponse>(body).cloudReplyOrNull()
         } catch (_: Exception) {
             null
         }
@@ -56,7 +55,21 @@ private data class AriadneChatRequest(
 )
 
 @Serializable
-private data class AriadneChatResponse(
+internal data class AriadneChatResponse(
     val reply: String = "",
     val ok: Boolean = false,
+    /** "offline" when the server's own cloud LLMs are down: not a real answer. */
+    val provider: String = "",
 )
+
+/**
+ * The cloud reply to surface, or null to fall through to the local engine.
+ *
+ * The server answers `ok=true` with `provider="offline"` and a canned
+ * "I can't reach my brain right now" message whenever its OWN cloud LLM providers
+ * are unreachable (which, on the current Pi, is every call). Returning that would
+ * shadow the fully-capable local grounded engine, so an offline-provider reply is
+ * treated as no cloud answer.
+ */
+internal fun AriadneChatResponse.cloudReplyOrNull(): String? =
+    if (ok && provider != "offline") reply else null

--- a/core/network/src/commonTest/kotlin/com/syrmos/core/network/AriadneChatServiceTest.kt
+++ b/core/network/src/commonTest/kotlin/com/syrmos/core/network/AriadneChatServiceTest.kt
@@ -1,0 +1,47 @@
+package com.syrmos.core.network
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The cloud-vs-local decision for Ariadne. The server returns ok=true with
+ * provider="offline" and a canned "I can't reach my brain" message whenever its
+ * own cloud LLMs are down; that must fall through to the local grounded engine,
+ * never be shown as if it were a real answer.
+ */
+class AriadneChatServiceTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun decode(body: String) = json.decodeFromString<AriadneChatResponse>(body)
+
+    @Test
+    fun offlineProviderReplyIsTreatedAsNoCloudAnswer() {
+        // The exact shape the live Pi returns when its cloud providers are down.
+        val body = """{"reply":"I can't reach my brain right now.","ok":true,"provider":"offline"}"""
+        assertNull(
+            decode(body).cloudReplyOrNull(),
+            "provider=offline must fall through to the local engine, not shadow it",
+        )
+    }
+
+    @Test
+    fun realCloudReplyIsSurfaced() {
+        val body = """{"reply":"Line A4 runs Piraeus to Kiato.","ok":true,"provider":"gemini"}"""
+        assertEquals("Line A4 runs Piraeus to Kiato.", decode(body).cloudReplyOrNull())
+    }
+
+    @Test
+    fun notOkIsNull() {
+        val body = """{"reply":"boom","ok":false,"provider":"gemini"}"""
+        assertNull(decode(body).cloudReplyOrNull())
+    }
+
+    @Test
+    fun missingProviderStillSurfacesAnOkReply() {
+        // Older server builds omit provider entirely; an ok reply must still show.
+        val body = """{"reply":"hello","ok":true}"""
+        assertEquals("hello", decode(body).cloudReplyOrNull())
+    }
+}

--- a/iosApp/iosApp/Core/Networking/AriadneAPIService.swift
+++ b/iosApp/iosApp/Core/Networking/AriadneAPIService.swift
@@ -8,6 +8,19 @@ struct AriadneChatMessage: Codable {
 struct AriadneChatResponse: Codable {
     let reply: String
     let ok: Bool
+    /// "offline" when the server's own cloud LLMs are down: not a real answer.
+    /// Optional so a server build that omits the key still decodes (a default
+    /// value would not stop Swift's synthesized Codable throwing on a missing key).
+    let provider: String?
+
+    /// The cloud reply to surface, or nil to fall through to the local engine.
+    /// The server answers ok=true with provider="offline" and a canned "I can't
+    /// reach my brain" message whenever its cloud providers are unreachable
+    /// (every call, on the current Pi). Surfacing it would shadow the capable
+    /// local grounded engine, so an offline-provider reply counts as no answer.
+    var cloudReplyOrNull: String? {
+        (ok && provider != "offline") ? reply : nil
+    }
 }
 
 @MainActor
@@ -39,7 +52,7 @@ final class AriadneAPIService {
             let (data, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
             let decoded = try JSONDecoder().decode(AriadneChatResponse.self, from: data)
-            return decoded.ok ? decoded.reply : nil
+            return decoded.cloudReplyOrNull
         } catch {
             return nil
         }


### PR DESCRIPTION
When the server's own cloud LLM providers are unreachable, it still answers HTTP 200 with `{"ok":true,"provider":"offline","reply":"I can't reach my brain right now..."}`. Both mobile clients decoded only `reply` + `ok`, so they surfaced that canned dead-end as a real answer and **never fell through to the fully-capable local grounded engine**. On the current Pi the cloud providers are down, so this shadowed *every* query: Ariadne looked broken on mobile even though the local engine could answer.

- **KMP** `AriadneChatService`: parse `provider`; `provider=="offline"` resolves to null via `cloudReplyOrNull()`, so `askCloudLLM` returns null and `handleQuery` runs the local engine. Added `AriadneChatServiceTest` (offline shape, real reply, not-ok, missing-provider).
- **iOS** `AriadneAPIService`: same via `cloudReplyOrNull`; `provider` is optional so a response omitting the key still decodes.

Top item from the Aug 2026 Ariadne diagnosis. Remaining follow-ups (cloud-first reachability guard, web popup-blocked actions, iOS on-device-model banner) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)