### PR TITLE
Ariadne: async provider chain (Groq/Cloudflare/local) + observability

### DIFF
--- a/ops/syrmos-api/requirements.txt
+++ b/ops/syrmos-api/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.5
 uvicorn[standard]==0.32.1
 python-multipart==0.0.12
 deep-translator==1.11.4
+httpx==0.28.1

--- a/ops/syrmos-api/syrmos_admin/app.py
+++ b/ops/syrmos-api/syrmos_admin/app.py
@@ -1057,7 +1057,7 @@ def _trigger_seed_refresh() -> None:
         pass
 
 
-# Ariadne chat (unauthenticated, rate-limited by Gemini quota)
+# Ariadne chat (unauthenticated, rate-limited by upstream provider quotas)
 
 @app.post("/api/ariadne/chat")
 async def api_ariadne_chat(request: Request) -> JSONResponse:
@@ -1073,8 +1073,13 @@ async def api_ariadne_chat(request: Request) -> JSONResponse:
         raise HTTPException(status_code=400, detail="messages array required")
     if len(messages) > 20:
         messages = messages[-20:]
-    result = ariadne_mod.chat(messages)
-    return JSONResponse({"reply": result["reply"], "ok": True, "provider": result["provider"]})
+    result = await ariadne_mod.chat_async(messages)
+    return JSONResponse({
+        "reply": result["reply"],
+        "ok": True,
+        "provider": result["provider"],
+        "model": result.get("model"),
+    })
 
 
 # Health (unauthenticated)

--- a/ops/syrmos-api/syrmos_admin/app.py
+++ b/ops/syrmos-api/syrmos_admin/app.py
@@ -1067,8 +1067,11 @@ def _trigger_seed_refresh() -> None:
 _ARIADNE_MAX_INPUT_CHARS = int(os.environ.get("ARIADNE_MAX_INPUT_CHARS", "6000"))
 _ARIADNE_MAX_CONCURRENCY = int(os.environ.get("ARIADNE_MAX_CONCURRENCY", "6"))
 _ARIADNE_RATE_PER_MIN = int(os.environ.get("ARIADNE_RATE_PER_MIN", "20"))
+_ARIADNE_GLOBAL_PER_MIN = int(os.environ.get("ARIADNE_GLOBAL_PER_MIN", "120"))
+_ARIADNE_RATE_MAX_KEYS = int(os.environ.get("ARIADNE_RATE_MAX_KEYS", "8192"))
 _ariadne_sem = asyncio.Semaphore(_ARIADNE_MAX_CONCURRENCY)
 _ariadne_hits: dict[str, list[float]] = {}
+_ariadne_global: list[float] = []
 _ariadne_rate_lock = asyncio.Lock()
 
 
@@ -1084,19 +1087,30 @@ def _ariadne_client_key(request: Request) -> str:
 
 
 async def _ariadne_rate_ok(key: str) -> bool:
-    """Sliding 60s per-client window, in-memory and ephemeral. Bounds sustained
-    single-client abuse; a stronger edge rate limit belongs at Cloudflare."""
+    """Admission for one request: a global 60s ceiling across all clients plus
+    a per-client 60s window, with the per-client map hard-capped so a flood of
+    distinct keys cannot grow memory without bound. In-memory, ephemeral,
+    single worker; a stronger edge limit still belongs at Cloudflare."""
     now = time.monotonic()
     async with _ariadne_rate_lock:
+        _ariadne_global[:] = [t for t in _ariadne_global if now - t < 60.0]
+        if len(_ariadne_global) >= _ARIADNE_GLOBAL_PER_MIN:
+            return False
         window = [t for t in _ariadne_hits.get(key, ()) if now - t < 60.0]
-        allowed = len(window) < _ARIADNE_RATE_PER_MIN
-        if allowed:
-            window.append(now)
+        if len(window) >= _ARIADNE_RATE_PER_MIN:
+            _ariadne_hits[key] = window
+            return False
+        window.append(now)
         _ariadne_hits[key] = window
-        if len(_ariadne_hits) > 4096:  # opportunistic sweep, keep the map bounded
+        _ariadne_global.append(now)
+        if len(_ariadne_hits) > _ARIADNE_RATE_MAX_KEYS:
             for stale in [k for k, v in _ariadne_hits.items() if not v or now - max(v) >= 60.0]:
                 _ariadne_hits.pop(stale, None)
-        return allowed
+            if len(_ariadne_hits) > _ARIADNE_RATE_MAX_KEYS:  # hard cap: evict oldest-active
+                overflow = len(_ariadne_hits) - _ARIADNE_RATE_MAX_KEYS
+                for k, _v in sorted(_ariadne_hits.items(), key=lambda kv: max(kv[1]))[:overflow]:
+                    _ariadne_hits.pop(k, None)
+        return True
 
 
 @app.post("/api/ariadne/chat")

--- a/ops/syrmos-api/syrmos_admin/app.py
+++ b/ops/syrmos-api/syrmos_admin/app.py
@@ -9,6 +9,7 @@ Run: uvicorn syrmos_admin.app:app --host 127.0.0.1 --port 8091
 """
 from __future__ import annotations
 
+import asyncio
 import os
 import pathlib
 import re
@@ -1057,7 +1058,14 @@ def _trigger_seed_refresh() -> None:
         pass
 
 
-# Ariadne chat (unauthenticated, rate-limited by upstream provider quotas)
+# Ariadne chat (unauthenticated). Admission control below caps total input
+# size and bounds concurrent in-flight chats so the public endpoint cannot
+# exhaust the Pi, the httpx pool, or upstream provider quotas. Per-IP rate
+# limiting belongs in nginx (follow-up).
+_ARIADNE_MAX_INPUT_CHARS = int(os.environ.get("ARIADNE_MAX_INPUT_CHARS", "6000"))
+_ARIADNE_MAX_CONCURRENCY = int(os.environ.get("ARIADNE_MAX_CONCURRENCY", "6"))
+_ariadne_sem = asyncio.Semaphore(_ARIADNE_MAX_CONCURRENCY)
+
 
 @app.post("/api/ariadne/chat")
 async def api_ariadne_chat(request: Request) -> JSONResponse:
@@ -1073,13 +1081,29 @@ async def api_ariadne_chat(request: Request) -> JSONResponse:
         raise HTTPException(status_code=400, detail="messages array required")
     if len(messages) > 20:
         messages = messages[-20:]
-    result = await ariadne_mod.chat_async(messages)
+    total_chars = sum(len(str(m.get("text", ""))) for m in messages if isinstance(m, dict))
+    if total_chars > _ARIADNE_MAX_INPUT_CHARS:
+        raise HTTPException(status_code=413, detail="input too large")
+    try:
+        await asyncio.wait_for(_ariadne_sem.acquire(), timeout=1.0)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=503, detail="assistant busy, retry shortly") from None
+    try:
+        result = await ariadne_mod.chat_async(messages)
+    finally:
+        _ariadne_sem.release()
     return JSONResponse({
         "reply": result["reply"],
         "ok": True,
         "provider": result["provider"],
         "model": result.get("model"),
     })
+
+
+@app.on_event("shutdown")
+async def _ariadne_shutdown() -> None:
+    """Close the shared Ariadne httpx client on shutdown."""
+    await ariadne_mod.providers.aclose_client()
 
 
 # Health (unauthenticated)

--- a/ops/syrmos-api/syrmos_admin/app.py
+++ b/ops/syrmos-api/syrmos_admin/app.py
@@ -10,9 +10,11 @@ Run: uvicorn syrmos_admin.app:app --host 127.0.0.1 --port 8091
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import pathlib
 import re
+import time
 import datetime as _dt
 from contextlib import contextmanager
 from html import escape as _html_escape
@@ -1064,7 +1066,37 @@ def _trigger_seed_refresh() -> None:
 # limiting belongs in nginx (follow-up).
 _ARIADNE_MAX_INPUT_CHARS = int(os.environ.get("ARIADNE_MAX_INPUT_CHARS", "6000"))
 _ARIADNE_MAX_CONCURRENCY = int(os.environ.get("ARIADNE_MAX_CONCURRENCY", "6"))
+_ARIADNE_RATE_PER_MIN = int(os.environ.get("ARIADNE_RATE_PER_MIN", "20"))
 _ariadne_sem = asyncio.Semaphore(_ARIADNE_MAX_CONCURRENCY)
+_ariadne_hits: dict[str, list[float]] = {}
+_ariadne_rate_lock = asyncio.Lock()
+
+
+def _ariadne_client_key(request: Request) -> str:
+    """Ephemeral, hashed client identity for rate limiting. Prefers the true
+    client IP behind Cloudflare; the raw IP is never stored or logged."""
+    ip = (
+        request.headers.get("cf-connecting-ip")
+        or request.headers.get("x-real-ip")
+        or (request.client.host if request.client else "unknown")
+    )
+    return hashlib.sha256(ip.encode("utf-8", "ignore")).hexdigest()[:16]
+
+
+async def _ariadne_rate_ok(key: str) -> bool:
+    """Sliding 60s per-client window, in-memory and ephemeral. Bounds sustained
+    single-client abuse; a stronger edge rate limit belongs at Cloudflare."""
+    now = time.monotonic()
+    async with _ariadne_rate_lock:
+        window = [t for t in _ariadne_hits.get(key, ()) if now - t < 60.0]
+        allowed = len(window) < _ARIADNE_RATE_PER_MIN
+        if allowed:
+            window.append(now)
+        _ariadne_hits[key] = window
+        if len(_ariadne_hits) > 4096:  # opportunistic sweep, keep the map bounded
+            for stale in [k for k, v in _ariadne_hits.items() if not v or now - max(v) >= 60.0]:
+                _ariadne_hits.pop(stale, None)
+        return allowed
 
 
 @app.post("/api/ariadne/chat")
@@ -1084,6 +1116,8 @@ async def api_ariadne_chat(request: Request) -> JSONResponse:
     total_chars = sum(len(str(m.get("text", ""))) for m in messages if isinstance(m, dict))
     if total_chars > _ARIADNE_MAX_INPUT_CHARS:
         raise HTTPException(status_code=413, detail="input too large")
+    if not await _ariadne_rate_ok(_ariadne_client_key(request)):
+        raise HTTPException(status_code=429, detail="rate limit, slow down")
     try:
         await asyncio.wait_for(_ariadne_sem.acquire(), timeout=1.0)
     except asyncio.TimeoutError:

--- a/ops/syrmos-api/syrmos_admin/ariadne.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne.py
@@ -214,6 +214,26 @@ def _to_openai_messages(messages: list[dict[str, str]]) -> list[dict[str, str]]:
     return out
 
 
+async def _build_system_text(deadline: float, loop: asyncio.AbstractEventLoop) -> str:
+    """Assemble the grounded system prompt without blocking the event loop.
+
+    _system_text() does synchronous SQLite connect/migrate/query work, so run
+    it in a worker thread and bound it by the remaining chain budget. If it is
+    slow (DB lock, migration) or errors, fall back to the no-context
+    abstention prompt so grounding can never blow the deadline or stall the
+    loop.
+    """
+    remaining = deadline - loop.time()
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(_system_text), timeout=max(0.1, remaining),
+        )
+    except asyncio.TimeoutError:
+        return SYSTEM_PROMPT + GROUNDING_NO_CONTEXT
+    except Exception:  # noqa: BLE001 - grounding must never break the reply
+        return SYSTEM_PROMPT + GROUNDING_NO_CONTEXT
+
+
 async def chat_async(messages: list[dict[str, str]]) -> dict:
     """Run the provider chain, returning the first grounded reply.
 
@@ -223,11 +243,11 @@ async def chat_async(messages: list[dict[str, str]]) -> dict:
     configured provider fails, fall back to a deterministic offline reply so
     the endpoint always answers.
     """
-    system_text = _system_text()
-    oai_messages = _to_openai_messages(messages)
-    client = providers.get_client()
     loop = asyncio.get_event_loop()
     deadline = loop.time() + providers.CHAIN_DEADLINE
+    oai_messages = _to_openai_messages(messages)
+    system_text = await _build_system_text(deadline, loop)
+    client = providers.get_client()
     for attempt, provider in enumerate(providers.build_chain(), 1):
         remaining = deadline - loop.time()
         if remaining < providers.MIN_ATTEMPT_BUDGET:

--- a/ops/syrmos-api/syrmos_admin/ariadne.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne.py
@@ -11,6 +11,7 @@ returned so the endpoint always responds.
 """
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 
 from . import ariadne_providers as providers
@@ -67,6 +68,18 @@ GROUNDING = (
     "facts below do not answer the question, say that Syrmos does not "
     "currently have enough information and point the rider to the app's "
     "planner, rather than making something up.\n\n"
+)
+
+# Used when the live DB context cannot be loaded. Keeps the abstention
+# contract in force so the model does not present the prompt's baseline
+# figures (fares, hours) as if they were current.
+GROUNDING_NO_CONTEXT = (
+    "\n\nLive Syrmos transit data is unavailable right now. Do not state "
+    "specific current departure times, fares, or service disruptions, and do "
+    "not present any figures above as if they were live. For anything "
+    "time-sensitive, tell the rider to check the app's planner or the "
+    "official operator (hellenictrain.gr, OASA). General guidance about which "
+    "lines exist and how the network connects is still fine.\n"
 )
 
 
@@ -179,11 +192,17 @@ def _get_transit_context() -> str | None:
 
 
 def _system_text() -> str:
-    """System prompt plus the grounding contract and live transit facts."""
+    """System prompt plus the grounding contract.
+
+    The abstention contract is always present. When live DB facts are
+    available they are appended under it; when they are not, an explicit
+    "no live data" note keeps the model from presenting the prompt's
+    baseline figures as current.
+    """
     transit_ctx = _get_transit_context()
     if transit_ctx:
         return SYSTEM_PROMPT + GROUNDING + transit_ctx
-    return SYSTEM_PROMPT
+    return SYSTEM_PROMPT + GROUNDING_NO_CONTEXT
 
 
 def _to_openai_messages(messages: list[dict[str, str]]) -> list[dict[str, str]]:
@@ -207,8 +226,27 @@ async def chat_async(messages: list[dict[str, str]]) -> dict:
     system_text = _system_text()
     oai_messages = _to_openai_messages(messages)
     client = providers.get_client()
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + providers.CHAIN_DEADLINE
     for attempt, provider in enumerate(providers.build_chain(), 1):
-        result = await provider.complete(client, system_text, oai_messages)
+        remaining = deadline - loop.time()
+        if remaining < providers.MIN_ATTEMPT_BUDGET:
+            break
+        try:
+            result = await asyncio.wait_for(
+                provider.complete(client, system_text, oai_messages, remaining),
+                timeout=remaining,
+            )
+        except asyncio.TimeoutError:
+            result = providers.ProviderResult(
+                provider.name, provider.model, False,
+                error_kind="timeout", error_detail="chain deadline reached",
+            )
+        except Exception as exc:  # noqa: BLE001 - contain, never abort the chain
+            result = providers.ProviderResult(
+                provider.name, provider.model, False,
+                error_kind="network", error_detail=repr(exc)[:200],
+            )
         providers.log_attempt(attempt, result)
         if result.ok:
             return {

--- a/ops/syrmos-api/syrmos_admin/ariadne.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne.py
@@ -1,48 +1,20 @@
-"""Ariadne cloud LLM backend.
+"""Ariadne assistant backend.
 
-Proxies user messages to Google Gemini Flash for the Ariadne assistant,
-unified across iOS, Android, and web. The system prompt includes Athens
-transit knowledge so answers are grounded in real data.
-
-Requires GEMINI_API_KEY env var. Falls back to a polite "offline only"
-response when the key is missing or the API is unreachable.
+Turns user messages into grounded, natural-language transit answers by
+calling a chain of OpenAI-compatible LLM providers (see ariadne_providers).
+The providers are the language layer only: schedules, departures, fares,
+station names, and disruptions come from the Syrmos database and are passed
+to the model as authoritative context. The model must not invent those
+facts and must abstain when the supplied context does not answer the
+question. If no provider is reachable, a deterministic offline reply is
+returned so the endpoint always responds.
 """
 from __future__ import annotations
 
-import json
-import logging
-import os
 import sqlite3
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
+from . import ariadne_providers as providers
 from . import db as dbmod
-
-logger = logging.getLogger("syrmos.ariadne")
-
-
-def _err_body(e: HTTPError) -> str:
-    """Short, key-free error body from a provider HTTPError (for logging)."""
-    try:
-        return e.read().decode("utf-8", "replace")[:300]
-    except Exception:
-        return "<no body>"
-
-GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "")
-GEMINI_MODEL = "gemini-flash-latest"
-GEMINI_URL = (
-    f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent"
-)
-
-GROQ_API_KEY = os.environ.get("GROQ_API_KEY", "")
-GROQ_MODEL = "openai/gpt-oss-120b"
-GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
-
-SAMBANOVA_API_KEY = os.environ.get("SAMBANOVA_API_KEY", "")
-SAMBANOVA_MODEL = "Meta-Llama-3.3-70B-Instruct"
-SAMBANOVA_URL = "https://api.sambanova.ai/v1/chat/completions"
-
-TIMEOUT_SECONDS = 15
 
 SYSTEM_PROMPT = """\
 You are Ariadne, the built-in transit assistant for Syrmos, an Athens public \
@@ -85,29 +57,17 @@ or stations."
 - Keep a friendly tone. Your mascot is an owl.
 """
 
-
-def _build_request_body(
-    messages: list[dict[str, str]],
-    transit_context: str | None = None,
-) -> dict:
-    system_text = SYSTEM_PROMPT
-    if transit_context:
-        system_text += f"\n\nCurrent transit context:\n{transit_context}"
-
-    contents = []
-    for msg in messages:
-        role = "user" if msg.get("role") == "user" else "model"
-        contents.append({"role": role, "parts": [{"text": msg["text"]}]})
-
-    return {
-        "system_instruction": {"parts": [{"text": system_text}]},
-        "contents": contents,
-        "generationConfig": {
-            "temperature": 0.7,
-            "maxOutputTokens": 300,
-            "topP": 0.9,
-        },
-    }
+# Prepended to the live DB context. Makes the grounding contract explicit so
+# the model treats the supplied facts as the only source of truth for
+# schedules/fares/stations/disruptions and abstains rather than guessing.
+GROUNDING = (
+    "\n\nAuthoritative Syrmos transit facts follow. Use ONLY these for any "
+    "claim about schedules, departure times, fares, station names, routes, "
+    "or service disruptions, and do not invent or guess such facts. If the "
+    "facts below do not answer the question, say that Syrmos does not "
+    "currently have enough information and point the rider to the app's "
+    "planner, rather than making something up.\n\n"
+)
 
 
 def _get_transit_context() -> str | None:
@@ -218,140 +178,44 @@ def _get_transit_context() -> str | None:
         return None
 
 
-def _call_gemini(
-    messages: list[dict[str, str]], transit_ctx: str | None,
-) -> str | None:
-    """Try Gemini. Returns reply text or None on failure."""
-    if not GEMINI_API_KEY:
-        return None
-    body = _build_request_body(messages, transit_ctx)
-    req = Request(
-        GEMINI_URL,
-        data=json.dumps(body).encode(),
-        headers={
-            "Content-Type": "application/json",
-            "X-goog-api-key": GEMINI_API_KEY,
-            "User-Agent": "Syrmos-Ariadne/1.0",
-        },
-        method="POST",
-    )
-    try:
-        with urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
-            result = json.loads(resp.read())
-        candidates = result.get("candidates", [])
-        if candidates:
-            parts = candidates[0].get("content", {}).get("parts", [])
-            if parts:
-                return parts[0].get("text", "").strip()
-        logger.warning("gemini: HTTP 200 but no usable candidates (blocked/empty)")
-    except HTTPError as e:
-        logger.warning("gemini HTTP %s: %s", e.code, _err_body(e))
-    except (URLError, TimeoutError, json.JSONDecodeError, KeyError) as e:
-        logger.warning("gemini call failed: %r", e)
-    return None
-
-
-def _call_groq(
-    messages: list[dict[str, str]], transit_ctx: str | None,
-) -> str | None:
-    """Try Groq (Llama). Returns reply text or None on failure."""
-    if not GROQ_API_KEY:
-        return None
-    system_text = SYSTEM_PROMPT
-    if transit_ctx:
-        system_text += f"\n\nCurrent transit context:\n{transit_ctx}"
-    oai_messages = [{"role": "system", "content": system_text}]
-    for msg in messages:
-        role = "user" if msg.get("role") == "user" else "assistant"
-        oai_messages.append({"role": role, "content": msg["text"]})
-    body = {
-        "model": GROQ_MODEL,
-        "messages": oai_messages,
-        "temperature": 0.7,
-        "max_tokens": 300,
-    }
-    req = Request(
-        GROQ_URL,
-        data=json.dumps(body).encode(),
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {GROQ_API_KEY}",
-            "User-Agent": "Syrmos-Ariadne/1.0",
-        },
-        method="POST",
-    )
-    try:
-        with urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
-            result = json.loads(resp.read())
-        choices = result.get("choices", [])
-        if choices:
-            return choices[0].get("message", {}).get("content", "").strip()
-    except HTTPError as e:
-        logger.warning("groq HTTP %s: %s", e.code, _err_body(e))
-    except (URLError, TimeoutError, json.JSONDecodeError, KeyError) as e:
-        logger.warning("groq call failed: %r", e)
-    return None
-
-
-def _call_sambanova(
-    messages: list[dict[str, str]], transit_ctx: str | None,
-) -> str | None:
-    """Try SambaNova (Llama 3.3 70B). Returns reply text or None on failure."""
-    if not SAMBANOVA_API_KEY:
-        return None
-    system_text = SYSTEM_PROMPT
-    if transit_ctx:
-        system_text += f"\n\nCurrent transit context:\n{transit_ctx}"
-    oai_messages = [{"role": "system", "content": system_text}]
-    for msg in messages:
-        role = "user" if msg.get("role") == "user" else "assistant"
-        oai_messages.append({"role": role, "content": msg["text"]})
-    body = {
-        "model": SAMBANOVA_MODEL,
-        "messages": oai_messages,
-        "temperature": 0.7,
-        "max_tokens": 300,
-    }
-    req = Request(
-        SAMBANOVA_URL,
-        data=json.dumps(body).encode(),
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {SAMBANOVA_API_KEY}",
-            "User-Agent": "Syrmos-Ariadne/1.0",
-        },
-        method="POST",
-    )
-    try:
-        with urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
-            result = json.loads(resp.read())
-        choices = result.get("choices", [])
-        if choices:
-            return choices[0].get("message", {}).get("content", "").strip()
-    except HTTPError as e:
-        logger.warning("sambanova HTTP %s: %s", e.code, _err_body(e))
-    except (URLError, TimeoutError, json.JSONDecodeError, KeyError) as e:
-        logger.warning("sambanova call failed: %r", e)
-    return None
-
-
-def chat(messages: list[dict[str, str]]) -> dict:
-    """Try providers in order of current reachability, then offline.
-
-    Groq is first because it is the working free tier right now. Gemini
-    stays as a fallback for when a valid AI Studio API key is in place
-    (an OAuth token in X-goog-api-key hangs instead of answering).
-    """
+def _system_text() -> str:
+    """System prompt plus the grounding contract and live transit facts."""
     transit_ctx = _get_transit_context()
-    reply = _call_groq(messages, transit_ctx)
-    if reply:
-        return {"reply": reply, "provider": "groq"}
-    reply = _call_gemini(messages, transit_ctx)
-    if reply:
-        return {"reply": reply, "provider": "gemini"}
-    reply = _call_sambanova(messages, transit_ctx)
-    if reply:
-        return {"reply": reply, "provider": "sambanova"}
+    if transit_ctx:
+        return SYSTEM_PROMPT + GROUNDING + transit_ctx
+    return SYSTEM_PROMPT
+
+
+def _to_openai_messages(messages: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Map Syrmos {role, text} turns to OpenAI {role, content} messages."""
+    out: list[dict[str, str]] = []
+    for msg in messages:
+        role = "user" if msg.get("role") == "user" else "assistant"
+        out.append({"role": role, "content": msg.get("text", "")})
+    return out
+
+
+async def chat_async(messages: list[dict[str, str]]) -> dict:
+    """Run the provider chain, returning the first grounded reply.
+
+    Providers are tried in configured order (Groq, Cloudflare, local
+    llama.cpp, optional extra). Each attempt is logged with provider,
+    status, latency, and token counts, but never the prompt text. If every
+    configured provider fails, fall back to a deterministic offline reply so
+    the endpoint always answers.
+    """
+    system_text = _system_text()
+    oai_messages = _to_openai_messages(messages)
+    client = providers.get_client()
+    for attempt, provider in enumerate(providers.build_chain(), 1):
+        result = await provider.complete(client, system_text, oai_messages)
+        providers.log_attempt(attempt, result)
+        if result.ok:
+            return {
+                "reply": result.text,
+                "provider": provider.name,
+                "model": provider.model,
+            }
     return {"reply": _offline_fallback(messages), "provider": "offline"}
 
 

--- a/ops/syrmos-api/syrmos_admin/ariadne_providers.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne_providers.py
@@ -9,15 +9,19 @@ env var, and a model name, nothing more.
 All calls are async (httpx.AsyncClient) so a slow or hung provider never
 blocks the FastAPI event loop, and each provider has strict connect/read
 timeouts so the chain fails over quickly. Failures are classified (config
-vs rate limit vs server vs timeout vs network) so a misconfiguration reads
-differently from a transient outage in the logs.
+vs rate limit vs server vs timeout vs network vs protocol vs empty) so a
+misconfiguration reads differently from a transient outage in the logs.
+Provider error bodies are redacted before logging so an echoed credential
+or prompt cannot leak into journald.
 """
 from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 import httpx
 
@@ -40,11 +44,15 @@ def _i(name: str, default: int) -> int:
 
 # Strict, quick timeouts for hosted providers so the chain fails over fast.
 # The local llama.cpp brain runs at a few tokens/sec, so it gets a longer
-# read budget. All are overridable from the environment after measuring real
-# latency from the Raspberry Pi in Athens.
+# read budget. CHAIN_DEADLINE bounds the whole chain to comfortably under
+# the 30s nginx proxy_read_timeout on /api/ariadne/chat, so the offline
+# reply always reaches the caller instead of a 504. All are overridable
+# from the environment after measuring real latency from the Pi in Athens.
 CONNECT_TIMEOUT = _f("ARIADNE_CONNECT_TIMEOUT", 2.0)
 READ_TIMEOUT = _f("ARIADNE_READ_TIMEOUT", 4.0)
 LOCAL_READ_TIMEOUT = _f("ARIADNE_LOCAL_READ_TIMEOUT", 25.0)
+CHAIN_DEADLINE = _f("ARIADNE_CHAIN_DEADLINE", 27.0)
+MIN_ATTEMPT_BUDGET = _f("ARIADNE_MIN_ATTEMPT_BUDGET", 1.0)
 TEMPERATURE = _f("ARIADNE_TEMPERATURE", 0.2)
 MAX_TOKENS = _i("ARIADNE_MAX_TOKENS", 400)
 LOCAL_MAX_TOKENS = _i("ARIADNE_LOCAL_MAX_TOKENS", 160)
@@ -72,6 +80,32 @@ async def aclose_client() -> None:
     _client = None
 
 
+# Credential shapes that must never reach the logs, even if a provider echoes
+# them back in an error body. Kept broad on purpose: the goal is redaction,
+# not perfect parsing.
+_SECRET_PATTERNS = [
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]+"),
+    re.compile(r"\bgsk_[A-Za-z0-9]+"),
+    re.compile(r"\bsk-[A-Za-z0-9]+"),
+    re.compile(r"\bAIza[0-9A-Za-z._\-]+"),
+    re.compile(r"\bAQ\.[A-Za-z0-9._\-]+"),
+    re.compile(r"\b[A-Za-z0-9._\-]{40,}\b"),
+]
+
+
+def _redact(text: str) -> str:
+    """Strip credential-like substrings from provider error text before it is
+    logged. The stable, human-readable part of the error (status meaning,
+    "model blocked", "payment required") survives, which is what makes the
+    logs diagnostic; only opaque token-shaped runs are masked."""
+    if not text:
+        return text
+    out = text
+    for pat in _SECRET_PATTERNS:
+        out = pat.sub("[REDACTED]", out)
+    return out
+
+
 @dataclass
 class ProviderResult:
     """Outcome of one provider attempt, carrying observability metadata."""
@@ -84,7 +118,7 @@ class ProviderResult:
     latency_ms: int | None = None
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
-    # config | rate_limit | server | client | timeout | network | empty
+    # config | rate_limit | server | client | timeout | network | protocol | empty
     error_kind: str | None = None
     error_detail: str | None = None
 
@@ -124,7 +158,13 @@ class OpenAICompatibleProvider:
         client: httpx.AsyncClient,
         system_text: str,
         messages: list[dict[str, str]],
+        timeout_override: float | None = None,
     ) -> ProviderResult:
+        # Squeeze this attempt into the remaining chain budget when close to
+        # the deadline; otherwise use the provider's own read timeout.
+        eff_read = self.read_timeout
+        if timeout_override is not None:
+            eff_read = max(0.1, min(self.read_timeout, timeout_override))
         payload = {
             "model": self.model,
             "messages": [{"role": "system", "content": system_text}, *messages],
@@ -133,10 +173,10 @@ class OpenAICompatibleProvider:
             "stream": False,
         }
         timeout = httpx.Timeout(
-            self.read_timeout,
-            connect=self.connect_timeout,
-            read=self.read_timeout,
-            write=self.read_timeout,
+            eff_read,
+            connect=min(self.connect_timeout, eff_read),
+            read=eff_read,
+            write=eff_read,
             pool=self.connect_timeout,
         )
         started = time.perf_counter()
@@ -153,12 +193,12 @@ class OpenAICompatibleProvider:
         except httpx.TimeoutException as exc:
             return ProviderResult(
                 self.name, self.model, False, latency_ms=_ms(started),
-                error_kind="timeout", error_detail=repr(exc),
+                error_kind="timeout", error_detail=_redact(repr(exc)),
             )
         except httpx.HTTPError as exc:
             return ProviderResult(
                 self.name, self.model, False, latency_ms=_ms(started),
-                error_kind="network", error_detail=repr(exc),
+                error_kind="network", error_detail=_redact(repr(exc)),
             )
 
         latency = _ms(started)
@@ -166,29 +206,52 @@ class OpenAICompatibleProvider:
             return ProviderResult(
                 self.name, self.model, False, status=resp.status_code,
                 latency_ms=latency, error_kind=_classify(resp.status_code),
-                error_detail=resp.text[:300],
+                error_detail=_redact(resp.text[:300]),
             )
         try:
             data = resp.json()
         except ValueError as exc:
             return ProviderResult(
                 self.name, self.model, False, status=200, latency_ms=latency,
-                error_kind="empty", error_detail=repr(exc),
+                error_kind="protocol", error_detail=_redact(repr(exc)),
             )
-        choices = data.get("choices") or []
+
+        # Defensive parsing: a 200 with a non-object root, malformed choices,
+        # a non-string content, or a non-object usage must degrade to a failed
+        # attempt, never an uncaught AttributeError/TypeError that would abort
+        # the whole chain and 500 the request.
         text = ""
-        if choices:
-            text = (choices[0].get("message", {}).get("content") or "").strip()
+        prompt_tokens: int | None = None
+        completion_tokens: int | None = None
+        try:
+            if isinstance(data, dict):
+                choices = data.get("choices")
+                if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+                    message = choices[0].get("message")
+                    if isinstance(message, dict):
+                        content = message.get("content")
+                        if isinstance(content, str):
+                            text = content.strip()
+                usage = data.get("usage")
+                if isinstance(usage, dict):
+                    pt = usage.get("prompt_tokens")
+                    ct = usage.get("completion_tokens")
+                    prompt_tokens = pt if isinstance(pt, int) else None
+                    completion_tokens = ct if isinstance(ct, int) else None
+        except Exception as exc:  # noqa: BLE001 - never let parsing crash the chain
+            return ProviderResult(
+                self.name, self.model, False, status=200, latency_ms=latency,
+                error_kind="protocol", error_detail=_redact(repr(exc)),
+            )
+
         if not text:
             return ProviderResult(
                 self.name, self.model, False, status=200, latency_ms=latency,
-                error_kind="empty", error_detail="no content in choices",
+                error_kind="empty", error_detail="no usable content in response",
             )
-        usage = data.get("usage") or {}
         return ProviderResult(
             self.name, self.model, True, text=text, status=200, latency_ms=latency,
-            prompt_tokens=usage.get("prompt_tokens"),
-            completion_tokens=usage.get("completion_tokens"),
+            prompt_tokens=prompt_tokens, completion_tokens=completion_tokens,
         )
 
 
@@ -200,59 +263,90 @@ def _env(*names: str) -> str:
     return ""
 
 
+def _is_https(url: str) -> bool:
+    try:
+        return urlparse(url).scheme == "https"
+    except ValueError:
+        return False
+
+
+def _is_loopback(url: str) -> bool:
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    return host in ("127.0.0.1", "localhost", "::1")
+
+
 def build_chain() -> list[OpenAICompatibleProvider]:
     """Assemble the provider chain from whatever is configured, in order.
 
     Groq (fast hosted free tier) first, then Cloudflare Workers AI, then a
     local llama.cpp server as a degraded offline brain, then an optional
     extra OpenAI-compatible provider (e.g. a paid endpoint). A provider is
-    only included when its required credentials/URL are present, so the
-    chain lights up provider by provider as configuration is added and never
-    wastes a round trip on an unconfigured backend.
+    only included when its required credentials/URL are present, so the chain
+    lights up provider by provider as configuration is added and never wastes
+    a round trip on an unconfigured backend.
+
+    Hosted providers must use HTTPS (their credential is sent as a Bearer
+    token); a plaintext override is refused so a key cannot leak in transit.
+    The local provider is allowed plaintext only to a loopback host.
     """
     chain: list[OpenAICompatibleProvider] = []
 
+    def add_hosted(name: str, base_url: str, api_key: str, model: str) -> None:
+        if not _is_https(base_url):
+            logger.warning(
+                "ariadne provider=%s skipped: base_url must be https (got %r)",
+                name, urlparse(base_url).scheme or "none",
+            )
+            return
+        chain.append(OpenAICompatibleProvider(
+            name=name, base_url=base_url, api_key=api_key, model=model,
+        ))
+
     groq_key = _env("ARIADNE_GROQ_API_KEY", "GROQ_API_KEY")
     if groq_key:
-        chain.append(OpenAICompatibleProvider(
-            name="groq",
-            base_url=_env("ARIADNE_GROQ_BASE_URL") or "https://api.groq.com/openai/v1",
-            api_key=groq_key,
-            model=_env("ARIADNE_GROQ_MODEL") or "openai/gpt-oss-120b",
-        ))
+        add_hosted(
+            "groq",
+            _env("ARIADNE_GROQ_BASE_URL") or "https://api.groq.com/openai/v1",
+            groq_key,
+            _env("ARIADNE_GROQ_MODEL") or "openai/gpt-oss-120b",
+        )
 
     cf_account = _env("CLOUDFLARE_ACCOUNT_ID", "ARIADNE_CLOUDFLARE_ACCOUNT_ID")
     cf_token = _env("CLOUDFLARE_AI_TOKEN", "ARIADNE_CLOUDFLARE_API_KEY")
     if cf_account and cf_token:
-        chain.append(OpenAICompatibleProvider(
-            name="cloudflare",
-            base_url=_env("ARIADNE_CLOUDFLARE_BASE_URL")
+        add_hosted(
+            "cloudflare",
+            _env("ARIADNE_CLOUDFLARE_BASE_URL")
             or f"https://api.cloudflare.com/client/v4/accounts/{cf_account}/ai/v1",
-            api_key=cf_token,
-            model=_env("ARIADNE_CLOUDFLARE_MODEL") or "@cf/qwen/qwen3.8-27b",
-        ))
+            cf_token,
+            _env("ARIADNE_CLOUDFLARE_MODEL") or "@cf/qwen/qwen3.8-27b",
+        )
 
     local_url = _env("ARIADNE_LOCAL_BASE_URL")
     if local_url:
-        chain.append(OpenAICompatibleProvider(
-            name="local",
-            base_url=local_url,
-            api_key=_env("ARIADNE_LOCAL_API_KEY") or "unused",
-            model=_env("ARIADNE_LOCAL_MODEL") or "Qwen3.5-2B",
-            read_timeout=LOCAL_READ_TIMEOUT,
-            max_tokens=LOCAL_MAX_TOKENS,
-        ))
+        if _is_https(local_url) or _is_loopback(local_url):
+            chain.append(OpenAICompatibleProvider(
+                name="local",
+                base_url=local_url,
+                api_key=_env("ARIADNE_LOCAL_API_KEY") or "unused",
+                model=_env("ARIADNE_LOCAL_MODEL") or "Qwen3.5-2B",
+                read_timeout=LOCAL_READ_TIMEOUT,
+                max_tokens=LOCAL_MAX_TOKENS,
+            ))
+        else:
+            logger.warning(
+                "ariadne provider=local skipped: base_url must be https or "
+                "loopback (got host %r)", urlparse(local_url).hostname or "none",
+            )
 
     extra_key = _env("ARIADNE_EXTRA_API_KEY")
     extra_url = _env("ARIADNE_EXTRA_BASE_URL")
     extra_model = _env("ARIADNE_EXTRA_MODEL")
     if extra_key and extra_url and extra_model:
-        chain.append(OpenAICompatibleProvider(
-            name=_env("ARIADNE_EXTRA_NAME") or "extra",
-            base_url=extra_url,
-            api_key=extra_key,
-            model=extra_model,
-        ))
+        add_hosted(_env("ARIADNE_EXTRA_NAME") or "extra", extra_url, extra_key, extra_model)
 
     return chain
 
@@ -261,7 +355,8 @@ def log_attempt(attempt: int, result: ProviderResult) -> None:
     """Structured, prompt-free record of one provider attempt.
 
     Failures log at WARNING so fallbacks stay visible in journald (uvicorn's
-    root logger drops INFO by default); successes log at INFO.
+    root logger drops INFO by default); successes log at INFO. The detail
+    field is already redacted of credential-shaped runs.
     """
     log = logger.info if result.ok else logger.warning
     log(

--- a/ops/syrmos-api/syrmos_admin/ariadne_providers.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne_providers.py
@@ -1,0 +1,274 @@
+"""OpenAI-compatible provider abstraction for the Ariadne assistant.
+
+Every hosted or local backend Ariadne uses (Groq, Cloudflare Workers AI, a
+local llama.cpp server, and optionally a paid OpenAI-compatible endpoint)
+speaks the same ``/v1/chat/completions`` contract, so a single provider type
+covers them all. Adding a provider means supplying a base URL, an API key
+env var, and a model name, nothing more.
+
+All calls are async (httpx.AsyncClient) so a slow or hung provider never
+blocks the FastAPI event loop, and each provider has strict connect/read
+timeouts so the chain fails over quickly. Failures are classified (config
+vs rate limit vs server vs timeout vs network) so a misconfiguration reads
+differently from a transient outage in the logs.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger("syrmos.ariadne")
+
+
+def _f(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+def _i(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+# Strict, quick timeouts for hosted providers so the chain fails over fast.
+# The local llama.cpp brain runs at a few tokens/sec, so it gets a longer
+# read budget. All are overridable from the environment after measuring real
+# latency from the Raspberry Pi in Athens.
+CONNECT_TIMEOUT = _f("ARIADNE_CONNECT_TIMEOUT", 2.0)
+READ_TIMEOUT = _f("ARIADNE_READ_TIMEOUT", 4.0)
+LOCAL_READ_TIMEOUT = _f("ARIADNE_LOCAL_READ_TIMEOUT", 25.0)
+TEMPERATURE = _f("ARIADNE_TEMPERATURE", 0.2)
+MAX_TOKENS = _i("ARIADNE_MAX_TOKENS", 400)
+LOCAL_MAX_TOKENS = _i("ARIADNE_LOCAL_MAX_TOKENS", 160)
+
+_client: httpx.AsyncClient | None = None
+
+
+def get_client() -> httpx.AsyncClient:
+    """Lazily create a shared AsyncClient so TCP/TLS connections are reused."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(
+            limits=httpx.Limits(max_keepalive_connections=8, max_connections=16),
+            headers={"User-Agent": "Syrmos-Ariadne/2.0"},
+            trust_env=False,
+        )
+    return _client
+
+
+async def aclose_client() -> None:
+    """Close the shared client (called on FastAPI shutdown)."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
+
+@dataclass
+class ProviderResult:
+    """Outcome of one provider attempt, carrying observability metadata."""
+
+    provider: str
+    model: str
+    ok: bool
+    text: str = ""
+    status: int | None = None
+    latency_ms: int | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    # config | rate_limit | server | client | timeout | network | empty
+    error_kind: str | None = None
+    error_detail: str | None = None
+
+
+def _classify(status: int) -> str:
+    if status in (401, 403):
+        return "config"
+    if status == 429:
+        return "rate_limit"
+    if status >= 500:
+        return "server"
+    return "client"
+
+
+def _ms(started: float) -> int:
+    return int((time.perf_counter() - started) * 1000)
+
+
+@dataclass
+class OpenAICompatibleProvider:
+    """A single ``/v1/chat/completions`` backend behind a uniform interface."""
+
+    name: str
+    base_url: str
+    api_key: str
+    model: str
+    read_timeout: float = READ_TIMEOUT
+    connect_timeout: float = CONNECT_TIMEOUT
+    max_tokens: int = MAX_TOKENS
+
+    @property
+    def endpoint(self) -> str:
+        return self.base_url.rstrip("/") + "/chat/completions"
+
+    async def complete(
+        self,
+        client: httpx.AsyncClient,
+        system_text: str,
+        messages: list[dict[str, str]],
+    ) -> ProviderResult:
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "system", "content": system_text}, *messages],
+            "temperature": TEMPERATURE,
+            "max_tokens": self.max_tokens,
+            "stream": False,
+        }
+        timeout = httpx.Timeout(
+            self.read_timeout,
+            connect=self.connect_timeout,
+            read=self.read_timeout,
+            write=self.read_timeout,
+            pool=self.connect_timeout,
+        )
+        started = time.perf_counter()
+        try:
+            resp = await client.post(
+                self.endpoint,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=timeout,
+            )
+        except httpx.TimeoutException as exc:
+            return ProviderResult(
+                self.name, self.model, False, latency_ms=_ms(started),
+                error_kind="timeout", error_detail=repr(exc),
+            )
+        except httpx.HTTPError as exc:
+            return ProviderResult(
+                self.name, self.model, False, latency_ms=_ms(started),
+                error_kind="network", error_detail=repr(exc),
+            )
+
+        latency = _ms(started)
+        if resp.status_code != 200:
+            return ProviderResult(
+                self.name, self.model, False, status=resp.status_code,
+                latency_ms=latency, error_kind=_classify(resp.status_code),
+                error_detail=resp.text[:300],
+            )
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            return ProviderResult(
+                self.name, self.model, False, status=200, latency_ms=latency,
+                error_kind="empty", error_detail=repr(exc),
+            )
+        choices = data.get("choices") or []
+        text = ""
+        if choices:
+            text = (choices[0].get("message", {}).get("content") or "").strip()
+        if not text:
+            return ProviderResult(
+                self.name, self.model, False, status=200, latency_ms=latency,
+                error_kind="empty", error_detail="no content in choices",
+            )
+        usage = data.get("usage") or {}
+        return ProviderResult(
+            self.name, self.model, True, text=text, status=200, latency_ms=latency,
+            prompt_tokens=usage.get("prompt_tokens"),
+            completion_tokens=usage.get("completion_tokens"),
+        )
+
+
+def _env(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def build_chain() -> list[OpenAICompatibleProvider]:
+    """Assemble the provider chain from whatever is configured, in order.
+
+    Groq (fast hosted free tier) first, then Cloudflare Workers AI, then a
+    local llama.cpp server as a degraded offline brain, then an optional
+    extra OpenAI-compatible provider (e.g. a paid endpoint). A provider is
+    only included when its required credentials/URL are present, so the
+    chain lights up provider by provider as configuration is added and never
+    wastes a round trip on an unconfigured backend.
+    """
+    chain: list[OpenAICompatibleProvider] = []
+
+    groq_key = _env("ARIADNE_GROQ_API_KEY", "GROQ_API_KEY")
+    if groq_key:
+        chain.append(OpenAICompatibleProvider(
+            name="groq",
+            base_url=_env("ARIADNE_GROQ_BASE_URL") or "https://api.groq.com/openai/v1",
+            api_key=groq_key,
+            model=_env("ARIADNE_GROQ_MODEL") or "openai/gpt-oss-120b",
+        ))
+
+    cf_account = _env("CLOUDFLARE_ACCOUNT_ID", "ARIADNE_CLOUDFLARE_ACCOUNT_ID")
+    cf_token = _env("CLOUDFLARE_AI_TOKEN", "ARIADNE_CLOUDFLARE_API_KEY")
+    if cf_account and cf_token:
+        chain.append(OpenAICompatibleProvider(
+            name="cloudflare",
+            base_url=_env("ARIADNE_CLOUDFLARE_BASE_URL")
+            or f"https://api.cloudflare.com/client/v4/accounts/{cf_account}/ai/v1",
+            api_key=cf_token,
+            model=_env("ARIADNE_CLOUDFLARE_MODEL") or "@cf/qwen/qwen3.8-27b",
+        ))
+
+    local_url = _env("ARIADNE_LOCAL_BASE_URL")
+    if local_url:
+        chain.append(OpenAICompatibleProvider(
+            name="local",
+            base_url=local_url,
+            api_key=_env("ARIADNE_LOCAL_API_KEY") or "unused",
+            model=_env("ARIADNE_LOCAL_MODEL") or "Qwen3.5-2B",
+            read_timeout=LOCAL_READ_TIMEOUT,
+            max_tokens=LOCAL_MAX_TOKENS,
+        ))
+
+    extra_key = _env("ARIADNE_EXTRA_API_KEY")
+    extra_url = _env("ARIADNE_EXTRA_BASE_URL")
+    extra_model = _env("ARIADNE_EXTRA_MODEL")
+    if extra_key and extra_url and extra_model:
+        chain.append(OpenAICompatibleProvider(
+            name=_env("ARIADNE_EXTRA_NAME") or "extra",
+            base_url=extra_url,
+            api_key=extra_key,
+            model=extra_model,
+        ))
+
+    return chain
+
+
+def log_attempt(attempt: int, result: ProviderResult) -> None:
+    """Structured, prompt-free record of one provider attempt.
+
+    Failures log at WARNING so fallbacks stay visible in journald (uvicorn's
+    root logger drops INFO by default); successes log at INFO.
+    """
+    log = logger.info if result.ok else logger.warning
+    log(
+        "ariadne attempt=%d provider=%s model=%s ok=%s status=%s "
+        "latency_ms=%s ptok=%s ctok=%s error=%s detail=%s",
+        attempt, result.provider, result.model, result.ok, result.status,
+        result.latency_ms, result.prompt_tokens, result.completion_tokens,
+        result.error_kind or "-",
+        "-" if result.ok else (result.error_detail or "").replace("\n", " ")[:200],
+    )

--- a/ops/syrmos-api/syrmos_admin/ariadne_providers.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne_providers.py
@@ -90,7 +90,7 @@ async def aclose_client() -> None:
 _SECRET_PATTERNS = [
     re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]+"),
     re.compile(r"\bgsk_[A-Za-z0-9]+"),
-    re.compile(r"\bsk-[A-Za-z0-9]+"),
+    re.compile(r"\bsk-[A-Za-z0-9\-]+"),
     re.compile(r"\bAIza[0-9A-Za-z._\-]+"),
     re.compile(r"\bAQ\.[A-Za-z0-9._\-]+"),
     re.compile(r"\b[A-Za-z0-9._\-]{40,}\b"),
@@ -110,35 +110,47 @@ def _redact(text: str) -> str:
     return out
 
 
-def _error_summary(resp: httpx.Response) -> str:
-    """Diagnostic summary of a non-200 body without logging it wholesale.
+_SAFE_CODE = re.compile(r"^[A-Za-z0-9_.\-]{1,64}$")
 
-    OpenAI-compatible and Cloudflare errors carry a stable ``error.code`` /
-    ``error.message`` (or ``errors[]``); those are the allowlisted fields we
-    log (still redacted). Arbitrary or non-JSON bodies, which could echo a
-    prompt or PII, are suppressed unless ARIADNE_LOG_RAW_BODIES is set.
-    """
+
+def _extract_error_code(resp: httpx.Response) -> str | None:
+    """The provider's stable error code, if present and shaped like a safe
+    enum token. Codes are provider-defined identifiers (``model_not_found``,
+    ``PAYMENT_METHOD_REQUIRED``, ``7000``), not free-form text, so they are
+    safe to log; anything containing spaces, ``@``, or other free-form
+    content is rejected."""
     try:
         data = resp.json()
     except ValueError:
-        data = None
-    if isinstance(data, dict):
-        err = data.get("error")
-        if isinstance(err, dict):
-            parts = [str(err.get(k)) for k in ("code", "message") if err.get(k)]
-            if parts:
-                return _redact(" ".join(parts))[:300]
-        if isinstance(err, str) and err:
-            return _redact(err)[:300]
-        errs = data.get("errors")
-        if isinstance(errs, list) and errs and isinstance(errs[0], dict):
-            e0 = errs[0]
-            parts = [str(e0.get(k)) for k in ("code", "message") if e0.get(k)]
-            if parts:
-                return _redact(" ".join(parts))[:300]
+        return None
+    if not isinstance(data, dict):
+        return None
+    containers = [data.get("error")]
+    errs = data.get("errors")
+    if isinstance(errs, list) and errs:
+        containers.append(errs[0])
+    for container in containers:
+        if isinstance(container, dict):
+            code = container.get("code")
+            if code is not None and _SAFE_CODE.match(str(code)):
+                return str(code)
+    return None
+
+
+def _error_summary(resp: httpx.Response) -> str:
+    """Non-free-form diagnostic for a non-200.
+
+    Logs only the provider's stable error code (a safe enum token). The
+    provider-supplied free-form message and the raw body are never logged,
+    since they are provider-controlled and can echo prompt text or PII,
+    unless ARIADNE_LOG_RAW_BODIES is explicitly set for debugging.
+    """
+    code = _extract_error_code(resp)
+    if code:
+        return f"code={code}"
     if LOG_RAW_BODIES:
         return _redact(resp.text[:300])
-    return "unstructured error body suppressed"
+    return "error body suppressed"
 
 
 @dataclass

--- a/ops/syrmos-api/syrmos_admin/ariadne_providers.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne_providers.py
@@ -56,6 +56,10 @@ MIN_ATTEMPT_BUDGET = _f("ARIADNE_MIN_ATTEMPT_BUDGET", 1.0)
 TEMPERATURE = _f("ARIADNE_TEMPERATURE", 0.2)
 MAX_TOKENS = _i("ARIADNE_MAX_TOKENS", 400)
 LOCAL_MAX_TOKENS = _i("ARIADNE_LOCAL_MAX_TOKENS", 160)
+# When off (default), only the stable structured error fields are logged, not
+# the raw provider body, so an echoed prompt/PII cannot be persisted. Set to
+# "1" in a non-production environment to capture full bodies for debugging.
+LOG_RAW_BODIES = os.environ.get("ARIADNE_LOG_RAW_BODIES", "") == "1"
 
 _client: httpx.AsyncClient | None = None
 
@@ -104,6 +108,37 @@ def _redact(text: str) -> str:
     for pat in _SECRET_PATTERNS:
         out = pat.sub("[REDACTED]", out)
     return out
+
+
+def _error_summary(resp: httpx.Response) -> str:
+    """Diagnostic summary of a non-200 body without logging it wholesale.
+
+    OpenAI-compatible and Cloudflare errors carry a stable ``error.code`` /
+    ``error.message`` (or ``errors[]``); those are the allowlisted fields we
+    log (still redacted). Arbitrary or non-JSON bodies, which could echo a
+    prompt or PII, are suppressed unless ARIADNE_LOG_RAW_BODIES is set.
+    """
+    try:
+        data = resp.json()
+    except ValueError:
+        data = None
+    if isinstance(data, dict):
+        err = data.get("error")
+        if isinstance(err, dict):
+            parts = [str(err.get(k)) for k in ("code", "message") if err.get(k)]
+            if parts:
+                return _redact(" ".join(parts))[:300]
+        if isinstance(err, str) and err:
+            return _redact(err)[:300]
+        errs = data.get("errors")
+        if isinstance(errs, list) and errs and isinstance(errs[0], dict):
+            e0 = errs[0]
+            parts = [str(e0.get(k)) for k in ("code", "message") if e0.get(k)]
+            if parts:
+                return _redact(" ".join(parts))[:300]
+    if LOG_RAW_BODIES:
+        return _redact(resp.text[:300])
+    return "unstructured error body suppressed"
 
 
 @dataclass
@@ -206,7 +241,7 @@ class OpenAICompatibleProvider:
             return ProviderResult(
                 self.name, self.model, False, status=resp.status_code,
                 latency_ms=latency, error_kind=_classify(resp.status_code),
-                error_detail=_redact(resp.text[:300]),
+                error_detail=_error_summary(resp),
             )
         try:
             data = resp.json()

--- a/ops/syrmos-api/tests/test_ariadne_providers.py
+++ b/ops/syrmos-api/tests/test_ariadne_providers.py
@@ -1,0 +1,199 @@
+"""Tests for the Ariadne OpenAI-compatible provider chain.
+
+Uses httpx.MockTransport so no network is touched: each test injects a
+canned HTTP response (or exception) and asserts the provider classifies it
+correctly (success, config error, rate limit, server error, timeout,
+network, empty) and that the chain fails over and finally falls back to a
+deterministic offline reply.
+"""
+import os
+import unittest
+from unittest import mock
+
+import httpx
+
+from syrmos_admin import ariadne_providers as ap
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _ok_response(content="Take the M3 from Syntagma.", ptok=42, ctok=9):
+    return httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"role": "assistant", "content": content}}],
+            "usage": {"prompt_tokens": ptok, "completion_tokens": ctok},
+        },
+    )
+
+
+PROVIDER = ap.OpenAICompatibleProvider(
+    name="test", base_url="https://api.example.com/v1", api_key="k", model="m",
+)
+SYS = "system"
+MSGS = [{"role": "user", "content": "how do I get to the airport?"}]
+
+
+class ProviderResultTest(unittest.IsolatedAsyncioTestCase):
+    async def test_success_parses_text_and_usage(self):
+        async def handler(request):
+            self.assertEqual(request.url.path, "/v1/chat/completions")
+            self.assertEqual(request.headers["authorization"], "Bearer k")
+            self.assertIn(b'"model":"m"', request.content)
+            return _ok_response()
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.text, "Take the M3 from Syntagma.")
+        self.assertEqual(r.prompt_tokens, 42)
+        self.assertEqual(r.completion_tokens, 9)
+        self.assertEqual(r.status, 200)
+        self.assertIsNotNone(r.latency_ms)
+
+    async def test_403_is_config_error(self):
+        async def handler(request):
+            return httpx.Response(403, json={"error": {"message": "blocked at org level"}})
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error_kind, "config")
+        self.assertEqual(r.status, 403)
+
+    async def test_401_is_config_error(self):
+        async def handler(request):
+            return httpx.Response(401, text="bad key")
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertEqual(r.error_kind, "config")
+
+    async def test_429_is_rate_limit(self):
+        async def handler(request):
+            return httpx.Response(429, text="slow down")
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error_kind, "rate_limit")
+
+    async def test_500_is_server(self):
+        async def handler(request):
+            return httpx.Response(500, text="boom")
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error_kind, "server")
+
+    async def test_timeout(self):
+        async def handler(request):
+            raise httpx.ReadTimeout("timed out", request=request)
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error_kind, "timeout")
+
+    async def test_network_error(self):
+        async def handler(request):
+            raise httpx.ConnectError("no route", request=request)
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error_kind, "network")
+
+    async def test_empty_choices_is_empty(self):
+        async def handler(request):
+            return httpx.Response(200, json={"choices": []})
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error_kind, "empty")
+
+    async def test_blank_content_is_empty(self):
+        async def handler(request):
+            return httpx.Response(200, json={"choices": [{"message": {"content": "   "}}]})
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error_kind, "empty")
+
+
+_PROVIDER_ENV_PREFIXES = ("ARIADNE_", "GROQ_", "CLOUDFLARE_", "SAMBANOVA_", "GEMINI_")
+
+
+class BuildChainTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = {
+            k: os.environ.pop(k)
+            for k in list(os.environ)
+            if k.startswith(_PROVIDER_ENV_PREFIXES)
+        }
+
+    def tearDown(self):
+        for k in list(os.environ):
+            if k.startswith(_PROVIDER_ENV_PREFIXES):
+                os.environ.pop(k)
+        os.environ.update(self._saved)
+
+    def test_empty_when_nothing_configured(self):
+        self.assertEqual(ap.build_chain(), [])
+
+    def test_groq_only_uses_production_model(self):
+        os.environ["GROQ_API_KEY"] = "gsk_x"
+        chain = ap.build_chain()
+        self.assertEqual([p.name for p in chain], ["groq"])
+        self.assertEqual(chain[0].model, "openai/gpt-oss-120b")
+        self.assertEqual(chain[0].base_url, "https://api.groq.com/openai/v1")
+
+    def test_cloudflare_needs_both_account_and_token(self):
+        os.environ["CLOUDFLARE_ACCOUNT_ID"] = "acc"
+        self.assertEqual(ap.build_chain(), [])  # token missing -> not included
+
+    def test_full_order_and_local_timeout(self):
+        os.environ["ARIADNE_GROQ_API_KEY"] = "gsk_x"
+        os.environ["CLOUDFLARE_ACCOUNT_ID"] = "acc"
+        os.environ["CLOUDFLARE_AI_TOKEN"] = "tok"
+        os.environ["ARIADNE_LOCAL_BASE_URL"] = "http://127.0.0.1:8081/v1"
+        chain = ap.build_chain()
+        self.assertEqual([p.name for p in chain], ["groq", "cloudflare", "local"])
+        self.assertIn("accounts/acc/ai/v1", chain[1].base_url)
+        self.assertEqual(chain[2].read_timeout, ap.LOCAL_READ_TIMEOUT)
+
+
+class ChatAsyncTest(unittest.IsolatedAsyncioTestCase):
+    class _Stub:
+        def __init__(self, name, ok):
+            self.name = name
+            self.model = name + "-model"
+            self._ok = ok
+
+        async def complete(self, client, system_text, messages):
+            return ap.ProviderResult(
+                self.name, self.model, self._ok,
+                text=("hi from " + self.name) if self._ok else "",
+                error_kind=None if self._ok else "server",
+            )
+
+    async def test_returns_first_successful_provider(self):
+        from syrmos_admin import ariadne
+        chain = [self._Stub("a", False), self._Stub("b", True), self._Stub("c", True)]
+        with mock.patch.object(ariadne.providers, "build_chain", lambda: chain), \
+                mock.patch.object(ariadne.providers, "get_client", lambda: None), \
+                mock.patch.object(ariadne, "_get_transit_context", lambda: None):
+            out = await ariadne.chat_async([{"role": "user", "text": "hi"}])
+        self.assertEqual(out["provider"], "b")
+        self.assertEqual(out["reply"], "hi from b")
+        self.assertEqual(out["model"], "b-model")
+
+    async def test_all_fail_falls_back_offline(self):
+        from syrmos_admin import ariadne
+        chain = [self._Stub("a", False), self._Stub("b", False)]
+        with mock.patch.object(ariadne.providers, "build_chain", lambda: chain), \
+                mock.patch.object(ariadne.providers, "get_client", lambda: None), \
+                mock.patch.object(ariadne, "_get_transit_context", lambda: None):
+            out = await ariadne.chat_async([{"role": "user", "text": "are you serious"}])
+        self.assertEqual(out["provider"], "offline")
+        self.assertIn("brain", out["reply"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/syrmos-api/tests/test_ariadne_providers.py
+++ b/ops/syrmos-api/tests/test_ariadne_providers.py
@@ -158,6 +158,23 @@ class BuildChainTest(unittest.TestCase):
         self.assertIn("accounts/acc/ai/v1", chain[1].base_url)
         self.assertEqual(chain[2].read_timeout, ap.LOCAL_READ_TIMEOUT)
 
+    def test_hosted_http_override_is_skipped(self):
+        os.environ["GROQ_API_KEY"] = "gsk_x"
+        os.environ["ARIADNE_GROQ_BASE_URL"] = "http://insecure.example/v1"
+        self.assertEqual(ap.build_chain(), [])  # plaintext hosted -> refused
+
+    def test_hosted_https_is_kept(self):
+        os.environ["GROQ_API_KEY"] = "gsk_x"
+        self.assertEqual([p.name for p in ap.build_chain()], ["groq"])
+
+    def test_local_loopback_http_allowed(self):
+        os.environ["ARIADNE_LOCAL_BASE_URL"] = "http://127.0.0.1:8081/v1"
+        self.assertEqual([p.name for p in ap.build_chain()], ["local"])
+
+    def test_local_non_loopback_http_skipped(self):
+        os.environ["ARIADNE_LOCAL_BASE_URL"] = "http://evil.example/v1"
+        self.assertEqual(ap.build_chain(), [])
+
 
 class ChatAsyncTest(unittest.IsolatedAsyncioTestCase):
     class _Stub:
@@ -166,7 +183,7 @@ class ChatAsyncTest(unittest.IsolatedAsyncioTestCase):
             self.model = name + "-model"
             self._ok = ok
 
-        async def complete(self, client, system_text, messages):
+        async def complete(self, client, system_text, messages, timeout_override=None):
             return ap.ProviderResult(
                 self.name, self.model, self._ok,
                 text=("hi from " + self.name) if self._ok else "",
@@ -193,6 +210,100 @@ class ChatAsyncTest(unittest.IsolatedAsyncioTestCase):
             out = await ariadne.chat_async([{"role": "user", "text": "are you serious"}])
         self.assertEqual(out["provider"], "offline")
         self.assertIn("brain", out["reply"].lower())
+
+
+class MalformedResponseTest(unittest.IsolatedAsyncioTestCase):
+    """A 200 with an unexpected shape must degrade to a failed attempt, never
+    raise out of complete() and abort the chain."""
+
+    async def _complete(self, payload):
+        async def handler(request):
+            return httpx.Response(200, json=payload)
+        return await PROVIDER.complete(_client(handler), SYS, MSGS)
+
+    async def test_non_object_root(self):
+        r = await self._complete(["not", "an", "object"])
+        self.assertFalse(r.ok)
+
+    async def test_choices_not_a_list(self):
+        r = await self._complete({"choices": "nope"})
+        self.assertFalse(r.ok)
+
+    async def test_choice_not_a_dict(self):
+        r = await self._complete({"choices": ["oops"]})
+        self.assertFalse(r.ok)
+
+    async def test_content_not_a_string(self):
+        r = await self._complete({"choices": [{"message": {"content": {"x": 1}}}]})
+        self.assertFalse(r.ok)
+
+    async def test_bad_usage_does_not_crash_a_good_reply(self):
+        r = await self._complete({"choices": [{"message": {"content": "M3."}}], "usage": [1, 2]})
+        self.assertTrue(r.ok)
+        self.assertEqual(r.text, "M3.")
+        self.assertIsNone(r.prompt_tokens)
+
+
+class RedactUnitTest(unittest.TestCase):
+    def test_masks_bearer_and_key_shapes(self):
+        s = ap._redact("Bearer gsk_abcdefghijklmnop then AIzaSy0123456789abcdefghij and sk-abcdefzz")
+        self.assertNotIn("gsk_abcdefghijklmnop", s)
+        self.assertNotIn("AIzaSy0123456789", s)
+        self.assertIn("[REDACTED]", s)
+
+    def test_keeps_plain_diagnostic_text(self):
+        s = ap._redact("The model is blocked at the organization level")
+        self.assertEqual(s, "The model is blocked at the organization level")
+
+
+class RedactionInErrorTest(unittest.IsolatedAsyncioTestCase):
+    async def test_error_body_secrets_are_redacted(self):
+        leaky = "rejected: Authorization Bearer gsk_supersecretkey1234567890 invalid"
+
+        async def handler(request):
+            return httpx.Response(400, text=leaky)
+
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        self.assertFalse(r.ok)
+        self.assertNotIn("gsk_supersecretkey1234567890", r.error_detail)
+        self.assertIn("[REDACTED]", r.error_detail)
+
+
+class GroundingTest(unittest.TestCase):
+    def test_no_context_still_carries_abstention(self):
+        from syrmos_admin import ariadne
+        with mock.patch.object(ariadne, "_get_transit_context", lambda: None):
+            text = ariadne._system_text()
+        self.assertIn("Live Syrmos transit data is unavailable", text)
+        self.assertIn("hellenictrain.gr", text)
+
+    def test_with_context_includes_grounding_and_facts(self):
+        from syrmos_admin import ariadne
+        with mock.patch.object(ariadne, "_get_transit_context", lambda: "Active lines:\n- M1"):
+            text = ariadne._system_text()
+        self.assertIn("Use ONLY these", text)
+        self.assertIn("Active lines", text)
+
+
+class ChainDeadlineTest(unittest.IsolatedAsyncioTestCase):
+    class _SlowStub:
+        name = "slow"
+        model = "slow"
+
+        async def complete(self, client, system_text, messages, timeout_override=None):
+            import asyncio
+            await asyncio.sleep(5)  # far longer than the (patched) deadline
+            return ap.ProviderResult("slow", "slow", True, text="too late")
+
+    async def test_deadline_forces_offline(self):
+        from syrmos_admin import ariadne
+        with mock.patch.object(ariadne.providers, "build_chain", lambda: [self._SlowStub()]), \
+                mock.patch.object(ariadne.providers, "get_client", lambda: None), \
+                mock.patch.object(ariadne.providers, "CHAIN_DEADLINE", 0.2), \
+                mock.patch.object(ariadne.providers, "MIN_ATTEMPT_BUDGET", 0.05), \
+                mock.patch.object(ariadne, "_get_transit_context", lambda: None):
+            out = await ariadne.chat_async([{"role": "user", "text": "hi"}])
+        self.assertEqual(out["provider"], "offline")
 
 
 if __name__ == "__main__":

--- a/ops/syrmos-api/tests/test_ariadne_providers.py
+++ b/ops/syrmos-api/tests/test_ariadne_providers.py
@@ -256,11 +256,16 @@ class RedactUnitTest(unittest.TestCase):
         s = ap._redact("The model is blocked at the organization level")
         self.assertEqual(s, "The model is blocked at the organization level")
 
+    def test_masks_hyphenated_openai_key(self):
+        s = ap._redact("token sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 end")
+        self.assertNotIn("sk-proj-abcdefghijklmnopqrstuvwxyz1234567890", s)
+        self.assertIn("[REDACTED]", s)
+
 
 class RedactionInErrorTest(unittest.IsolatedAsyncioTestCase):
-    async def test_structured_error_message_secrets_redacted(self):
-        # A provider echoes a key inside its structured error message; the
-        # human-readable part survives as diagnosis but the key is redacted.
+    async def test_secret_in_message_is_not_logged(self):
+        # A provider echoes a key in its free-form message; with code-only
+        # logging the whole message (and the key) is dropped, not just masked.
         async def handler(request):
             return httpx.Response(400, json={"error": {
                 "message": "bad key gsk_supersecretkey1234567890 rejected"}})
@@ -268,8 +273,7 @@ class RedactionInErrorTest(unittest.IsolatedAsyncioTestCase):
         r = await PROVIDER.complete(_client(handler), SYS, MSGS)
         self.assertFalse(r.ok)
         self.assertNotIn("gsk_supersecretkey1234567890", r.error_detail)
-        self.assertIn("[REDACTED]", r.error_detail)
-        self.assertIn("rejected", r.error_detail)
+        self.assertEqual(r.error_detail, "error body suppressed")
 
 
 class GroundingTest(unittest.TestCase):
@@ -310,8 +314,8 @@ class ChainDeadlineTest(unittest.IsolatedAsyncioTestCase):
 
 
 class ErrorSummaryTest(unittest.IsolatedAsyncioTestCase):
-    """Only stable structured error fields are logged; arbitrary bodies that
-    could echo a prompt or PII are suppressed by default."""
+    """Only the provider's stable error code is logged; free-form messages and
+    arbitrary bodies (which can echo prompt text or PII) are suppressed."""
 
     async def _detail(self, status, **kw):
         async def handler(request):
@@ -319,27 +323,40 @@ class ErrorSummaryTest(unittest.IsolatedAsyncioTestCase):
         r = await PROVIDER.complete(_client(handler), SYS, MSGS)
         return r.error_detail
 
-    async def test_openai_error_message_kept(self):
+    async def test_only_code_logged_not_message(self):
         detail = await self._detail(403, json={"error": {
             "code": "model_permission_blocked_org",
-            "message": "The model is blocked at the organization level",
+            "message": "user a@b.com sent this exact prompt",
         }})
-        self.assertIn("blocked at the organization level", detail)
-        self.assertIn("model_permission_blocked_org", detail)
+        self.assertEqual(detail, "code=model_permission_blocked_org")
+        self.assertNotIn("a@b.com", detail)
+        self.assertNotIn("prompt", detail)
 
-    async def test_cloudflare_errors_list_kept(self):
+    async def test_cloudflare_numeric_code_logged(self):
         detail = await self._detail(400, json={"errors": [{"code": 7000, "message": "No route for that URI"}]})
-        self.assertIn("No route", detail)
+        self.assertEqual(detail, "code=7000")
+        self.assertNotIn("No route", detail)
 
-    async def test_plaintext_body_with_pii_suppressed(self):
+    async def test_message_only_error_suppressed(self):
+        detail = await self._detail(400, json={"error": {"message": "email a@b.com in the prompt"}})
+        self.assertNotIn("a@b.com", detail)
+        self.assertEqual(detail, "error body suppressed")
+
+    async def test_unsafe_code_shape_rejected(self):
+        detail = await self._detail(400, json={"error": {"code": "contains spaces and a@b.com"}})
+        self.assertNotIn("a@b.com", detail)
+        self.assertEqual(detail, "error body suppressed")
+
+    async def test_plaintext_body_suppressed(self):
         detail = await self._detail(400, text="user email a@b.com password hunter2 rejected")
         self.assertNotIn("a@b.com", detail)
         self.assertNotIn("hunter2", detail)
-        self.assertEqual(detail, "unstructured error body suppressed")
+        self.assertEqual(detail, "error body suppressed")
 
     async def test_json_without_error_shape_suppressed(self):
         detail = await self._detail(400, json={"detail": "contact a@b.com"})
         self.assertNotIn("a@b.com", detail)
+        self.assertEqual(detail, "error body suppressed")
 
 
 class GroundingDeadlineTest(unittest.IsolatedAsyncioTestCase):
@@ -366,6 +383,7 @@ class RateLimitTest(unittest.IsolatedAsyncioTestCase):
         from syrmos_admin import app as appmod
         with mock.patch.object(appmod, "_ARIADNE_RATE_PER_MIN", 3):
             appmod._ariadne_hits.clear()
+            appmod._ariadne_global.clear()
             results = [await appmod._ariadne_rate_ok("client-abc") for _ in range(4)]
         self.assertEqual(results, [True, True, True, False])
 
@@ -373,9 +391,19 @@ class RateLimitTest(unittest.IsolatedAsyncioTestCase):
         from syrmos_admin import app as appmod
         with mock.patch.object(appmod, "_ARIADNE_RATE_PER_MIN", 1):
             appmod._ariadne_hits.clear()
+            appmod._ariadne_global.clear()
             self.assertTrue(await appmod._ariadne_rate_ok("client-a"))
             self.assertTrue(await appmod._ariadne_rate_ok("client-b"))
             self.assertFalse(await appmod._ariadne_rate_ok("client-a"))
+
+    async def test_global_ceiling_blocks_across_distinct_clients(self):
+        from syrmos_admin import app as appmod
+        with mock.patch.object(appmod, "_ARIADNE_RATE_PER_MIN", 100), \
+                mock.patch.object(appmod, "_ARIADNE_GLOBAL_PER_MIN", 3):
+            appmod._ariadne_hits.clear()
+            appmod._ariadne_global.clear()
+            results = [await appmod._ariadne_rate_ok(f"client-{i}") for i in range(4)]
+        self.assertEqual(results, [True, True, True, False])
 
 
 if __name__ == "__main__":

--- a/ops/syrmos-api/tests/test_ariadne_providers.py
+++ b/ops/syrmos-api/tests/test_ariadne_providers.py
@@ -6,6 +6,7 @@ correctly (success, config error, rate limit, server error, timeout,
 network, empty) and that the chain fails over and finally falls back to a
 deterministic offline reply.
 """
+import asyncio
 import os
 import unittest
 from unittest import mock
@@ -257,16 +258,18 @@ class RedactUnitTest(unittest.TestCase):
 
 
 class RedactionInErrorTest(unittest.IsolatedAsyncioTestCase):
-    async def test_error_body_secrets_are_redacted(self):
-        leaky = "rejected: Authorization Bearer gsk_supersecretkey1234567890 invalid"
-
+    async def test_structured_error_message_secrets_redacted(self):
+        # A provider echoes a key inside its structured error message; the
+        # human-readable part survives as diagnosis but the key is redacted.
         async def handler(request):
-            return httpx.Response(400, text=leaky)
+            return httpx.Response(400, json={"error": {
+                "message": "bad key gsk_supersecretkey1234567890 rejected"}})
 
         r = await PROVIDER.complete(_client(handler), SYS, MSGS)
         self.assertFalse(r.ok)
         self.assertNotIn("gsk_supersecretkey1234567890", r.error_detail)
         self.assertIn("[REDACTED]", r.error_detail)
+        self.assertIn("rejected", r.error_detail)
 
 
 class GroundingTest(unittest.TestCase):
@@ -304,6 +307,75 @@ class ChainDeadlineTest(unittest.IsolatedAsyncioTestCase):
                 mock.patch.object(ariadne, "_get_transit_context", lambda: None):
             out = await ariadne.chat_async([{"role": "user", "text": "hi"}])
         self.assertEqual(out["provider"], "offline")
+
+
+class ErrorSummaryTest(unittest.IsolatedAsyncioTestCase):
+    """Only stable structured error fields are logged; arbitrary bodies that
+    could echo a prompt or PII are suppressed by default."""
+
+    async def _detail(self, status, **kw):
+        async def handler(request):
+            return httpx.Response(status, **kw)
+        r = await PROVIDER.complete(_client(handler), SYS, MSGS)
+        return r.error_detail
+
+    async def test_openai_error_message_kept(self):
+        detail = await self._detail(403, json={"error": {
+            "code": "model_permission_blocked_org",
+            "message": "The model is blocked at the organization level",
+        }})
+        self.assertIn("blocked at the organization level", detail)
+        self.assertIn("model_permission_blocked_org", detail)
+
+    async def test_cloudflare_errors_list_kept(self):
+        detail = await self._detail(400, json={"errors": [{"code": 7000, "message": "No route for that URI"}]})
+        self.assertIn("No route", detail)
+
+    async def test_plaintext_body_with_pii_suppressed(self):
+        detail = await self._detail(400, text="user email a@b.com password hunter2 rejected")
+        self.assertNotIn("a@b.com", detail)
+        self.assertNotIn("hunter2", detail)
+        self.assertEqual(detail, "unstructured error body suppressed")
+
+    async def test_json_without_error_shape_suppressed(self):
+        detail = await self._detail(400, json={"detail": "contact a@b.com"})
+        self.assertNotIn("a@b.com", detail)
+
+
+class GroundingDeadlineTest(unittest.IsolatedAsyncioTestCase):
+    async def test_slow_grounding_is_bounded_and_falls_back(self):
+        from syrmos_admin import ariadne
+
+        def slow_ctx():
+            import time as _t
+            _t.sleep(1.5)  # simulate a locked/slow DB, off the event loop
+            return "Active lines:\n- M1"
+
+        loop = asyncio.get_event_loop()
+        with mock.patch.object(ariadne, "_get_transit_context", slow_ctx):
+            deadline = loop.time() + 0.2
+            start = loop.time()
+            text = await ariadne._build_system_text(deadline, loop)
+            elapsed = loop.time() - start
+        self.assertLess(elapsed, 1.0)  # did not wait the full 5s
+        self.assertIn("Live Syrmos transit data is unavailable", text)
+
+
+class RateLimitTest(unittest.IsolatedAsyncioTestCase):
+    async def test_allows_up_to_limit_then_blocks(self):
+        from syrmos_admin import app as appmod
+        with mock.patch.object(appmod, "_ARIADNE_RATE_PER_MIN", 3):
+            appmod._ariadne_hits.clear()
+            results = [await appmod._ariadne_rate_ok("client-abc") for _ in range(4)]
+        self.assertEqual(results, [True, True, True, False])
+
+    async def test_separate_clients_are_independent(self):
+        from syrmos_admin import app as appmod
+        with mock.patch.object(appmod, "_ARIADNE_RATE_PER_MIN", 1):
+            appmod._ariadne_hits.clear()
+            self.assertTrue(await appmod._ariadne_rate_ok("client-a"))
+            self.assertTrue(await appmod._ariadne_rate_ok("client-b"))
+            self.assertFalse(await appmod._ariadne_rate_ok("client-a"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the Ariadne provider architecture: one async, OpenAI-compatible abstraction with a Groq to Cloudflare to local-llama.cpp to deterministic fallback chain.

## Why
- The old code made three hardcoded `urllib` provider calls from inside an `async` route, so a hung provider (the 15s Gemini timeout) blocked the whole event loop.
- Gemini free is not usable for EEA user-facing production traffic (current Terms require Paid Services), and the stored credential was an OAuth token that hangs.
- Adding/replacing a provider meant editing bespoke request code each time.

## What
- **`ariadne_providers.py`** (new): `OpenAICompatibleProvider` over a shared `httpx.AsyncClient` (keep-alive pool, strict connect/read timeouts). `build_chain()` assembles providers from env; `ProviderResult` carries observability metadata; failures are classified `config | rate_limit | server | timeout | network | empty`.
- **`ariadne.py`**: `chat_async()` runs the chain and returns the first grounded reply, else a deterministic offline reply. Grounding is explicit: live DB transit facts are prefixed with a "use only these, abstain otherwise" contract. Transit-context DB logic preserved verbatim.
- **`app.py`**: the route now `await`s the async chain (no more event-loop blocking) and returns `model` too.
- Per-attempt structured logging (provider, model, status, latency_ms, tokens, error kind), never the prompt.

## Default chain and activation
| Order | Provider | Model (default, env-overridable) | Activates when |
|---|---|---|---|
| 1 | Groq | `openai/gpt-oss-120b` | `GROQ_API_KEY` set (already present) |
| 2 | Cloudflare Workers AI | `@cf/qwen/qwen3.8-27b` | `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_AI_TOKEN` |
| 3 | local llama.cpp | `Qwen3.5-2B` | `ARIADNE_LOCAL_BASE_URL` set |
| 4 | deterministic | n/a | always |

An unconfigured provider is skipped (no wasted round trip). Optional paid OpenAI-compatible provider via `ARIADNE_EXTRA_*`.

## Model slugs
Cloudflare/local model names use the values from the Sept 1 2026 research brief as env-overridable defaults. My training predates them, so they are not hardcoded anywhere except as defaults and must be confirmed against live provider docs before those providers are switched on.

## Tests
15 `unittest` cases via `httpx.MockTransport` (no network): success + usage parsing, the full error-status matrix, env-gated chain assembly, fail-through, offline fallback. All green on the Pi (Python 3.13, httpx 0.28.1). CI does not run Pi Python tests.

## Follow-ups (not in this PR)
- Streaming + true TTFT metric.
- Structured route/departure grounding object (needs a deterministic planner).
- Local llama.cpp setup on the Pi (build + model download + 127.0.0.1 bind + systemd).