### PR TITLE
Ariadne mobile: fast offline fallback + reachable on-device model download

### DIFF
--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/AriadneChatService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/AriadneChatService.kt
@@ -31,8 +31,11 @@ class AriadneChatService(
                 // server's multi-LLM chain still has time to answer when reachable.
                 timeout {
                     connectTimeoutMillis = 3_500
-                    requestTimeoutMillis = 30_000
-                    socketTimeoutMillis = 30_000
+                    // Above the server's nginx 30 s read cap (the backend tries up
+                    // to three LLM providers in sequence and emits nothing until
+                    // one answers), so a valid-but-slow reply is received, not cut.
+                    requestTimeoutMillis = 33_000
+                    socketTimeoutMillis = 33_000
                 }
                 contentType(ContentType.Application.Json)
                 setBody(json.encodeToString(AriadneChatRequest.serializer(), payload))

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/AriadneChatService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/AriadneChatService.kt
@@ -1,6 +1,7 @@
 package com.syrmos.core.network
 
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -23,6 +24,16 @@ class AriadneChatService(
                 }
             )
             val response = httpClient.post(CHAT_URL) {
+                // Reachability guard without a platform network API: a SHORT connect
+                // timeout means an unreachable Pi (or an offline device) drops to the
+                // local grounded engine in a few seconds instead of blocking on the
+                // shared client's 15 s connect. The request timeout stays long so the
+                // server's multi-LLM chain still has time to answer when reachable.
+                timeout {
+                    connectTimeoutMillis = 3_500
+                    requestTimeoutMillis = 30_000
+                    socketTimeoutMillis = 30_000
+                }
                 contentType(ContentType.Application.Json)
                 setBody(json.encodeToString(AriadneChatRequest.serializer(), payload))
             }

--- a/iosApp/iosApp/Core/Networking/AriadneAPIService.swift
+++ b/iosApp/iosApp/Core/Networking/AriadneAPIService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 
 struct AriadneChatMessage: Codable {
     let role: String
@@ -28,15 +29,31 @@ final class AriadneAPIService {
     static let shared = AriadneAPIService()
     private let baseURL = "https://api-syrmos.peterdsp.dev"
     private let session: URLSession
+    private let pathMonitor = NWPathMonitor()
+    /// Optimistic until the monitor's first update, so the very first turn still
+    /// tries the cloud (and falls back on failure) rather than being pinned offline.
+    private var isOnline = true
 
     private init() {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 20
         config.timeoutIntervalForResource = 25
+        // Do not sit and wait for a network to appear; fail so we can fall back.
+        config.waitsForConnectivity = false
         session = URLSession(configuration: config)
+        // Reachability guard: track connectivity so an offline device drops to the
+        // local grounded engine instantly instead of waiting out the request timeout.
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            let online = path.status == .satisfied
+            Task { @MainActor in self?.isOnline = online }
+        }
+        pathMonitor.start(queue: DispatchQueue(label: "ariadne.reachability"))
     }
 
     func chat(messages: [AriadneChatMessage]) async -> String? {
+        // No network: skip the cloud entirely so the caller uses the local engine
+        // with no delay, instead of blocking on a doomed request.
+        guard isOnline else { return nil }
         guard let url = URL(string: "\(baseURL)/api/ariadne/chat") else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/iosApp/iosApp/Core/Networking/AriadneAPIService.swift
+++ b/iosApp/iosApp/Core/Networking/AriadneAPIService.swift
@@ -36,8 +36,13 @@ final class AriadneAPIService {
 
     private init() {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 20
-        config.timeoutIntervalForResource = 25
+        // The backend emits no bytes while it tries up to three LLM providers in
+        // sequence, and nginx caps that at a 30 s read timeout. Keep the client
+        // ceilings just above 30 s so a valid-but-slow reply is received rather
+        // than truncated; the NWPathMonitor guard (not a short timeout) is what
+        // handles the offline/unreachable case.
+        config.timeoutIntervalForRequest = 33
+        config.timeoutIntervalForResource = 35
         // Do not sit and wait for a network to appear; fail so we can fall back.
         config.waitsForConnectivity = false
         session = URLSession(configuration: config)

--- a/iosApp/iosApp/Features/Assistant/AriadneModelStore.swift
+++ b/iosApp/iosApp/Features/Assistant/AriadneModelStore.swift
@@ -9,7 +9,7 @@ import Foundation
 final class AriadneModelStore: ObservableObject {
     static let shared = AriadneModelStore()
 
-    enum Status: Equatable { case notDownloaded, downloading(Double), ready, error }
+    enum Status: Equatable { case notDownloaded, downloading(Double), verifying, ready, error, insufficientStorage }
 
     // Kept in sync with core/common AriadneModelManifest.
     nonisolated static let fileName = "qwen2.5-1.5b-instruct-q4_k_m.gguf"
@@ -49,13 +49,35 @@ final class AriadneModelStore: ObservableObject {
         }
     }
 
-    /// Explicit, user-triggered download with checksum verification.
+    /// Explicit, user-triggered download with real progress, a storage preflight,
+    /// and off-main-actor checksum verification.
     func download() async {
         if case .ready = status { return }
+        // Storage preflight: fail fast with an actionable state instead of
+        // spending 1.1 GB of transfer only to hit a generic write error.
+        guard hasSpaceForModel() else { status = .insufficientStorage; return }
         status = .downloading(0)
         do {
-            let (tempURL, _) = try await URLSession.shared.download(from: Self.url)
-            let ok = try verify(tempURL)
+            // A per-task delegate reports real byte progress (the plain async
+            // download(from:) reports none, which left the banner stuck at 0%).
+            let progress = DownloadProgressDelegate { [weak self] fraction in
+                Task { @MainActor in
+                    guard let self else { return }
+                    if case .downloading = self.status { self.status = .downloading(fraction) }
+                }
+            }
+            let (tempURL, response) = try await URLSession.shared.download(from: Self.url, delegate: progress)
+            if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                status = .error
+                return
+            }
+            // Hashing 1.1 GB must NOT run on the main actor (it would freeze the UI
+            // for seconds and risk a watchdog kill). Do it on a utility task.
+            status = .verifying
+            let expected = Self.sha256
+            let ok = try await Task.detached(priority: .utility) {
+                try AriadneModelStore.verify(tempURL, expected: expected)
+            }.value
             guard ok else { status = .error; return }
             let dest = modelURL
             try? FileManager.default.removeItem(at: dest)
@@ -66,15 +88,48 @@ final class AriadneModelStore: ObservableObject {
         }
     }
 
-    private func verify(_ url: URL) throws -> Bool {
+    /// True when the volume has room for the model plus a safety margin. Uses the
+    /// "important usage" figure iOS actually honours for on-demand downloads.
+    private func hasSpaceForModel() -> Bool {
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        if let values = try? dir.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]),
+           let available = values.volumeAvailableCapacityForImportantUsage {
+            return available > Self.byteCount + Self.byteCount / 10
+        }
+        return true // capacity unknown: stay optimistic and let the write fail if it must
+    }
+
+    /// Streaming SHA-256 of the file. `nonisolated static` so it can run off the
+    /// main actor via a detached task.
+    nonisolated private static func verify(_ url: URL, expected: String) throws -> Bool {
         var hasher = SHA256Streaming()
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
         while case let data = handle.readData(ofLength: 1 << 20), !data.isEmpty {
             hasher.update(data)
         }
-        return hasher.hexDigest() == Self.sha256
+        return hasher.hexDigest() == expected
     }
+}
+
+/// Reports download byte-progress for the async `download(from:delegate:)` call.
+/// `@unchecked Sendable`: it only forwards immutable progress numbers through a
+/// closure that hops to the main actor.
+private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let onProgress: (Double) -> Void
+    init(onProgress: @escaping (Double) -> Void) { self.onProgress = onProgress }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
+                    totalBytesExpectedToWrite: Int64) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        onProgress(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+    }
+
+    // Required by the protocol; the async download(from:delegate:) call returns the
+    // file location itself, so nothing to do here.
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didFinishDownloadingTo location: URL) {}
 }
 
 // Minimal streaming SHA-256 (CryptoKit's Insecure is not needed; use CommonCrypto

--- a/iosApp/iosApp/Features/Assistant/AriadneView.swift
+++ b/iosApp/iosApp/Features/Assistant/AriadneView.swift
@@ -411,6 +411,20 @@ private struct AriadneModelBanner: View {
                 Button(retryText) { Task { await store.download() } }
                     .font(.caption.weight(.semibold))
             }
+        case .verifying:
+            card {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text(verifyingText).font(.caption.weight(.medium))
+                }
+            }
+        case .insufficientStorage:
+            card {
+                Text(storageTitle).font(.subheadline.weight(.bold))
+                Text(storageText).font(.caption).foregroundStyle(.secondary)
+                Button(retryText) { Task { await store.download() } }
+                    .font(.caption.weight(.semibold))
+            }
         case .notDownloaded:
             card {
                 Text(title).font(.subheadline.weight(.bold))
@@ -443,6 +457,30 @@ private struct AriadneModelBanner: View {
         case .albanian: return "Shkarko një AI në pajisje (~1.1 GB, një herë) për fjalë më të lira. Punon offline më pas."
         case .italian: return "Scarica un AI sul dispositivo (~1.1 GB, una volta) per un linguaggio più libero. Funziona offline dopo."
         case .english: return "Download an on-device AI (~1.1 GB, one time) so Ariadne understands freer wording. Works offline after."
+        }
+    }
+    private var verifyingText: String {
+        switch loc.language {
+        case .greek: return "Επαλήθευση μοντέλου..."
+        case .albanian: return "Po verifikohet modeli..."
+        case .italian: return "Verifica del modello..."
+        case .english: return "Verifying model..."
+        }
+    }
+    private var storageTitle: String {
+        switch loc.language {
+        case .greek: return "Δεν υπάρχει αρκετός χώρος"
+        case .albanian: return "Nuk ka hapësirë të mjaftueshme"
+        case .italian: return "Spazio insufficiente"
+        case .english: return "Not enough space"
+        }
+    }
+    private var storageText: String {
+        switch loc.language {
+        case .greek: return "Το μοντέλο χρειάζεται ~1.1 GB. Ελευθέρωσε χώρο και δοκίμασε ξανά."
+        case .albanian: return "Modeli kërkon ~1.1 GB. Liro pak hapësirë dhe provo sërish."
+        case .italian: return "Il modello richiede ~1.1 GB. Libera spazio e riprova."
+        case .english: return "The model needs ~1.1 GB. Free up some space and try again."
         }
     }
     private func downloadingText(_ pct: Int) -> String {

--- a/iosApp/iosApp/Features/Assistant/AriadneView.swift
+++ b/iosApp/iosApp/Features/Assistant/AriadneView.swift
@@ -23,6 +23,14 @@ struct AriadneView: View {
                         .padding(.top, 12)
                         .padding(.bottom, 8)
 
+                    // On-device model control: offers the ~1.1 GB GGUF download,
+                    // shows progress, and hides itself once ready. Without this the
+                    // download was unreachable, so AriadneGuided's on-device clever
+                    // tier (LlamaSession) never had a model to load.
+                    AriadneModelBanner()
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 8)
+
                     ScrollViewReader { proxy in
                         ScrollView {
                             LazyVStack(alignment: .leading, spacing: 12) {


### PR DESCRIPTION
Two items from the Aug 2026 Ariadne diagnosis.

**Reachability guard (fast offline fallback).** The cloud call could block on the shared client's 15 s connect timeout when the Pi was unreachable, stalling the turn before the local engine ran.
- **KMP**: a short per-request **connect** timeout (3.5 s) on the Ariadne call, keeping a long **request** timeout so the server's multi-LLM chain still has time when reachable. An unreachable Pi or offline device drops to the local grounded engine in a few seconds (near-instant when truly offline, since connect fails immediately).
- **iOS**: an `NWPathMonitor` guard in `AriadneAPIService` skips the cloud call entirely when offline, so the local answer is instant; `waitsForConnectivity = false` so it never sits waiting for a network.

**iOS on-device model download was unreachable.** `AriadneModelBanner` (offer / progress / retry for the ~1.1 GB Qwen GGUF that `AriadneGuided` + `LlamaSession` use for the on-device clever tier) was defined but never placed in the view — so the model could never be downloaded and that tier never activated. Now shown at the top of the assistant, hiding itself once ready.

## Testing
No new unit test: both are I/O-bound (network monitor, socket timeouts), not unit-testable in this repo's pure-logic style. Validated by KMP + iOS CI compile; existing `AriadneChatServiceTest` still covers the reply decision.

Completes the mobile Ariadne backlog (offline-shadow + dead-composer shipped in betas 20/21; this adds reachability + model download). Ships in beta.22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)