### PR TITLE
Web map: Ariadne tappable links + line-state legend

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -362,8 +362,38 @@
             </button>
         </div>
 
-        <!-- Map chrome: bottom-left live-status pill -->
+        <!-- Map chrome: bottom-left legend + live-status pill -->
         <div class="map-chrome map-chrome--bl">
+            <div class="map-legend" id="mapLegend">
+                <button class="map-legend__toggle" id="mapLegendToggle" type="button"
+                        aria-expanded="false" aria-controls="mapLegendBody">
+                    <span class="map-legend__icon" aria-hidden="true">≡</span>
+                    <span data-i18n="legend_title">Legend</span>
+                </button>
+                <div class="map-legend__body" id="mapLegendBody" role="group"
+                     aria-label="Map legend" hidden>
+                    <div class="legend-row">
+                        <span class="legend-swatch legend-swatch--line"></span>
+                        <span data-i18n="legend_active">In service</span>
+                    </div>
+                    <div class="legend-row">
+                        <span class="legend-swatch legend-swatch--bus"></span>
+                        <span data-i18n="legend_bus">Bus / shuttle</span>
+                    </div>
+                    <div class="legend-row">
+                        <span class="legend-swatch legend-swatch--closed"></span>
+                        <span data-i18n="legend_closed">Suspended / under construction</span>
+                    </div>
+                    <div class="legend-row">
+                        <span class="legend-swatch legend-swatch--live"></span>
+                        <span data-i18n="legend_live">Live vehicle</span>
+                    </div>
+                    <div class="legend-row">
+                        <span class="legend-swatch legend-swatch--parked"></span>
+                        <span data-i18n="legend_parked">Parked / not in service</span>
+                    </div>
+                </div>
+            </div>
             <div class="live-status-pill" id="liveStatusPill">
                 <span class="live-status-pill__dot"></span>
                 <span id="liveStatusText" data-i18n="live_trains">Live trains</span>

--- a/composeApp/src/wasmJsMain/resources/web-map.css
+++ b/composeApp/src/wasmJsMain/resources/web-map.css
@@ -1306,6 +1306,27 @@ body.dark-mode .live-status-pill {
     border-bottom-left-radius: 4px;
 }
 
+/* Tappable action link inside an Ariadne reply (directions, official alerts).
+   Rendered as a pill the user taps, so the browser treats the open as a user
+   gesture and never popup-blocks it. */
+.ariadne-msg__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 8px;
+    padding: 5px 12px;
+    border-radius: var(--sy-radius-pill);
+    background: var(--sy-accent);
+    color: #fff;
+    font-size: 12px;
+    font-weight: 600;
+    text-decoration: none;
+    width: fit-content;
+}
+.ariadne-msg__link::after { content: "↗"; font-weight: 400; }
+.ariadne-msg__link:hover { background: var(--sy-accent-strong); }
+.ariadne-msg__link:focus-visible { outline: 2px solid var(--sy-accent); outline-offset: 2px; }
+
 .ariadne-panel__composer {
     display: flex; gap: 8px;
     padding: 12px 16px;

--- a/composeApp/src/wasmJsMain/resources/web-map.css
+++ b/composeApp/src/wasmJsMain/resources/web-map.css
@@ -612,7 +612,51 @@ body.dark-mode .nav-item--active {
 .map-chrome--tl { top: 16px; left: 16px; gap: 6px; }
 .map-chrome--tr { top: 16px; right: 16px; gap: 8px; align-items: center; }
 .map-chrome--br { bottom: 24px; right: 16px; flex-direction: column; gap: 8px; align-items: flex-end; }
-.map-chrome--bl { bottom: 24px; left: 16px; }
+.map-chrome--bl { bottom: 24px; left: 16px; flex-direction: column; gap: 8px; align-items: flex-start; }
+
+/* Map legend: a collapsible key for the line-state styling. */
+.map-legend {
+    display: flex; flex-direction: column; gap: 6px; align-items: flex-start;
+}
+.map-legend__toggle {
+    display: inline-flex; align-items: center; gap: 6px;
+    height: 30px; padding: 0 12px;
+    border: 1px solid var(--sy-border-subtle);
+    border-radius: var(--sy-radius-pill);
+    background: var(--sy-background-raised);
+    color: var(--sy-text-secondary);
+    font: inherit; font-size: 12px; font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,.08);
+}
+.map-legend__toggle:hover { color: var(--sy-text-primary); }
+.map-legend__toggle:focus-visible { outline: 2px solid var(--sy-accent); outline-offset: 2px; }
+.map-legend__icon { font-size: 14px; line-height: 1; }
+.map-legend__body {
+    display: flex; flex-direction: column; gap: 8px;
+    padding: 12px 14px;
+    border: 1px solid var(--sy-border-subtle);
+    border-radius: var(--sy-radius-md);
+    background: var(--sy-background-raised);
+    box-shadow: 0 4px 16px rgba(0,0,0,.12);
+    max-width: 240px;
+}
+.map-legend__body[hidden] { display: none; }
+.legend-row {
+    display: flex; align-items: center; gap: 10px;
+    font-size: 12px; color: var(--sy-text-primary);
+}
+.legend-swatch { flex: 0 0 auto; width: 26px; height: 12px; display: inline-block; }
+/* A solid line = in service; dashed = bus; grey dashed = built but not running.
+   These mirror the polyline styling in web-map.js (MAP_TOKENS.greyedColor / dashes). */
+.legend-swatch--line { border-top: 3px solid var(--sy-accent); height: 3px; align-self: center; }
+.legend-swatch--bus { border-top: 3px dashed var(--sy-accent); height: 3px; align-self: center; }
+.legend-swatch--closed { border-top: 3px dashed #94a3b8; height: 3px; align-self: center; opacity: .7; }
+.legend-swatch--live, .legend-swatch--parked {
+    width: 12px; height: 12px; border-radius: 50%;
+}
+.legend-swatch--live { background: var(--sy-accent); box-shadow: 0 0 0 3px rgba(20,102,184,.25); }
+.legend-swatch--parked { background: #9CA3AF; opacity: .6; }
 
 /* Region Chips */
 .region-chip {

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -44,6 +44,12 @@
             show_vehicles: "Show vehicles",
             hide_vehicles: "Hide vehicles",
             live_trains: "Live trains",
+            legend_title: "Legend",
+            legend_active: "In service",
+            legend_bus: "Bus / shuttle",
+            legend_closed: "Suspended or under construction",
+            legend_live: "Live vehicle",
+            legend_parked: "Parked / not in service",
             trains_active: "{n} trains active",
             nearby_stations: "Nearby stations",
             popular_stations: "Popular stations",
@@ -132,6 +138,12 @@
             show_vehicles: "Εμφάνιση οχημάτων",
             hide_vehicles: "Απόκρυψη οχημάτων",
             live_trains: "Ζωντανά τρένα",
+            legend_title: "Υπόμνημα",
+            legend_active: "Σε λειτουργία",
+            legend_bus: "Λεωφορείο / σατλ",
+            legend_closed: "Σε αναστολή ή υπό κατασκευή",
+            legend_live: "Ζωντανό όχημα",
+            legend_parked: "Σταθμευμένο / εκτός λειτουργίας",
             trains_active: "{n} ενεργά τρένα",
             nearby_stations: "Κοντινοί σταθμοί",
             popular_stations: "Δημοφιλείς σταθμοί",
@@ -220,6 +232,12 @@
             show_vehicles: "Shfaq mjetet",
             hide_vehicles: "Fshih mjetet",
             live_trains: "Trenat aktiv",
+            legend_title: "Legjenda",
+            legend_active: "Në shërbim",
+            legend_bus: "Autobus / satël",
+            legend_closed: "I pezulluar ose në ndërtim",
+            legend_live: "Automjet i drejtpërdrejtë",
+            legend_parked: "I parkuar / jashtë shërbimit",
             trains_active: "{n} trena aktiv",
             nearby_stations: "Stacionet pranë",
             popular_stations: "Stacionet kryesore",
@@ -308,6 +326,12 @@
             show_vehicles: "Mostra veicoli",
             hide_vehicles: "Nascondi veicoli",
             live_trains: "Treni in tempo reale",
+            legend_title: "Legenda",
+            legend_active: "In servizio",
+            legend_bus: "Autobus / navetta",
+            legend_closed: "Sospeso o in costruzione",
+            legend_live: "Veicolo in tempo reale",
+            legend_parked: "Fermo / non in servizio",
             trains_active: "{n} treni attivi",
             nearby_stations: "Stazioni vicine",
             popular_stations: "Stazioni principali",
@@ -800,6 +824,20 @@
             if (e.key !== "Enter" && e.key !== " ") return;
             const row = e.target.closest("[data-train-id]");
             if (row) { e.preventDefault(); _openTrainRow(row); }
+        });
+    }
+
+    // Map legend: explains the line-state styling (a solid line is in service, a
+    // dashed one is a bus, a grey dashed one is suspended or under construction)
+    // so the grey track from the seasonal/suspended work is never "unexplained".
+    const mapLegendToggle = document.getElementById("mapLegendToggle");
+    const mapLegendBody = document.getElementById("mapLegendBody");
+    if (mapLegendToggle && mapLegendBody) {
+        mapLegendToggle.addEventListener("click", () => {
+            const willOpen = mapLegendBody.hasAttribute("hidden");
+            if (willOpen) mapLegendBody.removeAttribute("hidden");
+            else mapLegendBody.setAttribute("hidden", "");
+            mapLegendToggle.setAttribute("aria-expanded", String(willOpen));
         });
     }
     const nearbyStationList = document.getElementById("nearbyStationList");

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -107,6 +107,7 @@
             search_ask_ariadne: "Ask Ariadne",
             ariadne_open_map: "Opening {station} on the map.",
             ariadne_open_alerts: "Showing service alerts.",
+            ariadne_open_link: "Open",
             ariadne_open_route: "Opening directions from {from} to {to}.",
             ariadne_eta_locating: "Getting your location to estimate the trip to {station}…",
             ariadne_eta_ask_origin: "I couldn't get your location. Which station are you starting from?",
@@ -194,6 +195,7 @@
             search_ask_ariadne: "Ρώτησε την Αριάδνη",
             ariadne_open_map: "Άνοιγμα του {station} στον χάρτη.",
             ariadne_open_alerts: "Εμφάνιση ειδοποιήσεων.",
+            ariadne_open_link: "Άνοιγμα",
             ariadne_open_route: "Άνοιγμα διαδρομής από {from} προς {to}.",
             ariadne_eta_locating: "Εντοπίζω την τοποθεσία σου για τον χρόνο προς {station}…",
             ariadne_eta_ask_origin: "Δεν βρήκα την τοποθεσία σου. Από ποιον σταθμό ξεκινάς;",
@@ -281,6 +283,7 @@
             search_ask_ariadne: "Pyet Ariadnen",
             ariadne_open_map: "Po hap {station} në hartë.",
             ariadne_open_alerts: "Po tregoj njoftimet.",
+            ariadne_open_link: "Hap",
             ariadne_open_route: "Po hap udhëzimet nga {from} te {to}.",
             ariadne_eta_locating: "Po marr vendndodhjen tënde për kohën te {station}…",
             ariadne_eta_ask_origin: "S'e mora dot vendndodhjen. Nga cili stacion po nisesh?",
@@ -368,6 +371,7 @@
             search_ask_ariadne: "Chiedi ad Ariadne",
             ariadne_open_map: "Apro {station} sulla mappa.",
             ariadne_open_alerts: "Mostro gli avvisi di servizio.",
+            ariadne_open_link: "Apri",
             ariadne_open_route: "Apro le indicazioni da {from} a {to}.",
             ariadne_eta_locating: "Ottengo la tua posizione per stimare il viaggio verso {station}...",
             ariadne_eta_ask_origin: "Non ho potuto ottenere la tua posizione. Da quale stazione parti?",
@@ -4330,6 +4334,21 @@
             return el;
         }
 
+        // A tappable external link inside an Ariadne reply (directions, official
+        // alerts). Opening on the user's tap is a real gesture, so it is never
+        // popup-blocked the way a script-timed window.open is.
+        function appendActionLink(el, link) {
+            if (!link || !link.href) return;
+            const a = document.createElement("a");
+            a.className = "ariadne-msg__link";
+            a.href = link.href;
+            a.target = "_blank";
+            a.rel = "noopener noreferrer";
+            a.textContent = link.label || link.href;
+            el.appendChild(a);
+            messages.scrollTop = messages.scrollHeight;
+        }
+
         function openPanel() {
             panel.classList.remove("ariadne-panel--hidden");
             panel.setAttribute("aria-hidden", "false");
@@ -4675,10 +4694,13 @@
                     }
                     return { text: t("ariadne_no_station") };
                 case "alerts": {
+                    // A tappable link, NOT an auto-fired window.open: the reply is
+                    // rendered after async work, so a popup opened then is blocked.
+                    // The user's tap on the link is a gesture the browser allows.
                     return {
                         text: t("ariadne_open_alerts"),
                         sourceConf: "live",
-                        act: () => window.open("https://www.stasy.gr/en/news/", "_blank", "noopener"),
+                        link: { href: "https://www.stasy.gr/en/news/", label: t("ariadne_open_link") },
                     };
                 }
                 case "plan": {
@@ -4692,7 +4714,7 @@
                             to: stationName(to.id),
                         }),
                         sourceConf: "offline",
-                        act: () => window.open(url, "_blank", "noopener"),
+                        link: { href: url, label: t("ariadne_open_link") },
                     };
                 }
                 case "travelTime": {
@@ -4705,7 +4727,7 @@
                         return {
                             text: t("ariadne_open_route", { from: stationName(from.id), to: stationName(to.id) }),
                             sourceConf: "offline",
-                            act: () => window.open(url, "_blank", "noopener"),
+                            link: { href: url, label: t("ariadne_open_link") },
                         };
                     }
                     // No named origin: use the browser location, else ask.
@@ -5018,7 +5040,11 @@
                     return;
                 }
                 const reply = respond(finalIntent);
-                appendMessage(reply.text, "assistant", reply.sourceConf);
+                const replyEl = appendMessage(reply.text, "assistant", reply.sourceConf);
+                // A link is a tappable affordance (opens on the user's gesture, so
+                // never popup-blocked). An `act` is internal navigation (open a
+                // station, focus the map) that needs no gesture, so it still fires.
+                if (reply.link && replyEl) appendActionLink(replyEl, reply.link);
                 if (reply.departuresFor) {
                     departuresSummary(reply.departuresFor).then((summary) => {
                         if (summary) appendMessage(summary, "assistant", "scheduled");


### PR DESCRIPTION
Ariadne's directions / route / alerts actions fired `window.open(...)` from `setTimeout(reply.act, 400)` after the reply rendered. Outside a user gesture, browsers **popup-block** it — the assistant said "opening directions" and nothing opened.

Those external-URL actions now return `link: { href, label }` and render as a **tappable pill** inside the reply (localized "Open" in EN/EL/SQ/IT). The tap is a gesture, so the open always works. Internal navigation actions (open a station, focus the map) still auto-fire since they need no gesture.

**Verified in a local browser**: "directions from Syntagma to Piraeus" → Google-Maps directions pill; "service alerts" → stasy.gr pill; both `target=_blank rel="noopener noreferrer"`. The rare travel-time-without-origin path (opens after a geolocation callback) is left as a follow-up.

Third item from the Aug 2026 Ariadne diagnosis. Remaining: cloud-first reachability guard, iOS on-device-model banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)