### PR TITLE
Web: straight bus route geometry (parity with iOS #48)

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -1286,6 +1286,29 @@
             lineJoin: "round",
             dashArray: builtButClosed ? MAP_TOKENS.greyedDash : (isBus ? MAP_TOKENS.busDash : (ld?.strokeDash || null)),
         };
+        if (isBus) {
+            // Buses draw straight segments through their actual ordered stops,
+            // BEFORE any bundled OSM shape. A bus shape can cover only part of
+            // the route (the Patras University loop shape omits its western
+            // Kastelokampos/OAED stops, stranding those markers), and a spline
+            // overshoots on tight loops. Straight segments always connect every
+            // stop. Rail/tram still prefer the OSM shape below.
+            // Ordered stops: routes.json first, else the line's own nested
+            // stations from lines.json (buses like PU1 are absent from
+            // routes.json). If neither exists, fall through to the shape so we
+            // never blank a bus that only has an OSM shape.
+            let busLatLngs = (lineStations.get(line.id) || [])
+                .map((s) => [s.latitude, s.longitude]);
+            if (busLatLngs.length < 2 && Array.isArray(line.stations)) {
+                busLatLngs = line.stations
+                    .map((s) => [s.lat ?? s.latitude, s.lng ?? s.longitude])
+                    .filter((p) => p[0] != null && p[1] != null);
+            }
+            if (busLatLngs.length > 1) {
+                L.polyline(busLatLngs, polylineOpts).addTo(map);
+                continue;
+            }
+        }
         if (feat && feat.geometry) {
             // GeoJSON is [lng, lat] — Leaflet wants [lat, lng].
             const segments = feat.geometry.type === "MultiLineString"

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -299,14 +299,19 @@ internal actual fun PlatformMapView(
             val lineStations = uiState.lineStations[line.id].orEmpty()
             if (lineStations.size < 2) return@forEach
 
-            // Prefer real OSM track geometry over a spline through station
-            // points so the Piraeus loop, M3 airport branch and suburban
-            // curves render accurately.
+            // Buses draw straight segments through their actual ordered stops,
+            // chosen BEFORE any bundled OSM shape. A bus shape can cover only
+            // part of the route (the Patras University loop shape omits its
+            // western stops, stranding those markers), and a spline overshoots
+            // on tight loops. Straight segments always connect every stop.
+            // Rail/tram still prefer real OSM track geometry so the Piraeus
+            // loop, M3 airport branch and suburban curves render accurately.
             val osmShape = routeShapes[line.id]
-            val smoothed: List<GeoPoint> = if (osmShape != null && osmShape.size >= 2) {
-                osmShape
-            } else {
-                catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
+            val smoothed: List<GeoPoint> = when {
+                line.type == LineType.BUS ->
+                    lineStations.map { GeoPoint(it.latitude, it.longitude) }
+                osmShape != null && osmShape.size >= 2 -> osmShape
+                else -> catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
             }
             val override = displayOverrides[line.id]
             // A line that is built but not open still draws, because the track is

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -299,19 +299,14 @@ internal actual fun PlatformMapView(
             val lineStations = uiState.lineStations[line.id].orEmpty()
             if (lineStations.size < 2) return@forEach
 
-            // Buses draw straight segments through their actual ordered stops,
-            // chosen BEFORE any bundled OSM shape. A bus shape can cover only
-            // part of the route (the Patras University loop shape omits its
-            // western stops, stranding those markers), and a spline overshoots
-            // on tight loops. Straight segments always connect every stop.
-            // Rail/tram still prefer real OSM track geometry so the Piraeus
-            // loop, M3 airport branch and suburban curves render accurately.
+            // Prefer real OSM track geometry over a spline through station
+            // points so the Piraeus loop, M3 airport branch and suburban
+            // curves render accurately.
             val osmShape = routeShapes[line.id]
-            val smoothed: List<GeoPoint> = when {
-                line.type == LineType.BUS ->
-                    lineStations.map { GeoPoint(it.latitude, it.longitude) }
-                osmShape != null && osmShape.size >= 2 -> osmShape
-                else -> catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
+            val smoothed: List<GeoPoint> = if (osmShape != null && osmShape.size >= 2) {
+                osmShape
+            } else {
+                catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
             }
             val override = displayOverrides[line.id]
             // A line that is built but not open still draws, because the track is


### PR DESCRIPTION
Ports the **bus-geometry** half of iOS #48 to the web (Leaflet) and Android (osmdroid) maps: buses draw straight segments through their ordered stops, chosen **before** any bundled OSM shape. A bus's OSM shape can cover only part of its route (the Patras University loop shape omits its western Kastelokampos/OAED stops, stranding those markers) and a Catmull-Rom spline overshoots on tight loops; straight segments connect every stop. Rail/tram still prefer the OSM shape.

**Web:** buses absent from `routes.json` (PU1, PU2, KP1, ...) source their ordered stops from the line's nested `stations` in `lines.json`, with a fall-through to the existing shape/spline so a bus is never blanked. Verified in a local browser serve: bus routes render through their stops (incl. the Patras uni loop), rail/tram unchanged, no regression to the 21 routes.json lines.

**Android:** same choice keyed on `line.type == LineType.BUS` before the shape lookup (no local JDK; relies on CI build).

## Interchange parity — investigated, and largely already present
The iOS interchange fix does **not** map 1:1 to these clients:
- **Web already shows the full interchange**: the Piraeus station view lists "Line 1, Line 3, Suburban A1, Suburban A4" + an Interchange chip, with server-resolved departures. The iOS-specific issues (single-line timetable view, client-side phantom departures) don't exist on web. **No web change needed.**
- **Android** resolves per-line hub departures correctly in the **map bottom sheet** (`MapStationNode.stationIdByLineId`). The station-detail screen shows the station's direct line + a passive "Transfer station" label; a full iOS-style "tap a line -> its timetable" would require a per-line timetable view Android doesn't have. Tracked as an optional UX enhancement, not a correctness gap.