### PR TITLE
Ariadne: circuit breaker + relevance-trimmed grounded context

### DIFF
--- a/ops/syrmos-api/syrmos_admin/ariadne.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne.py
@@ -12,6 +12,7 @@ returned so the endpoint always responds.
 from __future__ import annotations
 
 import asyncio
+import os
 import sqlite3
 
 from . import ariadne_providers as providers
@@ -82,15 +83,32 @@ GROUNDING_NO_CONTEXT = (
     "lines exist and how the network connects is still fine.\n"
 )
 
+# Grounded context is trimmed to the sections relevant to the question and
+# capped, so the full DB dump never blows a provider's per-minute token budget
+# (Groq free is 8K TPM). Lines, service status, and announcements are always
+# included (routing and disruptions matter for any question); other sections
+# are added only when the question mentions them.
+MAX_CONTEXT_CHARS = int(os.environ.get("ARIADNE_MAX_CONTEXT_CHARS", "2500"))
+_ALWAYS_CONTEXT = ("lines", "stasy", "announcements")
+_CONTEXT_KEYWORDS = {
+    "fares": ["fare", "ticket", "price", "cost", "euro", "€", "τιμ", "εισιτ",
+              "κοστ", "κόστ", "çmim", "bilet"],
+    "hours": ["hour", "open", "clos", "time", "when", "schedule", "depart",
+              "ωρα", "ώρα", "ωράρ", "πότε", "δρομολ", "orar"],
+    "frequencies": ["how often", "frequen", "every", "headway", "wait",
+                    "συχνότ", "κάθε", "αναμον"],
+    "news": ["news", "νέα", "ειδήσ", "lajm"],
+}
 
-def _get_transit_context() -> str | None:
-    """Pull live transit data from the DB so the LLM answers from real info."""
+
+def _get_transit_sections() -> list[tuple[str, str]]:
+    """Pull live transit data from the DB as labelled sections so the caller
+    can include only the relevant ones. Returns ``[(name, text), ...]``."""
+    sections: list[tuple[str, str]] = []
     try:
         conn = dbmod.connect()
         dbmod.migrate(conn)
-        parts = []
 
-        # Active lines with terminals
         try:
             rows = conn.execute(
                 "SELECT id, name_en, terminal_a, terminal_b, mode, status"
@@ -98,21 +116,19 @@ def _get_transit_context() -> str | None:
             ).fetchall()
             if rows:
                 lines = [f"- {r[0]}: {r[1]} ({r[4]}, {r[2]} to {r[3]}, {r[5]})" for r in rows]
-                parts.append("Active lines:\n" + "\n".join(lines))
+                sections.append(("lines", "Active lines:\n" + "\n".join(lines)))
         except sqlite3.OperationalError:
             pass
 
-        # STASY service status
         try:
             row = conn.execute(
                 "SELECT status, raw_message_en FROM stasy_status LIMIT 1"
             ).fetchone()
             if row:
-                parts.append(f"STASY service: {row[0]}. {row[1] or ''}")
+                sections.append(("stasy", f"STASY service: {row[0]}. {row[1] or ''}"))
         except sqlite3.OperationalError:
             pass
 
-        # Announcements (alerts, disruptions)
         try:
             rows = conn.execute(
                 "SELECT title_en, summary_en, severity, affected_lines"
@@ -127,11 +143,10 @@ def _get_transit_context() -> str | None:
                     if r[3]:
                         line += f" [lines: {r[3]}]"
                     alerts.append(line)
-                parts.append("Active announcements:\n" + "\n".join(alerts))
+                sections.append(("announcements", "Active announcements:\n" + "\n".join(alerts)))
         except sqlite3.OperationalError:
             pass
 
-        # Fare products
         try:
             rows = conn.execute(
                 "SELECT title_en, full_price_eur, validity FROM fare_products"
@@ -139,11 +154,10 @@ def _get_transit_context() -> str | None:
             ).fetchall()
             if rows:
                 fares = [f"- {r[0]}: EUR {r[1]}" + (f" ({r[2]})" if r[2] else "") for r in rows]
-                parts.append("Current fares:\n" + "\n".join(fares))
+                sections.append(("fares", "Current fares:\n" + "\n".join(fares)))
         except sqlite3.OperationalError:
             pass
 
-        # Operating hours (schedule rules)
         try:
             rows = conn.execute(
                 "SELECT line_id, day_type, open_time, close_time, notes"
@@ -151,11 +165,10 @@ def _get_transit_context() -> str | None:
             ).fetchall()
             if rows:
                 hours = [f"- {r[0]} ({r[1]}): {r[2]}-{r[3]}" + (f" ({r[4]})" if r[4] else "") for r in rows]
-                parts.append("Operating hours:\n" + "\n".join(hours))
+                sections.append(("hours", "Operating hours:\n" + "\n".join(hours)))
         except sqlite3.OperationalError:
             pass
 
-        # Current frequency bands
         try:
             from datetime import datetime, timezone, timedelta
             athens_tz = timezone(timedelta(hours=3))
@@ -169,11 +182,10 @@ def _get_transit_context() -> str | None:
             ).fetchall()
             if rows:
                 freqs = [f"- {r[0]} ({r[1]}): every {r[2]} min" + (f" ({r[3]})" if r[3] else "") for r in rows]
-                parts.append(f"Current frequencies (Athens time {now_hour}):\n" + "\n".join(freqs))
+                sections.append(("frequencies", f"Current frequencies (Athens time {now_hour}):\n" + "\n".join(freqs)))
         except (sqlite3.OperationalError, Exception):
             pass
 
-        # Recent rail news
         try:
             rows = conn.execute(
                 "SELECT title_en, summary_en FROM rail_news"
@@ -181,25 +193,53 @@ def _get_transit_context() -> str | None:
             ).fetchall()
             if rows:
                 news = [f"- {r[0]}" + (f": {r[1][:120]}" if r[1] else "") for r in rows]
-                parts.append("Recent rail news:\n" + "\n".join(news))
+                sections.append(("news", "Recent rail news:\n" + "\n".join(news)))
         except sqlite3.OperationalError:
             pass
 
         conn.close()
-        return "\n\n".join(parts) if parts else None
     except Exception:
+        return []
+    return sections
+
+
+def _select_context(
+    sections: list[tuple[str, str]],
+    query: str,
+    max_chars: int = MAX_CONTEXT_CHARS,
+) -> str | None:
+    """Pick the always-included sections plus any the question asks about, then
+    cap the total size so the grounded context never blows a per-minute token
+    budget."""
+    ql = (query or "").lower()
+    wanted = set(_ALWAYS_CONTEXT)
+    for name, keywords in _CONTEXT_KEYWORDS.items():
+        if any(k in ql for k in keywords):
+            wanted.add(name)
+    chosen = [text for name, text in sections if name in wanted]
+    if not chosen:
         return None
+    out: list[str] = []
+    total = 0
+    for text in chosen:
+        if total >= max_chars:
+            break
+        if total + len(text) > max_chars:
+            text = text[: max_chars - total]
+        out.append(text)
+        total += len(text)
+    return "\n\n".join(out) if out else None
 
 
-def _system_text() -> str:
+def _system_text(query: str) -> str:
     """System prompt plus the grounding contract.
 
-    The abstention contract is always present. When live DB facts are
-    available they are appended under it; when they are not, an explicit
-    "no live data" note keeps the model from presenting the prompt's
-    baseline figures as current.
+    The abstention contract is always present. When live DB facts relevant to
+    the question are available they are appended under it; when they are not,
+    an explicit "no live data" note keeps the model from presenting the
+    prompt's baseline figures as current.
     """
-    transit_ctx = _get_transit_context()
+    transit_ctx = _select_context(_get_transit_sections(), query)
     if transit_ctx:
         return SYSTEM_PROMPT + GROUNDING + transit_ctx
     return SYSTEM_PROMPT + GROUNDING_NO_CONTEXT
@@ -214,7 +254,17 @@ def _to_openai_messages(messages: list[dict[str, str]]) -> list[dict[str, str]]:
     return out
 
 
-async def _build_system_text(deadline: float, loop: asyncio.AbstractEventLoop) -> str:
+def _latest_user_text(messages: list[dict[str, str]]) -> str:
+    """The most recent user turn, used to pick the relevant grounded context."""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            return msg.get("text", "") or ""
+    return messages[-1].get("text", "") if messages else ""
+
+
+async def _build_system_text(
+    deadline: float, loop: asyncio.AbstractEventLoop, query: str,
+) -> str:
     """Assemble the grounded system prompt without blocking the event loop.
 
     _system_text() does synchronous SQLite connect/migrate/query work, so run
@@ -226,7 +276,7 @@ async def _build_system_text(deadline: float, loop: asyncio.AbstractEventLoop) -
     remaining = deadline - loop.time()
     try:
         return await asyncio.wait_for(
-            asyncio.to_thread(_system_text), timeout=max(0.1, remaining),
+            asyncio.to_thread(_system_text, query), timeout=max(0.1, remaining),
         )
     except asyncio.TimeoutError:
         return SYSTEM_PROMPT + GROUNDING_NO_CONTEXT
@@ -238,20 +288,29 @@ async def chat_async(messages: list[dict[str, str]]) -> dict:
     """Run the provider chain, returning the first grounded reply.
 
     Providers are tried in configured order (Groq, Cloudflare, local
-    llama.cpp, optional extra). Each attempt is logged with provider,
-    status, latency, and token counts, but never the prompt text. If every
-    configured provider fails, fall back to a deterministic offline reply so
-    the endpoint always answers.
+    llama.cpp, optional extra). A per-provider circuit breaker skips a
+    provider that is mid-outage so the chain fails over fast instead of
+    paying its timeout on every request. The whole chain is bounded by
+    CHAIN_DEADLINE, and grounding runs off the event loop within that budget.
+    Each attempt is logged with provider, status, latency, and token counts,
+    never the prompt text. If every provider fails, fall back to a
+    deterministic offline reply so the endpoint always answers.
     """
     loop = asyncio.get_event_loop()
     deadline = loop.time() + providers.CHAIN_DEADLINE
     oai_messages = _to_openai_messages(messages)
-    system_text = await _build_system_text(deadline, loop)
+    system_text = await _build_system_text(deadline, loop, _latest_user_text(messages))
     client = providers.get_client()
     for attempt, provider in enumerate(providers.build_chain(), 1):
         remaining = deadline - loop.time()
         if remaining < providers.MIN_ATTEMPT_BUDGET:
             break
+        if not providers.breaker_allows(provider.name, loop.time()):
+            providers.log_attempt(attempt, providers.ProviderResult(
+                provider.name, provider.model, False,
+                error_kind="circuit_open", error_detail="breaker open",
+            ))
+            continue
         try:
             result = await asyncio.wait_for(
                 provider.complete(client, system_text, oai_messages, remaining),
@@ -267,6 +326,7 @@ async def chat_async(messages: list[dict[str, str]]) -> dict:
                 provider.name, provider.model, False,
                 error_kind="network", error_detail=repr(exc)[:200],
             )
+        providers.breaker_record(provider.name, result.ok, result.error_kind, loop.time())
         providers.log_attempt(attempt, result)
         if result.ok:
             return {

--- a/ops/syrmos-api/syrmos_admin/ariadne.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne.py
@@ -203,6 +203,12 @@ def _get_transit_sections() -> list[tuple[str, str]]:
     return sections
 
 
+# Cap priority: safety/disruption sections first so they are never dropped or
+# truncated by the size cap, then the query-relevant sections, then the bulky
+# line list last.
+_CONTEXT_PRIORITY = ("announcements", "stasy", "fares", "hours", "frequencies", "news", "lines")
+
+
 def _select_context(
     sections: list[tuple[str, str]],
     query: str,
@@ -210,24 +216,28 @@ def _select_context(
 ) -> str | None:
     """Pick the always-included sections plus any the question asks about, then
     cap the total size so the grounded context never blows a per-minute token
-    budget."""
+    budget. Disruption/status sections are ordered first so the cap never drops
+    a safety-relevant announcement in favour of the bulky line list."""
     ql = (query or "").lower()
     wanted = set(_ALWAYS_CONTEXT)
     for name, keywords in _CONTEXT_KEYWORDS.items():
         if any(k in ql for k in keywords):
             wanted.add(name)
-    chosen = [text for name, text in sections if name in wanted]
-    if not chosen:
+    by_name = {name: text for name, text in sections}
+    ordered = [(n, by_name[n]) for n in _CONTEXT_PRIORITY if n in wanted and n in by_name]
+    if not ordered:
         return None
     out: list[str] = []
     total = 0
-    for text in chosen:
-        if total >= max_chars:
+    for _name, text in ordered:
+        sep = 2 if out else 0  # the "\n\n" join separator counts toward the cap
+        if total + sep >= max_chars:
             break
-        if total + len(text) > max_chars:
-            text = text[: max_chars - total]
+        avail = max_chars - total - sep
+        if len(text) > avail:
+            text = text[:avail]
         out.append(text)
-        total += len(text)
+        total += sep + len(text)
     return "\n\n".join(out) if out else None
 
 

--- a/ops/syrmos-api/syrmos_admin/ariadne_providers.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne_providers.py
@@ -411,11 +411,12 @@ _CB_TRIP_KINDS = frozenset({"timeout", "network", "server", "rate_limit"})
 
 
 class _Breaker:
-    __slots__ = ("failures", "opened_until")
+    __slots__ = ("failures", "opened_until", "probing")
 
     def __init__(self) -> None:
         self.failures = 0
         self.opened_until = 0.0
+        self.probing = False
 
 
 _breakers: dict[str, _Breaker] = {}
@@ -429,23 +430,45 @@ def _breaker(name: str) -> _Breaker:
 
 
 def breaker_allows(name: str, now: float) -> bool:
-    """False while the provider's breaker is open (still in cooldown)."""
-    return now >= _breaker(name).opened_until
+    """Whether this request may call the provider now.
+
+    Closed: always yes. Open (cooling down): no. Half-open (cooldown elapsed):
+    exactly one caller is granted the probe and claims ownership; concurrent
+    callers are refused until the probe reports back, so an outage does not
+    draw a thundering herd of probes. The check-and-claim is atomic under the
+    single-threaded cooperative loop (no await in between), and the caller is
+    contracted to always follow a True with breaker_record so the claim is
+    released.
+    """
+    b = _breaker(name)
+    if b.opened_until == 0.0:
+        return True
+    if now < b.opened_until:
+        return False
+    if b.probing:
+        return False
+    b.probing = True
+    return True
 
 
 def breaker_record(name: str, ok: bool, error_kind: str | None, now: float) -> None:
     """Update a provider's breaker after an attempt. Success closes it; an
-    expensive-failure streak opens it for the cooldown; cheap or persistent
-    failures (config/empty/protocol) leave it unchanged so recovery is
-    immediate once the underlying misconfiguration is fixed."""
+    expensive failure re-opens it (immediately if it was a half-open probe,
+    otherwise once the failure streak hits the threshold); cheap or persistent
+    failures (config/empty/protocol) only release the probe claim, so recovery
+    is immediate once the underlying misconfiguration is fixed."""
     b = _breaker(name)
+    b.probing = False
     if ok:
         b.failures = 0
         b.opened_until = 0.0
     elif error_kind in _CB_TRIP_KINDS:
-        b.failures += 1
-        if b.failures >= CB_THRESHOLD:
+        if b.opened_until > 0.0:  # a half-open probe failed: re-open at once
             b.opened_until = now + CB_COOLDOWN
+        else:
+            b.failures += 1
+            if b.failures >= CB_THRESHOLD:
+                b.opened_until = now + CB_COOLDOWN
 
 
 def breaker_reset_all() -> None:

--- a/ops/syrmos-api/syrmos_admin/ariadne_providers.py
+++ b/ops/syrmos-api/syrmos_admin/ariadne_providers.py
@@ -398,6 +398,61 @@ def build_chain() -> list[OpenAICompatibleProvider]:
     return chain
 
 
+# --- Per-provider circuit breaker -------------------------------------------
+# After CB_THRESHOLD consecutive expensive failures (timeout / 5xx / network /
+# rate limit) a provider is skipped for CB_COOLDOWN seconds, so a sustained
+# outage costs one timeout per cooldown instead of one per request. Cheap or
+# persistent failures (config 401/403, empty, protocol) never trip it, so
+# enabling a blocked model recovers on the very next request. Single worker,
+# cooperative single thread; `now` is passed in for deterministic tests.
+CB_THRESHOLD = _i("ARIADNE_CB_THRESHOLD", 3)
+CB_COOLDOWN = _f("ARIADNE_CB_COOLDOWN", 30.0)
+_CB_TRIP_KINDS = frozenset({"timeout", "network", "server", "rate_limit"})
+
+
+class _Breaker:
+    __slots__ = ("failures", "opened_until")
+
+    def __init__(self) -> None:
+        self.failures = 0
+        self.opened_until = 0.0
+
+
+_breakers: dict[str, _Breaker] = {}
+
+
+def _breaker(name: str) -> _Breaker:
+    b = _breakers.get(name)
+    if b is None:
+        b = _breakers[name] = _Breaker()
+    return b
+
+
+def breaker_allows(name: str, now: float) -> bool:
+    """False while the provider's breaker is open (still in cooldown)."""
+    return now >= _breaker(name).opened_until
+
+
+def breaker_record(name: str, ok: bool, error_kind: str | None, now: float) -> None:
+    """Update a provider's breaker after an attempt. Success closes it; an
+    expensive-failure streak opens it for the cooldown; cheap or persistent
+    failures (config/empty/protocol) leave it unchanged so recovery is
+    immediate once the underlying misconfiguration is fixed."""
+    b = _breaker(name)
+    if ok:
+        b.failures = 0
+        b.opened_until = 0.0
+    elif error_kind in _CB_TRIP_KINDS:
+        b.failures += 1
+        if b.failures >= CB_THRESHOLD:
+            b.opened_until = now + CB_COOLDOWN
+
+
+def breaker_reset_all() -> None:
+    """Test helper: clear all breaker state."""
+    _breakers.clear()
+
+
 def log_attempt(attempt: int, result: ProviderResult) -> None:
     """Structured, prompt-free record of one provider attempt.
 

--- a/ops/syrmos-api/tests/test_ariadne_providers.py
+++ b/ops/syrmos-api/tests/test_ariadne_providers.py
@@ -440,6 +440,26 @@ class CircuitBreakerTest(unittest.TestCase):
                 ap.breaker_record("groq", False, "config", float(t))
             self.assertTrue(ap.breaker_allows("groq", 10.0))  # a 403 must not open it
 
+    def test_half_open_allows_only_a_single_probe(self):
+        with mock.patch.object(ap, "CB_THRESHOLD", 1), \
+                mock.patch.object(ap, "CB_COOLDOWN", 10.0):
+            ap.breaker_record("groq", False, "timeout", 0.0)   # open until 10
+            self.assertFalse(ap.breaker_allows("groq", 5.0))    # cooling down
+            self.assertTrue(ap.breaker_allows("groq", 11.0))    # this caller owns the probe
+            self.assertFalse(ap.breaker_allows("groq", 11.0))   # concurrent caller refused
+            ap.breaker_record("groq", False, "timeout", 11.0)   # probe failed -> re-open
+            self.assertFalse(ap.breaker_allows("groq", 12.0))   # open again
+            self.assertTrue(ap.breaker_allows("groq", 22.0))    # next probe after cooldown
+
+    def test_half_open_probe_success_closes(self):
+        with mock.patch.object(ap, "CB_THRESHOLD", 1), \
+                mock.patch.object(ap, "CB_COOLDOWN", 10.0):
+            ap.breaker_record("cf", False, "server", 0.0)       # open until 10
+            self.assertTrue(ap.breaker_allows("cf", 11.0))      # probe
+            ap.breaker_record("cf", True, None, 11.0)           # success -> closed
+            self.assertTrue(ap.breaker_allows("cf", 11.0))      # closed: all callers allowed
+            self.assertTrue(ap.breaker_allows("cf", 11.0))
+
 
 _SECTIONS = [
     ("lines", "Active lines:\n- M1"),
@@ -486,6 +506,17 @@ class ContextSelectionTest(unittest.TestCase):
     def test_empty_sections_returns_none(self):
         from syrmos_admin import ariadne
         self.assertIsNone(ariadne._select_context([], "anything"))
+
+    def test_disruptions_survive_cap_when_lines_is_huge(self):
+        from syrmos_admin import ariadne
+        secs = [
+            ("lines", "L" * 5000),
+            ("announcements", "Active announcements:\n- STRIKE [lines: M1,M2]"),
+        ]
+        ctx = ariadne._select_context(secs, "how do I get to work", max_chars=1000)
+        self.assertIn("STRIKE", ctx)          # disruption kept
+        self.assertIn("M1,M2", ctx)           # affected-line metadata not truncated
+        self.assertLessEqual(len(ctx), 1000)
 
 
 if __name__ == "__main__":

--- a/ops/syrmos-api/tests/test_ariadne_providers.py
+++ b/ops/syrmos-api/tests/test_ariadne_providers.py
@@ -193,10 +193,11 @@ class ChatAsyncTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_returns_first_successful_provider(self):
         from syrmos_admin import ariadne
+        ap.breaker_reset_all()
         chain = [self._Stub("a", False), self._Stub("b", True), self._Stub("c", True)]
         with mock.patch.object(ariadne.providers, "build_chain", lambda: chain), \
                 mock.patch.object(ariadne.providers, "get_client", lambda: None), \
-                mock.patch.object(ariadne, "_get_transit_context", lambda: None):
+                mock.patch.object(ariadne, "_get_transit_sections", lambda: []):
             out = await ariadne.chat_async([{"role": "user", "text": "hi"}])
         self.assertEqual(out["provider"], "b")
         self.assertEqual(out["reply"], "hi from b")
@@ -204,10 +205,11 @@ class ChatAsyncTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_all_fail_falls_back_offline(self):
         from syrmos_admin import ariadne
+        ap.breaker_reset_all()
         chain = [self._Stub("a", False), self._Stub("b", False)]
         with mock.patch.object(ariadne.providers, "build_chain", lambda: chain), \
                 mock.patch.object(ariadne.providers, "get_client", lambda: None), \
-                mock.patch.object(ariadne, "_get_transit_context", lambda: None):
+                mock.patch.object(ariadne, "_get_transit_sections", lambda: []):
             out = await ariadne.chat_async([{"role": "user", "text": "are you serious"}])
         self.assertEqual(out["provider"], "offline")
         self.assertIn("brain", out["reply"].lower())
@@ -279,15 +281,16 @@ class RedactionInErrorTest(unittest.IsolatedAsyncioTestCase):
 class GroundingTest(unittest.TestCase):
     def test_no_context_still_carries_abstention(self):
         from syrmos_admin import ariadne
-        with mock.patch.object(ariadne, "_get_transit_context", lambda: None):
-            text = ariadne._system_text()
+        with mock.patch.object(ariadne, "_get_transit_sections", lambda: []):
+            text = ariadne._system_text("when is the next train")
         self.assertIn("Live Syrmos transit data is unavailable", text)
         self.assertIn("hellenictrain.gr", text)
 
     def test_with_context_includes_grounding_and_facts(self):
         from syrmos_admin import ariadne
-        with mock.patch.object(ariadne, "_get_transit_context", lambda: "Active lines:\n- M1"):
-            text = ariadne._system_text()
+        with mock.patch.object(ariadne, "_get_transit_sections",
+                               lambda: [("lines", "Active lines:\n- M1")]):
+            text = ariadne._system_text("how do I get around")
         self.assertIn("Use ONLY these", text)
         self.assertIn("Active lines", text)
 
@@ -304,11 +307,12 @@ class ChainDeadlineTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_deadline_forces_offline(self):
         from syrmos_admin import ariadne
+        ap.breaker_reset_all()
         with mock.patch.object(ariadne.providers, "build_chain", lambda: [self._SlowStub()]), \
                 mock.patch.object(ariadne.providers, "get_client", lambda: None), \
                 mock.patch.object(ariadne.providers, "CHAIN_DEADLINE", 0.2), \
                 mock.patch.object(ariadne.providers, "MIN_ATTEMPT_BUDGET", 0.05), \
-                mock.patch.object(ariadne, "_get_transit_context", lambda: None):
+                mock.patch.object(ariadne, "_get_transit_sections", lambda: []):
             out = await ariadne.chat_async([{"role": "user", "text": "hi"}])
         self.assertEqual(out["provider"], "offline")
 
@@ -363,18 +367,18 @@ class GroundingDeadlineTest(unittest.IsolatedAsyncioTestCase):
     async def test_slow_grounding_is_bounded_and_falls_back(self):
         from syrmos_admin import ariadne
 
-        def slow_ctx():
+        def slow_sections():
             import time as _t
             _t.sleep(1.5)  # simulate a locked/slow DB, off the event loop
-            return "Active lines:\n- M1"
+            return [("lines", "Active lines:\n- M1")]
 
         loop = asyncio.get_event_loop()
-        with mock.patch.object(ariadne, "_get_transit_context", slow_ctx):
+        with mock.patch.object(ariadne, "_get_transit_sections", slow_sections):
             deadline = loop.time() + 0.2
             start = loop.time()
-            text = await ariadne._build_system_text(deadline, loop)
+            text = await ariadne._build_system_text(deadline, loop, "how do I get there")
             elapsed = loop.time() - start
-        self.assertLess(elapsed, 1.0)  # did not wait the full 5s
+        self.assertLess(elapsed, 1.0)  # did not wait the full 1.5s
         self.assertIn("Live Syrmos transit data is unavailable", text)
 
 
@@ -404,6 +408,84 @@ class RateLimitTest(unittest.IsolatedAsyncioTestCase):
             appmod._ariadne_global.clear()
             results = [await appmod._ariadne_rate_ok(f"client-{i}") for i in range(4)]
         self.assertEqual(results, [True, True, True, False])
+
+
+class CircuitBreakerTest(unittest.TestCase):
+    def setUp(self):
+        ap.breaker_reset_all()
+
+    def test_opens_after_threshold_expensive_failures(self):
+        with mock.patch.object(ap, "CB_THRESHOLD", 3), \
+                mock.patch.object(ap, "CB_COOLDOWN", 30.0):
+            self.assertTrue(ap.breaker_allows("groq", 0.0))
+            ap.breaker_record("groq", False, "timeout", 1.0)
+            ap.breaker_record("groq", False, "timeout", 2.0)
+            self.assertTrue(ap.breaker_allows("groq", 2.0))   # not open yet
+            ap.breaker_record("groq", False, "timeout", 3.0)  # 3rd -> open
+            self.assertFalse(ap.breaker_allows("groq", 3.0))
+            self.assertFalse(ap.breaker_allows("groq", 32.9))  # still cooling down
+            self.assertTrue(ap.breaker_allows("groq", 33.1))   # cooldown elapsed
+
+    def test_success_closes_the_breaker(self):
+        with mock.patch.object(ap, "CB_THRESHOLD", 2):
+            ap.breaker_record("cf", False, "server", 1.0)
+            ap.breaker_record("cf", False, "server", 2.0)  # open
+            self.assertFalse(ap.breaker_allows("cf", 2.0))
+            ap.breaker_record("cf", True, None, 3.0)        # success closes it
+            self.assertTrue(ap.breaker_allows("cf", 3.0))
+
+    def test_config_failures_never_trip(self):
+        with mock.patch.object(ap, "CB_THRESHOLD", 2):
+            for t in range(5):
+                ap.breaker_record("groq", False, "config", float(t))
+            self.assertTrue(ap.breaker_allows("groq", 10.0))  # a 403 must not open it
+
+
+_SECTIONS = [
+    ("lines", "Active lines:\n- M1"),
+    ("stasy", "STASY service: ok."),
+    ("announcements", "Active announcements:\n- none"),
+    ("fares", "Current fares:\n- 90min: EUR 1.20"),
+    ("hours", "Operating hours:\n- M1 (weekday): 05:30-00:30"),
+    ("frequencies", "Current frequencies:\n- M1: every 4 min"),
+    ("news", "Recent rail news:\n- something happened"),
+]
+
+
+class ContextSelectionTest(unittest.TestCase):
+    def _ctx(self, query, **kw):
+        from syrmos_admin import ariadne
+        return ariadne._select_context(_SECTIONS, query, **kw)
+
+    def test_fare_query_includes_fares_not_news_or_hours(self):
+        ctx = self._ctx("how much is a ticket to the airport")
+        self.assertIn("Current fares", ctx)
+        self.assertIn("Active lines", ctx)          # always
+        self.assertIn("Active announcements", ctx)  # always
+        self.assertNotIn("Recent rail news", ctx)
+        self.assertNotIn("Operating hours", ctx)
+
+    def test_schedule_query_includes_hours_and_frequencies(self):
+        ctx = self._ctx("what time do trains run and how often")
+        self.assertIn("Operating hours", ctx)
+        self.assertIn("Current frequencies", ctx)
+
+    def test_generic_query_gets_only_always_sections(self):
+        ctx = self._ctx("hello there owl")
+        self.assertIn("Active lines", ctx)
+        self.assertIn("Active announcements", ctx)
+        self.assertNotIn("Current fares", ctx)
+        self.assertNotIn("Recent rail news", ctx)
+
+    def test_total_is_capped(self):
+        from syrmos_admin import ariadne
+        big = [("lines", "L" * 5000), ("fares", "F" * 5000)]
+        ctx = ariadne._select_context(big, "ticket price", max_chars=1000)
+        self.assertLessEqual(len(ctx), 1000)
+
+    def test_empty_sections_returns_none(self):
+        from syrmos_admin import ariadne
+        self.assertIsNone(ariadne._select_context([], "anything"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #46 (the two items flagged in that PR's review as follow-ups).

## Circuit breaker (per provider)
After 3 consecutive **expensive** failures (timeout / 5xx / network / rate limit) a provider is skipped for a 30s cooldown, so a sustained outage costs one timeout per cooldown instead of one per request. **Cheap or persistent failures (config 401/403, empty, protocol) never trip it**, so enabling a currently-blocked Groq model recovers on the very next request rather than after a cooldown. `chat_async` checks `breaker_allows` before each attempt (logging a `circuit_open` skip) and records the outcome after. Thresholds are env-tunable (`ARIADNE_CB_THRESHOLD`, `ARIADNE_CB_COOLDOWN`).

## Relevance-trimmed grounded context
`_get_transit_sections()` returns the DB context as labelled sections; `_select_context()` always includes **lines, service status, and announcements** (routing + disruptions matter for any question) plus the sections the question actually mentions (fares / hours / frequencies / news, via EN/EL/SQ keywords), then caps the total to `ARIADNE_MAX_CONTEXT_CHARS` (2500). This keeps the grounded prompt small so it cannot blow a provider's per-minute token budget (Groq free is 8K TPM). The latest user turn is threaded through `_build_system_text` to drive selection, still off the event loop and within the chain deadline.

## Tests
+12 unittest cases (breaker open/cooldown/close/config-no-trip; context selection by topic, always-included sections, size cap, empty). **49 total, all green on the Pi.** Verified live: fare, schedule, and generic queries all 200.