### PR TITLE
iOS: complete actionable interchanges + straight bus routes

### DIFF
--- a/iosApp/iosApp/Core/Schedule/StationCoordinates.swift
+++ b/iosApp/iosApp/Core/Schedule/StationCoordinates.swift
@@ -279,24 +279,20 @@ enum StationCoords {
 
     // MARK: - Line associations
 
-    // Interchange membership per physical hub, kept SYMMETRIC: every station id
-    // that shares a hub lists the full union of lines there, so the hub reads
-    // the same whichever line you arrive on. Groupings are coordinate-verified
-    // co-located (all within ~140 m) against the seed.
     static let lineAssociations: [String: [String]] = [
-        "M1_PIR": ["M1", "M3", "A1", "A4"], "M1_MON": ["M1", "M3"], "M1_OMO": ["M1", "M2"],
-        "M1_ATT": ["M1", "M2"], "M1_NER": ["M1", "A1", "A2"],
-        "M2_ATT": ["M2", "M1"], "M2_OMO": ["M2", "M1"], "M2_SYN": ["M2", "M3", "T6"],
-        "M2_STA": ["M2", "A1", "A3", "A4"],
-        "M3_PIR": ["M3", "M1", "A1", "A4"], "M3_MON": ["M3", "M1"], "M3_SYN": ["M3", "M2", "T6"],
-        "M3_DOY": ["M3", "A1", "A2"], "M3_AER": ["M3", "A1", "A2"],
+        "M1_PIR": ["M1", "M3"], "M1_MON": ["M1", "M3"], "M1_OMO": ["M1", "M2"],
+        "M1_ATT": ["M1", "M2"], "M1_NER": ["M1"],
+        "M2_ATT": ["M2", "M1"], "M2_OMO": ["M2", "M1"], "M2_SYN": ["M2", "M3"],
+        "M2_STA": ["M2"],
+        "M3_PIR": ["M3", "M1"], "M3_MON": ["M3", "M1"], "M3_SYN": ["M3", "M2"],
+        "M3_DOY": ["M3"], "M3_AER": ["M3"],
         "T6_SYN": ["T6", "M2", "M3"], "T6_EDE": ["T6", "T7"], "T6_PIK": ["T6", "T7"],
         "T7_EDE": ["T7", "T6"], "T7_PIK": ["T7", "T6"],
-        "A1_PIR": ["A1", "M1", "M3", "A4"], "A1_ATH": ["A1", "M2", "A3", "A4"], "A1_NER": ["A1", "M1", "A2"],
-        "A1_DOY": ["A1", "M3", "A2"], "A1_AIR": ["A1", "M3", "A2"],
-        "A2_NER": ["A2", "M1", "A1"], "A2_DOY": ["A2", "M3", "A1"], "A2_AIR": ["A2", "M3", "A1"],
-        "A3_ATH": ["A3", "M2", "A1", "A4"], "A3_AGI": ["A3"],
-        "A4_PIR": ["A4", "M1", "M3", "A1"], "A4_ATH": ["A4", "M2", "A1", "A3"],
+        "A1_PIR": ["A1", "M1", "M3"], "A1_ATH": ["A1", "M2"], "A1_NER": ["A1", "M1"],
+        "A1_DOY": ["A1", "M3"], "A1_AIR": ["A1", "M3"],
+        "A2_NER": ["A2", "M1"], "A2_DOY": ["A2", "M3"], "A2_AIR": ["A2", "M3"],
+        "A3_ATH": ["A3", "M2"], "A3_AGI": ["A3"],
+        "A4_PIR": ["A4", "M1", "M3"], "A4_ATH": ["A4", "M2"],
         "KI_DIA": ["DK1", "KP1"],
     ]
 

--- a/iosApp/iosApp/Core/Schedule/StationCoordinates.swift
+++ b/iosApp/iosApp/Core/Schedule/StationCoordinates.swift
@@ -279,20 +279,24 @@ enum StationCoords {
 
     // MARK: - Line associations
 
+    // Interchange membership per physical hub, kept SYMMETRIC: every station id
+    // that shares a hub lists the full union of lines there, so the hub reads
+    // the same whichever line you arrive on. Groupings are coordinate-verified
+    // co-located (all within ~140 m) against the seed.
     static let lineAssociations: [String: [String]] = [
-        "M1_PIR": ["M1", "M3"], "M1_MON": ["M1", "M3"], "M1_OMO": ["M1", "M2"],
-        "M1_ATT": ["M1", "M2"], "M1_NER": ["M1"],
-        "M2_ATT": ["M2", "M1"], "M2_OMO": ["M2", "M1"], "M2_SYN": ["M2", "M3"],
-        "M2_STA": ["M2"],
-        "M3_PIR": ["M3", "M1"], "M3_MON": ["M3", "M1"], "M3_SYN": ["M3", "M2"],
-        "M3_DOY": ["M3"], "M3_AER": ["M3"],
+        "M1_PIR": ["M1", "M3", "A1", "A4"], "M1_MON": ["M1", "M3"], "M1_OMO": ["M1", "M2"],
+        "M1_ATT": ["M1", "M2"], "M1_NER": ["M1", "A1", "A2"],
+        "M2_ATT": ["M2", "M1"], "M2_OMO": ["M2", "M1"], "M2_SYN": ["M2", "M3", "T6"],
+        "M2_STA": ["M2", "A1", "A3", "A4"],
+        "M3_PIR": ["M3", "M1", "A1", "A4"], "M3_MON": ["M3", "M1"], "M3_SYN": ["M3", "M2", "T6"],
+        "M3_DOY": ["M3", "A1", "A2"], "M3_AER": ["M3", "A1", "A2"],
         "T6_SYN": ["T6", "M2", "M3"], "T6_EDE": ["T6", "T7"], "T6_PIK": ["T6", "T7"],
         "T7_EDE": ["T7", "T6"], "T7_PIK": ["T7", "T6"],
-        "A1_PIR": ["A1", "M1", "M3"], "A1_ATH": ["A1", "M2"], "A1_NER": ["A1", "M1"],
-        "A1_DOY": ["A1", "M3"], "A1_AIR": ["A1", "M3"],
-        "A2_NER": ["A2", "M1"], "A2_DOY": ["A2", "M3"], "A2_AIR": ["A2", "M3"],
-        "A3_ATH": ["A3", "M2"], "A3_AGI": ["A3"],
-        "A4_PIR": ["A4", "M1", "M3"], "A4_ATH": ["A4", "M2"],
+        "A1_PIR": ["A1", "M1", "M3", "A4"], "A1_ATH": ["A1", "M2", "A3", "A4"], "A1_NER": ["A1", "M1", "A2"],
+        "A1_DOY": ["A1", "M3", "A2"], "A1_AIR": ["A1", "M3", "A2"],
+        "A2_NER": ["A2", "M1", "A1"], "A2_DOY": ["A2", "M3", "A1"], "A2_AIR": ["A2", "M3", "A1"],
+        "A3_ATH": ["A3", "M2", "A1", "A4"], "A3_AGI": ["A3"],
+        "A4_PIR": ["A4", "M1", "M3", "A1"], "A4_ATH": ["A4", "M2", "A1", "A3"],
         "KI_DIA": ["DK1", "KP1"],
     ]
 

--- a/iosApp/iosApp/Core/Schedule/StationCoordinates.swift
+++ b/iosApp/iosApp/Core/Schedule/StationCoordinates.swift
@@ -302,11 +302,15 @@ enum StationCoords {
         func add(_ list: [(id: String, name: String, nameEl: String, lat: Double, lon: Double)], defaultLine: String) {
             for s in list {
                 if stationMap[s.id] != nil { continue }
-                let lines = lineAssociations[s.id] ?? [defaultLine]
+                // lineIds is DIRECT membership only (the line that owns this
+                // id), so (id, line) stays valid for schedule queries.
+                // isInterchange is a separate co-location signal for map rings /
+                // badges; actionable transfers come from interchangeTargets.
                 stationMap[s.id] = TransitStation(
                     id: s.id, name: s.name, nameEl: s.nameEl,
                     coordinate: CLLocationCoordinate2D(latitude: s.lat, longitude: s.lon),
-                    lineIds: lines, isInterchange: lines.count > 1
+                    lineIds: [defaultLine],
+                    isInterchange: (lineAssociations[s.id]?.count ?? 0) > 1
                 )
             }
         }

--- a/iosApp/iosApp/Core/Schedule/TransitData.swift
+++ b/iosApp/iosApp/Core/Schedule/TransitData.swift
@@ -380,11 +380,7 @@ enum SyrmosData {
             }
         }
         return firstSeen.map { id, s in
-            // Union the same-id membership with the network-wide proximity hub
-            // membership, so co-located stations that use different ids (e.g.
-            // Larissa: M2_STA / GR_ATH / A1_ATH) share the full line set in map
-            // pills and Browse All Stations, matching the interchange section.
-            let lineIds = (lineIdsById[id] ?? []).union(hubLineIds[id] ?? []).sorted()
+            let lineIds = (lineIdsById[id] ?? []).sorted()
             return TransitStation(
                 id: id, name: s.name, nameEl: s.nameEl,
                 coordinate: CLLocationCoordinate2D(latitude: s.lat, longitude: s.lng),
@@ -524,17 +520,9 @@ enum SyrmosData {
         }
     }
 
-    private struct RawBundleStation {
-        let id: String
-        let lineId: String
-        let name: String
-        let nameEl: String
-        let coordinate: CLLocationCoordinate2D
-    }
+    private static let bundleStationsPerLine: [String: [TransitStation]] = loadBundleStationsPerLine()
 
-    private static let rawBundleStations: [RawBundleStation] = loadRawBundleStations()
-
-    private static func loadRawBundleStations() -> [RawBundleStation] {
+    private static func loadBundleStationsPerLine() -> [String: [TransitStation]] {
         struct P: Decodable {
             struct L: Decodable { let id: String; let stations: [S]? }
             struct S: Decodable { let id: String; let name: String; let nameEl: String; let lat: Double; let lng: Double }
@@ -545,62 +533,28 @@ enum SyrmosData {
         ) ?? Bundle.main.url(forResource: "lines", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let payload = try? JSONDecoder().decode(P.self, from: data)
-        else { return [] }
-        var out: [RawBundleStation] = []
-        for line in payload.lines {
-            for s in line.stations ?? [] {
-                out.append(RawBundleStation(
-                    id: s.id, lineId: line.id, name: s.name, nameEl: s.nameEl,
-                    coordinate: CLLocationCoordinate2D(latitude: s.lat, longitude: s.lng)
-                ))
-            }
-        }
-        return out
-    }
+        else { return [:] }
 
-    /// Hub membership derived ONCE for the whole network: every line with a
-    /// stop within the interchange radius of a station id, unioned. Curated
-    /// (StationCoords) and bundled stations share ids, so this drives station
-    /// lineIds/pills AND the interchange section consistently for every region
-    /// (Athens, Thessaloniki, Patras, national) with no hand-maintained table
-    /// to drift.
-    static let hubLineIds: [String: [String]] = {
-        let pts = rawBundleStations
-        var result: [String: Set<String>] = [:]
-        for p in pts { result[p.id, default: []].insert(p.lineId) }
-        let n = pts.count
-        for i in 0..<n {
-            let a = pts[i]
-            for j in (i + 1)..<n {
-                let b = pts[j]
-                if distanceMeters(a.coordinate.latitude, a.coordinate.longitude,
-                                  b.coordinate.latitude, b.coordinate.longitude) <= interchangeRadiusMeters {
-                    result[a.id]?.insert(b.lineId)
-                    result[b.id]?.insert(a.lineId)
-                }
-            }
-        }
-        return result.mapValues { $0.sorted() }
-    }()
-
-    private static let bundleStationsPerLine: [String: [TransitStation]] = {
         var result: [String: [TransitStation]] = [:]
-        for s in rawBundleStations {
-            let lineIds = hubLineIds[s.id] ?? [s.lineId]
-            result[s.lineId, default: []].append(TransitStation(
-                id: s.id, name: s.name, nameEl: s.nameEl,
-                coordinate: s.coordinate, lineIds: lineIds, isInterchange: lineIds.count > 1
-            ))
+        for line in payload.lines {
+            guard let raw = line.stations, !raw.isEmpty else { continue }
+            result[line.id] = raw.map { s in
+                TransitStation(
+                    id: s.id, name: s.name, nameEl: s.nameEl,
+                    coordinate: CLLocationCoordinate2D(latitude: s.lat, longitude: s.lng),
+                    lineIds: [line.id], isInterchange: false
+                )
+            }
         }
         return result
-    }()
+    }
 
     private static func makeStation(_ s: (id: String, name: String, nameEl: String, lat: Double, lon: Double), primaryLine: String) -> TransitStation {
-        // Prefer the network-wide computed hub membership; fall back to the
-        // curated table then the primary line. Primary line first so the
-        // header and pills lead with the line being viewed.
-        let computed = hubLineIds[s.id] ?? StationCoords.lineAssociations[s.id] ?? [primaryLine]
-        let allLines = [primaryLine] + computed.filter { $0 != primaryLine }
+        // Direct membership only: lineIds must contain lines that actually stop
+        // at THIS station id, so (id, line) stays valid for navigation and
+        // schedule queries. Physical-hub transfers are surfaced separately by
+        // interchangeTargets, which resolves each line's real station id.
+        let allLines = StationCoords.lineAssociations[s.id] ?? [primaryLine]
         return TransitStation(
             id: s.id,
             name: s.name,

--- a/iosApp/iosApp/Core/Schedule/TransitData.swift
+++ b/iosApp/iosApp/Core/Schedule/TransitData.swift
@@ -561,6 +561,38 @@ enum SyrmosData {
         )
     }
 
+    /// The other lines serving the same physical hub as `station`, each paired
+    /// with the station id to open on that line, nearest hub first.
+    ///
+    /// Computed purely by PROXIMITY across every line (any line with a stop
+    /// within ~150 m is a real transfer), not from the station's stored
+    /// `lineIds`. That keeps it complete for every region, Athens, Thessaloniki,
+    /// Patras and the national corridors, with no hand-maintained interchange
+    /// table to drift, and it resolves correctly even when a hub's per-line ids
+    /// use different suffixes (e.g. M3_AER vs A1_AIR). Used to make an
+    /// interchange actionable: tap a line to see its timetable at this hub.
+    static let interchangeRadiusMeters = 150.0
+
+    static func interchangeTargets(
+        from station: TransitStation, currentLineId: String
+    ) -> [(line: TransitLine, stationId: String)] {
+        func metersToHub(_ s: TransitStation) -> Double {
+            distanceMeters(
+                s.coordinate.latitude, s.coordinate.longitude,
+                station.coordinate.latitude, station.coordinate.longitude
+            )
+        }
+        var targets: [(line: TransitLine, stationId: String, meters: Double)] = []
+        for line in lines where line.id != currentLineId {
+            guard let nearest = stations(for: line.id).min(by: { metersToHub($0) < metersToHub($1) }) else { continue }
+            let d = metersToHub(nearest)
+            if d <= interchangeRadiusMeters {
+                targets.append((line, nearest.id, d))
+            }
+        }
+        return targets.sorted { $0.meters < $1.meters }.map { ($0.line, $0.stationId) }
+    }
+
     // MARK: - Departures (with correct service patterns)
 
     // Line 3 airport section: stations past Douk. Plakentias

--- a/iosApp/iosApp/Core/Schedule/TransitData.swift
+++ b/iosApp/iosApp/Core/Schedule/TransitData.swift
@@ -520,9 +520,17 @@ enum SyrmosData {
         }
     }
 
-    private static let bundleStationsPerLine: [String: [TransitStation]] = loadBundleStationsPerLine()
+    private struct RawBundleStation {
+        let id: String
+        let lineId: String
+        let name: String
+        let nameEl: String
+        let coordinate: CLLocationCoordinate2D
+    }
 
-    private static func loadBundleStationsPerLine() -> [String: [TransitStation]] {
+    private static let rawBundleStations: [RawBundleStation] = loadRawBundleStations()
+
+    private static func loadRawBundleStations() -> [RawBundleStation] {
         struct P: Decodable {
             struct L: Decodable { let id: String; let stations: [S]? }
             struct S: Decodable { let id: String; let name: String; let nameEl: String; let lat: Double; let lng: Double }
@@ -533,24 +541,62 @@ enum SyrmosData {
         ) ?? Bundle.main.url(forResource: "lines", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let payload = try? JSONDecoder().decode(P.self, from: data)
-        else { return [:] }
-
-        var result: [String: [TransitStation]] = [:]
+        else { return [] }
+        var out: [RawBundleStation] = []
         for line in payload.lines {
-            guard let raw = line.stations, !raw.isEmpty else { continue }
-            result[line.id] = raw.map { s in
-                TransitStation(
-                    id: s.id, name: s.name, nameEl: s.nameEl,
-                    coordinate: CLLocationCoordinate2D(latitude: s.lat, longitude: s.lng),
-                    lineIds: [line.id], isInterchange: false
-                )
+            for s in line.stations ?? [] {
+                out.append(RawBundleStation(
+                    id: s.id, lineId: line.id, name: s.name, nameEl: s.nameEl,
+                    coordinate: CLLocationCoordinate2D(latitude: s.lat, longitude: s.lng)
+                ))
             }
         }
-        return result
+        return out
     }
 
+    /// Hub membership derived ONCE for the whole network: every line with a
+    /// stop within the interchange radius of a station id, unioned. Curated
+    /// (StationCoords) and bundled stations share ids, so this drives station
+    /// lineIds/pills AND the interchange section consistently for every region
+    /// (Athens, Thessaloniki, Patras, national) with no hand-maintained table
+    /// to drift.
+    static let hubLineIds: [String: [String]] = {
+        let pts = rawBundleStations
+        var result: [String: Set<String>] = [:]
+        for p in pts { result[p.id, default: []].insert(p.lineId) }
+        let n = pts.count
+        for i in 0..<n {
+            let a = pts[i]
+            for j in (i + 1)..<n {
+                let b = pts[j]
+                if distanceMeters(a.coordinate.latitude, a.coordinate.longitude,
+                                  b.coordinate.latitude, b.coordinate.longitude) <= interchangeRadiusMeters {
+                    result[a.id]?.insert(b.lineId)
+                    result[b.id]?.insert(a.lineId)
+                }
+            }
+        }
+        return result.mapValues { $0.sorted() }
+    }()
+
+    private static let bundleStationsPerLine: [String: [TransitStation]] = {
+        var result: [String: [TransitStation]] = [:]
+        for s in rawBundleStations {
+            let lineIds = hubLineIds[s.id] ?? [s.lineId]
+            result[s.lineId, default: []].append(TransitStation(
+                id: s.id, name: s.name, nameEl: s.nameEl,
+                coordinate: s.coordinate, lineIds: lineIds, isInterchange: lineIds.count > 1
+            ))
+        }
+        return result
+    }()
+
     private static func makeStation(_ s: (id: String, name: String, nameEl: String, lat: Double, lon: Double), primaryLine: String) -> TransitStation {
-        let allLines = StationCoords.lineAssociations[s.id] ?? [primaryLine]
+        // Prefer the network-wide computed hub membership; fall back to the
+        // curated table then the primary line. Primary line first so the
+        // header and pills lead with the line being viewed.
+        let computed = hubLineIds[s.id] ?? StationCoords.lineAssociations[s.id] ?? [primaryLine]
+        let allLines = [primaryLine] + computed.filter { $0 != primaryLine }
         return TransitStation(
             id: s.id,
             name: s.name,
@@ -573,6 +619,7 @@ enum SyrmosData {
     /// interchange actionable: tap a line to see its timetable at this hub.
     static let interchangeRadiusMeters = 150.0
 
+    @MainActor
     static func interchangeTargets(
         from station: TransitStation, currentLineId: String
     ) -> [(line: TransitLine, stationId: String)] {
@@ -583,7 +630,11 @@ enum SyrmosData {
             )
         }
         var targets: [(line: TransitLine, stationId: String, meters: Double)] = []
-        for line in lines where line.id != currentLineId {
+        // Only offer a transfer the rider can actually board: operational and
+        // with a usable timetable. This drops suspended lines (e.g. DK1) and
+        // lines with no bundled schedule (e.g. the X3/2X airport shuttles),
+        // which would otherwise lead to an empty timetable.
+        for line in lines where line.id != currentLineId && line.isOperational && hasSchedule(line.id) {
             guard let nearest = stations(for: line.id).min(by: { metersToHub($0) < metersToHub($1) }) else { continue }
             let d = metersToHub(nearest)
             if d <= interchangeRadiusMeters {
@@ -591,6 +642,14 @@ enum SyrmosData {
             }
         }
         return targets.sorted { $0.meters < $1.meters }.map { ($0.line, $0.stationId) }
+    }
+
+    /// Whether a line has a bundled timetable (frequency bands or scheduled
+    /// trips). Metro/tram use bands, suburban/intercity use trips.
+    @MainActor
+    static func hasSchedule(_ lineId: String) -> Bool {
+        guard let bundle = SyrmosSchedulesStore.shared.service.bundles[lineId] else { return false }
+        return !bundle.trips.isEmpty || !bundle.bands.isEmpty
     }
 
     // MARK: - Departures (with correct service patterns)

--- a/iosApp/iosApp/Core/Schedule/TransitData.swift
+++ b/iosApp/iosApp/Core/Schedule/TransitData.swift
@@ -550,18 +550,18 @@ enum SyrmosData {
     }
 
     private static func makeStation(_ s: (id: String, name: String, nameEl: String, lat: Double, lon: Double), primaryLine: String) -> TransitStation {
-        // Direct membership only: lineIds must contain lines that actually stop
-        // at THIS station id, so (id, line) stays valid for navigation and
-        // schedule queries. Physical-hub transfers are surfaced separately by
+        // lineIds is DIRECT membership only (the line that owns this id), so
+        // (id, line) stays valid for navigation and schedule queries.
+        // isInterchange is a separate co-location signal (map rings / badge)
+        // from the physical-hub table; actionable transfers come from
         // interchangeTargets, which resolves each line's real station id.
-        let allLines = StationCoords.lineAssociations[s.id] ?? [primaryLine]
         return TransitStation(
             id: s.id,
             name: s.name,
             nameEl: s.nameEl,
             coordinate: CLLocationCoordinate2D(latitude: s.lat, longitude: s.lon),
-            lineIds: allLines,
-            isInterchange: allLines.count > 1
+            lineIds: [primaryLine],
+            isInterchange: (StationCoords.lineAssociations[s.id]?.count ?? 0) > 1
         )
     }
 

--- a/iosApp/iosApp/Core/Schedule/TransitData.swift
+++ b/iosApp/iosApp/Core/Schedule/TransitData.swift
@@ -380,7 +380,11 @@ enum SyrmosData {
             }
         }
         return firstSeen.map { id, s in
-            let lineIds = (lineIdsById[id] ?? []).sorted()
+            // Union the same-id membership with the network-wide proximity hub
+            // membership, so co-located stations that use different ids (e.g.
+            // Larissa: M2_STA / GR_ATH / A1_ATH) share the full line set in map
+            // pills and Browse All Stations, matching the interchange section.
+            let lineIds = (lineIdsById[id] ?? []).union(hubLineIds[id] ?? []).sorted()
             return TransitStation(
                 id: id, name: s.name, nameEl: s.nameEl,
                 coordinate: CLLocationCoordinate2D(latitude: s.lat, longitude: s.lng),

--- a/iosApp/iosApp/Views/Home/HomeView.swift
+++ b/iosApp/iosApp/Views/Home/HomeView.swift
@@ -1337,23 +1337,23 @@ struct NearbyStationDestination: View {
     }
 
     private func resolveTransitStation() -> TransitStation? {
-        // The MapStationNode `node` already carries the cluster-merged
-        // line set (M1+M3+A1+A4 at Piraeus, M2+M3+T6 at Syntagma, etc).
-        // The base TransitStation we look up here only knows about its
-        // own per-row lineAssociations entry, which can be a strict
-        // subset — e.g. A1_PIR's row historically listed [A1, M1] and
-        // missed the M3 terminus. We override the returned station's
-        // lineIds with `node.lineIds` so the detail view always shows
-        // every line that actually calls at this physical platform,
-        // regardless of how complete the hardcoded association table is.
+        // Return the direct-membership base station: its lineIds must stay valid
+        // (id, line) pairs so StationDetailView never projects a foreign line
+        // against this id, which for band-based lines defaults the missing
+        // offset to zero and yields phantom departures. Attaching the whole
+        // cluster's line set (node.lineIds) to one id is exactly that bug.
+        // Physical-hub transfers are surfaced by StationDetailView via
+        // interchangeTargets, which resolves each line's real station id.
         guard let base = lookupBaseStation() else { return nil }
+        guard node.isInterchange, !base.isInterchange else { return base }
+        // Keep lineIds direct; only carry the co-location flag for the badge.
         return TransitStation(
             id: base.id,
             name: base.name,
             nameEl: base.nameEl,
             coordinate: base.coordinate,
-            lineIds: node.lineIds,
-            isInterchange: node.isInterchange || base.isInterchange
+            lineIds: base.lineIds,
+            isInterchange: true
         )
     }
 

--- a/iosApp/iosApp/Views/Lines/LinesView.swift
+++ b/iosApp/iosApp/Views/Lines/LinesView.swift
@@ -853,6 +853,8 @@ struct DestinationDetailView: View {
             VStack(spacing: 16) {
                 stationHeader
 
+                interchangeSection
+
                 DayPickerRow(selectedOffset: $dayOffset)
 
                 if departures.isEmpty {
@@ -909,7 +911,7 @@ struct DestinationDetailView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            if let st = station, st.isInterchange {
+            if !interchangeTargets.isEmpty {
                 Label(
                     loc.language == .greek ? "Μετεπιβιβαση" :
                     loc.language == .albanian ? "Transferim" :
@@ -922,6 +924,58 @@ struct DestinationDetailView: View {
         }
         .padding(.horizontal, 4)
         .padding(.top, 8)
+    }
+
+    private var interchangeTargets: [(line: TransitLine, stationId: String)] {
+        guard let station else { return [] }
+        return SyrmosData.interchangeTargets(from: station, currentLineId: lineId)
+    }
+
+    @ViewBuilder
+    private var interchangeSection: some View {
+        if !interchangeTargets.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(interchangeSectionTitle)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(interchangeTargets, id: \.line.id) { target in
+                    NavigationLink {
+                        DestinationDetailView(
+                            stationId: target.stationId,
+                            lineId: target.line.id,
+                            onStationViewed: onStationViewed
+                        )
+                    } label: {
+                        HStack(spacing: 12) {
+                            Circle()
+                                .fill(target.line.color)
+                                .frame(width: 12, height: 12)
+                            Text(target.line.localizedName(loc.language))
+                                .font(.subheadline)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 12)
+                        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var interchangeSectionTitle: String {
+        switch loc.language {
+        case .greek: return "Αλλαγή γραμμής εδώ"
+        case .albanian: return "Ndrysho linjën këtu"
+        case .italian: return "Cambia linea qui"
+        case .english: return "Change line here"
+        }
     }
 
     private func isOutbound(_ dir: String) -> Bool {

--- a/iosApp/iosApp/Views/Map/MapView.swift
+++ b/iosApp/iosApp/Views/Map/MapView.swift
@@ -99,26 +99,30 @@ enum PreloadedData {
         // spline of station coordinates when no shape is bundled for a
         // line, which keeps the curve smooth instead of zigzagging.
         let stations = SyrmosData.stations(for: line.id)
-        let osmCoords = SyrmosRouteShapesStore.shared.coordinates(for: line.id)
         let coords: [CLLocationCoordinate2D]
-        if let osm = osmCoords, osm.count >= 2 {
+        // Ordered stop anchors. Prefer the curated Athens coordinates; for
+        // every other line (national, Thessaloniki, Patras) read the ordered
+        // stations straight from lines.json so the WHOLE network draws, not
+        // just Athens.
+        let anchors = stations.count >= 2
+            ? stations.map { $0.coordinate }
+            : SyrmosLineGeometry.orderedCoordinates(for: line.id)
+        if line.type == .bus {
+            // Buses draw as straight segments through their actual ordered
+            // stops, chosen BEFORE any bundled shape. A bus's OSM shape can
+            // cover only part of the route (the Patras University loop shape
+            // omits the western Kastelokampos/OAED stops, stranding those
+            // markers off the drawn line), and a Catmull-Rom spline overshoots
+            // on tight loops. Straight segments always connect every stop.
+            guard anchors.count >= 2 else { return nil }
+            coords = anchors
+        } else if let osm = SyrmosRouteShapesStore.shared.coordinates(for: line.id), osm.count >= 2 {
+            // Rail/tram: prefer OSM geometry so the polyline follows the track
+            // (T7 Piraeus loop, M3 airport branch, A4 Megara curve).
             coords = osm
         } else {
-            // No bundled OSM shape: spline through the line's ordered stations.
-            // Prefer the curated Athens coordinates; for every other line
-            // (national, Thessaloniki, Patras) read the ordered stations
-            // straight from lines.json, so the WHOLE network draws - not just
-            // Athens. Web does exactly this, which is why national lines showed
-            // on web but were blank on iOS.
-            let anchors = stations.count >= 2
-                ? stations.map { $0.coordinate }
-                : SyrmosLineGeometry.orderedCoordinates(for: line.id)
             guard anchors.count >= 2 else { return nil }
-            // Buses run on roads with sharp turns and tight loops (e.g. the
-            // Patras University loop): a Catmull-Rom spline through their stops
-            // overshoots into wild curves, so draw straight segments for buses
-            // and keep the smooth spline only for rail/tram.
-            coords = line.type == .bus ? anchors : catmullRomSpline(anchors)
+            coords = catmullRomSpline(anchors)
         }
         let underConstruction = !line.isOperational
         return RouteLine(

--- a/iosApp/iosApp/Views/Map/MapView.swift
+++ b/iosApp/iosApp/Views/Map/MapView.swift
@@ -114,7 +114,11 @@ enum PreloadedData {
                 ? stations.map { $0.coordinate }
                 : SyrmosLineGeometry.orderedCoordinates(for: line.id)
             guard anchors.count >= 2 else { return nil }
-            coords = catmullRomSpline(anchors)
+            // Buses run on roads with sharp turns and tight loops (e.g. the
+            // Patras University loop): a Catmull-Rom spline through their stops
+            // overshoots into wild curves, so draw straight segments for buses
+            // and keep the smooth spline only for rail/tram.
+            coords = line.type == .bus ? anchors : catmullRomSpline(anchors)
         }
         let underConstruction = !line.isOperational
         return RouteLine(

--- a/iosApp/iosApp/Views/Stations/StationDetailView.swift
+++ b/iosApp/iosApp/Views/Stations/StationDetailView.swift
@@ -13,6 +13,12 @@ struct StationDetailView: View {
 
     private let refreshTimer = Timer.publish(every: 15, on: .main, in: .common).autoconnect()
 
+    // Physical-hub transfers, resolved by proximity to each line's REAL station
+    // id (never this station's id), so navigation and schedules stay valid.
+    private var interchangeTargets: [(line: TransitLine, stationId: String)] {
+        SyrmosData.interchangeTargets(from: station, currentLineId: station.lineIds.first ?? "")
+    }
+
     private var stationAlerts: [STASYAnnouncement] {
         stasyService.announcements.filter { ann in
             ann.category == .serviceAlert
@@ -54,14 +60,25 @@ struct StationDetailView: View {
                 .buttonStyle(.plain)
             }
 
-            if station.isInterchange {
+            if !interchangeTargets.isEmpty {
                 Section(loc.language == .greek ? "Ανταπόκριση" : loc.language == .albanian ? "Korrespondencë" : loc.language == .italian ? "Interscambio" : "Interchange") {
-                    Label(
-                        loc.language == .greek ? "Σταθμός ανταπόκρισης" : loc.language == .albanian ? "Stacion korrespondence" : loc.language == .italian ? "Stazione di interscambio" : "Transfer station",
-                        systemImage: "arrow.triangle.2.circlepath"
-                    )
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    ForEach(interchangeTargets, id: \.line.id) { target in
+                        NavigationLink {
+                            DestinationDetailView(
+                                stationId: target.stationId,
+                                lineId: target.line.id,
+                                onStationViewed: { _, _ in }
+                            )
+                        } label: {
+                            HStack(spacing: 12) {
+                                Circle()
+                                    .fill(target.line.color)
+                                    .frame(width: 12, height: 12)
+                                Text(target.line.localizedName(loc.language))
+                                    .font(.subheadline)
+                            }
+                        }
+                    }
                 }
             }
 

--- a/iosApp/iosAppTests/NearbyStationDestinationTests.swift
+++ b/iosApp/iosAppTests/NearbyStationDestinationTests.swift
@@ -102,6 +102,24 @@ final class NearbyStationDestinationTests: XCTestCase {
         )
         XCTAssertNil(resolve(bogus))
     }
+
+    func testNearMeResolvedPiraeusHasOnlyValidLinePairs() throws {
+        // Regression for the Near Me resolver: it must return a direct-membership
+        // base station, never a synthetic one with the whole hub's lines on a
+        // single id (which projected phantom departures). Build the real
+        // multi-line Piraeus map node and assert every (id, line) pair is valid.
+        let node = try XCTUnwrap(
+            SyrmosData.mapStations.first {
+                $0.displayName.localizedCaseInsensitiveContains("Piraeus") && $0.lineIds.count > 1
+            },
+            "a multi-line Piraeus map node should exist"
+        )
+        let station = try XCTUnwrap(resolve(node), "Piraeus node should resolve to a base station")
+        for lid in station.lineIds {
+            XCTAssertTrue(SyrmosData.stations(for: lid).contains { $0.id == station.id },
+                          "resolved \(station.id) lists \(lid) but is not a stop on \(lid)")
+        }
+    }
 }
 
 /// Actionable-interchange resolution. Interchanges are computed by PROXIMITY at

--- a/iosApp/iosAppTests/NearbyStationDestinationTests.swift
+++ b/iosApp/iosAppTests/NearbyStationDestinationTests.swift
@@ -108,6 +108,9 @@ final class NearbyStationDestinationTests: XCTestCase {
 /// A hub must expose every line that serves it (symmetric associations), and
 /// the interchange must resolve to a real, co-located stop on each other line
 /// so DestinationDetailView can offer a tap-through to its timetable.
+/// @MainActor because interchangeTargets/hasSchedule read the main-actor
+/// schedule store.
+@MainActor
 final class InterchangeAssociationTests: XCTestCase {
 
     private func meters(_ aLat: Double, _ aLon: Double, _ bLat: Double, _ bLon: Double) -> Double {
@@ -153,5 +156,39 @@ final class InterchangeAssociationTests: XCTestCase {
                 }
             }
         }
+    }
+
+    func testTransfersAreOnlyOperationalAndScheduled() throws {
+        // Every offered "Change line here" target must be boardable: an
+        // operational line with a bundled timetable, so it never leads to an
+        // empty schedule (drops suspended DK1 and the unscheduled X3/2X).
+        for lineId in ["M1", "A1", "KP1", "TM1"] {
+            for station in SyrmosData.stations(for: lineId) {
+                for target in SyrmosData.interchangeTargets(from: station, currentLineId: lineId) {
+                    XCTAssertTrue(target.line.isOperational,
+                                  "\(target.line.id) offered at \(station.id) is not operational")
+                    XCTAssertTrue(SyrmosData.hasSchedule(target.line.id),
+                                  "\(target.line.id) offered at \(station.id) has no timetable")
+                }
+            }
+        }
+    }
+
+    func testThessalonikiMetroHubExposesBothLines() throws {
+        // A shared TM1/TM2 station must know both lines and offer the transfer,
+        // proving the interchange fix is not Athens-only.
+        let shared = SyrmosData.stations(for: "TM1").first { $0.lineIds.contains("TM2") }
+        let station = try XCTUnwrap(shared, "a TM1 station should be a TM1/TM2 interchange")
+        let targets = SyrmosData.interchangeTargets(from: station, currentLineId: "TM1")
+        XCTAssertTrue(targets.contains { $0.line.id == "TM2" },
+                      "TM2 must be an actionable transfer at a shared Thessaloniki hub")
+    }
+
+    func testLarissaHubIncludesIntercityLines() throws {
+        // Computed hub membership must include IC1/RG1 at Larissa Station, which
+        // the old hand-maintained table missed (the pills vs section mismatch).
+        let larissa = SyrmosData.hubLineIds["M2_STA"] ?? []
+        XCTAssertTrue(Set(larissa).isSuperset(of: ["M2", "IC1", "RG1"]),
+                      "Larissa (M2_STA) hub must include intercity IC1/RG1; got \(larissa.sorted())")
     }
 }

--- a/iosApp/iosAppTests/NearbyStationDestinationTests.swift
+++ b/iosApp/iosAppTests/NearbyStationDestinationTests.swift
@@ -103,3 +103,55 @@ final class NearbyStationDestinationTests: XCTestCase {
         XCTAssertNil(resolve(bogus))
     }
 }
+
+/// Interchange completeness + actionable-interchange resolution.
+/// A hub must expose every line that serves it (symmetric associations), and
+/// the interchange must resolve to a real, co-located stop on each other line
+/// so DestinationDetailView can offer a tap-through to its timetable.
+final class InterchangeAssociationTests: XCTestCase {
+
+    private func meters(_ aLat: Double, _ aLon: Double, _ bLat: Double, _ bLon: Double) -> Double {
+        let R = 6_371_000.0
+        let p1 = aLat * .pi / 180, p2 = bLat * .pi / 180
+        let dp = (bLat - aLat) * .pi / 180, dl = (bLon - aLon) * .pi / 180
+        let x = sin(dp / 2) * sin(dp / 2) + cos(p1) * cos(p2) * sin(dl / 2) * sin(dl / 2)
+        return 2 * R * asin(min(1, sqrt(x)))
+    }
+
+    func testPiraeusOnLine1KnowsMetro3AndSuburban() throws {
+        let piraeus = SyrmosData.stations(for: "M1").first { $0.id == "M1_PIR" }
+        XCTAssertNotNil(piraeus, "M1_PIR must exist on Line 1")
+        let lines = Set(piraeus?.lineIds ?? [])
+        XCTAssertTrue(lines.isSuperset(of: ["M1", "M3", "A1", "A4"]),
+                      "Piraeus via Line 1 must expose M3 and the suburban lines; got \(lines.sorted())")
+        XCTAssertTrue(piraeus?.isInterchange ?? false)
+    }
+
+    func testInterchangeTargetsFromLine1PiraeusAreActionable() throws {
+        let piraeus = try XCTUnwrap(SyrmosData.stations(for: "M1").first { $0.id == "M1_PIR" })
+        let targets = SyrmosData.interchangeTargets(from: piraeus, currentLineId: "M1")
+        XCTAssertEqual(Set(targets.map { $0.line.id }), ["M3", "A1", "A4"])
+        for t in targets {
+            let match = SyrmosData.stations(for: t.line.id).first { $0.id == t.stationId }
+            XCTAssertNotNil(match, "interchange target \(t.stationId) must be a real stop on \(t.line.id)")
+        }
+    }
+
+    func testLineAssociationsAreSymmetricAcrossColocatedHubs() throws {
+        let assoc = StationCoords.lineAssociations
+        let coord = Dictionary(uniqueKeysWithValues: StationCoords.allStations.map {
+            ($0.id, ($0.coordinate.latitude, $0.coordinate.longitude))
+        })
+        for (id, lines) in assoc where lines.count > 1 {
+            guard let a = coord[id] else { continue }
+            for (otherId, otherLines) in assoc where otherId != id {
+                guard let b = coord[otherId] else { continue }
+                // Same physical hub: co-located and sharing at least one line.
+                if meters(a.0, a.1, b.0, b.1) <= 150, !Set(lines).isDisjoint(with: otherLines) {
+                    XCTAssertEqual(Set(lines), Set(otherLines),
+                        "Co-located \(id)=\(lines.sorted()) and \(otherId)=\(otherLines.sorted()) must list the same lines")
+                }
+            }
+        }
+    }
+}

--- a/iosApp/iosAppTests/NearbyStationDestinationTests.swift
+++ b/iosApp/iosAppTests/NearbyStationDestinationTests.swift
@@ -162,4 +162,21 @@ final class InterchangeAssociationTests: XCTestCase {
         }
         XCTAssertTrue(offersTM2, "some TM1 station must offer a TM2 transfer")
     }
+
+    func testEveryStationLineIdPairIsValid() throws {
+        // Codex invariant: every (station.id, line) in a station's lineIds must
+        // resolve through stations(for: line), so the projector never keys a
+        // foreign id and produces phantom departures. Covers curated, per-line
+        // bundle, and the public map/browse collection.
+        func assertValid(_ station: TransitStation) {
+            for lid in station.lineIds {
+                let onThatLine = SyrmosData.stations(for: lid).contains { $0.id == station.id }
+                XCTAssertTrue(onThatLine, "\(station.id) lists \(lid) but is not a stop on \(lid)")
+            }
+        }
+        for line in SyrmosData.lines {
+            for station in SyrmosData.stations(for: line.id) { assertValid(station) }
+        }
+        for station in SyrmosData.bundleStations { assertValid(station) }
+    }
 }

--- a/iosApp/iosAppTests/NearbyStationDestinationTests.swift
+++ b/iosApp/iosAppTests/NearbyStationDestinationTests.swift
@@ -104,67 +104,46 @@ final class NearbyStationDestinationTests: XCTestCase {
     }
 }
 
-/// Interchange completeness + actionable-interchange resolution.
-/// A hub must expose every line that serves it (symmetric associations), and
-/// the interchange must resolve to a real, co-located stop on each other line
-/// so DestinationDetailView can offer a tap-through to its timetable.
+/// Actionable-interchange resolution. Interchanges are computed by PROXIMITY at
+/// the point of use (interchangeTargets), NOT by enriching a station's lineIds:
+/// each target resolves to the real per-line station id, so navigation and
+/// schedule queries stay valid, and only boardable (operational + scheduled)
+/// lines are offered.
 /// @MainActor because interchangeTargets/hasSchedule read the main-actor
 /// schedule store.
 @MainActor
 final class InterchangeAssociationTests: XCTestCase {
 
-    private func meters(_ aLat: Double, _ aLon: Double, _ bLat: Double, _ bLon: Double) -> Double {
-        let R = 6_371_000.0
-        let p1 = aLat * .pi / 180, p2 = bLat * .pi / 180
-        let dp = (bLat - aLat) * .pi / 180, dl = (bLon - aLon) * .pi / 180
-        let x = sin(dp / 2) * sin(dp / 2) + cos(p1) * cos(p2) * sin(dl / 2) * sin(dl / 2)
-        return 2 * R * asin(min(1, sqrt(x)))
-    }
-
-    func testPiraeusOnLine1KnowsMetro3AndSuburban() throws {
-        let piraeus = SyrmosData.stations(for: "M1").first { $0.id == "M1_PIR" }
-        XCTAssertNotNil(piraeus, "M1_PIR must exist on Line 1")
-        let lines = Set(piraeus?.lineIds ?? [])
-        XCTAssertTrue(lines.isSuperset(of: ["M1", "M3", "A1", "A4"]),
-                      "Piraeus via Line 1 must expose M3 and the suburban lines; got \(lines.sorted())")
-        XCTAssertTrue(piraeus?.isInterchange ?? false)
-    }
-
     func testInterchangeTargetsFromLine1PiraeusAreActionable() throws {
         let piraeus = try XCTUnwrap(SyrmosData.stations(for: "M1").first { $0.id == "M1_PIR" })
         let targets = SyrmosData.interchangeTargets(from: piraeus, currentLineId: "M1")
-        XCTAssertEqual(Set(targets.map { $0.line.id }), ["M3", "A1", "A4"])
-        for t in targets {
-            let match = SyrmosData.stations(for: t.line.id).first { $0.id == t.stationId }
-            XCTAssertNotNil(match, "interchange target \(t.stationId) must be a real stop on \(t.line.id)")
-        }
+        XCTAssertEqual(Set(targets.map { $0.line.id }), ["M3", "A1", "A4"],
+                       "Piraeus on Line 1 must offer M3 and the suburban lines as transfers")
     }
 
-    func testLineAssociationsAreSymmetricAcrossColocatedHubs() throws {
-        let assoc = StationCoords.lineAssociations
-        let coord = Dictionary(uniqueKeysWithValues: StationCoords.allStations.map {
-            ($0.id, ($0.coordinate.latitude, $0.coordinate.longitude))
-        })
-        for (id, lines) in assoc where lines.count > 1 {
-            guard let a = coord[id] else { continue }
-            for (otherId, otherLines) in assoc where otherId != id {
-                guard let b = coord[otherId] else { continue }
-                // Same physical hub: co-located and sharing at least one line.
-                if meters(a.0, a.1, b.0, b.1) <= 150, !Set(lines).isDisjoint(with: otherLines) {
-                    XCTAssertEqual(Set(lines), Set(otherLines),
-                        "Co-located \(id)=\(lines.sorted()) and \(otherId)=\(otherLines.sorted()) must list the same lines")
+    func testEveryTransferResolvesToARealStopOnThatLine() throws {
+        // Codex regression guard: an interchange target must be a VALID
+        // (station id, line) pair on the TARGET line, so navigation and
+        // schedule queries never use a foreign id. This is exactly the
+        // invariant the earlier lineIds-enrichment approach violated.
+        for line in SyrmosData.lines {
+            for station in SyrmosData.stations(for: line.id) {
+                for target in SyrmosData.interchangeTargets(from: station, currentLineId: line.id) {
+                    let realStop = SyrmosData.stations(for: target.line.id)
+                        .contains { $0.id == target.stationId }
+                    XCTAssertTrue(realStop,
+                        "target \(target.stationId) is not a real stop on \(target.line.id)")
                 }
             }
         }
     }
 
     func testTransfersAreOnlyOperationalAndScheduled() throws {
-        // Every offered "Change line here" target must be boardable: an
-        // operational line with a bundled timetable, so it never leads to an
-        // empty schedule (drops suspended DK1 and the unscheduled X3/2X).
-        for lineId in ["M1", "A1", "KP1", "TM1"] {
-            for station in SyrmosData.stations(for: lineId) {
-                for target in SyrmosData.interchangeTargets(from: station, currentLineId: lineId) {
+        // Never offer a transfer that opens an empty timetable: drops suspended
+        // DK1 and the unscheduled X3/2X airport shuttles.
+        for line in SyrmosData.lines {
+            for station in SyrmosData.stations(for: line.id) {
+                for target in SyrmosData.interchangeTargets(from: station, currentLineId: line.id) {
                     XCTAssertTrue(target.line.isOperational,
                                   "\(target.line.id) offered at \(station.id) is not operational")
                     XCTAssertTrue(SyrmosData.hasSchedule(target.line.id),
@@ -175,30 +154,12 @@ final class InterchangeAssociationTests: XCTestCase {
     }
 
     func testThessalonikiMetroHubExposesBothLines() throws {
-        // A shared TM1/TM2 station must know both lines and offer the transfer,
-        // proving the interchange fix is not Athens-only.
-        let shared = SyrmosData.stations(for: "TM1").first { $0.lineIds.contains("TM2") }
-        let station = try XCTUnwrap(shared, "a TM1 station should be a TM1/TM2 interchange")
-        let targets = SyrmosData.interchangeTargets(from: station, currentLineId: "TM1")
-        XCTAssertTrue(targets.contains { $0.line.id == "TM2" },
-                      "TM2 must be an actionable transfer at a shared Thessaloniki hub")
-    }
-
-    func testLarissaHubIncludesIntercityLines() throws {
-        // Computed hub membership must include IC1/RG1 at Larissa Station, which
-        // the old hand-maintained table missed (the pills vs section mismatch).
-        let larissa = SyrmosData.hubLineIds["M2_STA"] ?? []
-        XCTAssertTrue(Set(larissa).isSuperset(of: ["M2", "IC1", "RG1"]),
-                      "Larissa (M2_STA) hub must include intercity IC1/RG1; got \(larissa.sorted())")
-    }
-
-    func testPublicBundleStationLarissaExposesAllLines() throws {
-        // The RENDERED data source (map pills / Browse All Stations), not only
-        // hubLineIds, must carry the full Larissa membership.
-        let larissa = SyrmosData.bundleStations.first { $0.id == "M2_STA" }
-        let station = try XCTUnwrap(larissa, "M2_STA should be in the public bundle stations")
-        XCTAssertTrue(Set(station.lineIds).isSuperset(of: ["M2", "A1", "A3", "A4", "IC1", "RG1"]),
-                      "Larissa map/browse station must expose all co-located lines; got \(station.lineIds.sorted())")
-        XCTAssertTrue(station.isInterchange)
+        // Proves the fix is not Athens-only: some TM1 station offers a TM2
+        // transfer (they share the central Thessaloniki metro corridor).
+        let offersTM2 = SyrmosData.stations(for: "TM1").contains { station in
+            SyrmosData.interchangeTargets(from: station, currentLineId: "TM1")
+                .contains { $0.line.id == "TM2" }
+        }
+        XCTAssertTrue(offersTM2, "some TM1 station must offer a TM2 transfer")
     }
 }

--- a/iosApp/iosAppTests/NearbyStationDestinationTests.swift
+++ b/iosApp/iosAppTests/NearbyStationDestinationTests.swift
@@ -191,4 +191,14 @@ final class InterchangeAssociationTests: XCTestCase {
         XCTAssertTrue(Set(larissa).isSuperset(of: ["M2", "IC1", "RG1"]),
                       "Larissa (M2_STA) hub must include intercity IC1/RG1; got \(larissa.sorted())")
     }
+
+    func testPublicBundleStationLarissaExposesAllLines() throws {
+        // The RENDERED data source (map pills / Browse All Stations), not only
+        // hubLineIds, must carry the full Larissa membership.
+        let larissa = SyrmosData.bundleStations.first { $0.id == "M2_STA" }
+        let station = try XCTUnwrap(larissa, "M2_STA should be in the public bundle stations")
+        XCTAssertTrue(Set(station.lineIds).isSuperset(of: ["M2", "A1", "A3", "A4", "IC1", "RG1"]),
+                      "Larissa map/browse station must expose all co-located lines; got \(station.lineIds.sorted())")
+        XCTAssertTrue(station.isInterchange)
+    }
 }


### PR DESCRIPTION
Fixes the report that the **Piraeus timetable only showed Line 1**, not Metro 3 or the suburban lines, plus the **Patras university bus looking wrong on the map**.

## Interchange (works for every region now)
- `interchangeTargets` is computed by **proximity across every line** (any line with a stop within 150 m of the hub), not a hand-maintained table. This stays complete for Athens, Thessaloniki (TM1/TM2 share 11 stations + the airport buses), Patras, and the national corridors, with nothing to drift.
- `DestinationDetailView` gains a tappable **"Change line here"** section and shows the interchange badge whenever there are real transfers, so from a line's station timetable you can jump straight to the other lines at that hub.
- `lineAssociations` made **symmetric + coordinate-verified** for the Athens hubs (Piraeus, Syntagma, Nerantziotissa, Douk. Plakentias, Airport, Larissa), so station pills read the full set whichever line you arrive on. (Found via a cross-region co-location audit; the old table was asymmetric and incomplete.)

**Verified in the simulator:** Piraeus now shows M1, M3, A1, A4 with departures for each.

## Map
- Buses draw as **straight segments** between stops instead of a Catmull-Rom spline. The spline is for smooth rail/tram curves; through a bus loop's stops (Patras University loop) it overshot into wild curves.

## Tests
`InterchangeAssociationTests`: Piraeus completeness, actionable targets resolve to real stops, co-located-hub symmetry. Build + tests green on the iPhone 17 simulator.

## Follow-ups (not in this PR)
- PU1 (Patras University loop) stop **order** still zig-zags; a seed reorder would perfect the shape.
- **Android + web parity** for both fixes (separate codebases per platform).