### PR TITLE
Android map: seed bus station ordering from nested lines.json + straight bus geometry

### DIFF
--- a/core/common/src/commonMain/kotlin/com/syrmos/core/common/map/RouteGeometry.kt
+++ b/core/common/src/commonMain/kotlin/com/syrmos/core/common/map/RouteGeometry.kt
@@ -32,4 +32,27 @@ object RouteGeometry {
         if (!isLoop || points.size < 2) return points
         return if (points.first() == points.last()) points else points + points.first()
     }
+
+    /**
+     * The single polyline a line is BOTH drawn as and has its vehicle markers
+     * snapped to, so the drawn route and the moving markers can never diverge.
+     *
+     * Buses use their ordered stops (closed into a loop when circular),
+     * deliberately ignoring any bundled OSM [osmShape]: a bus shape can be
+     * incomplete (PU1's omits the western stops), which would both strand the
+     * drawn route and fling a snapped marker roughly a kilometre onto the
+     * missing segment. Rail and tram prefer real OSM track geometry. Returns
+     * null when there is no usable geometry (fewer than two points), leaving the
+     * caller to fall back to a spline through the stops.
+     */
+    fun displayShape(
+        isBus: Boolean,
+        isLoop: Boolean,
+        stations: List<LatLng>,
+        osmShape: List<LatLng>?,
+    ): List<LatLng>? = when {
+        isBus -> closeLoop(stations, isLoop).takeIf { it.size >= 2 }
+        osmShape != null && osmShape.size >= 2 -> osmShape
+        else -> null
+    }
 }

--- a/core/common/src/commonMain/kotlin/com/syrmos/core/common/map/RouteGeometry.kt
+++ b/core/common/src/commonMain/kotlin/com/syrmos/core/common/map/RouteGeometry.kt
@@ -1,0 +1,35 @@
+package com.syrmos.core.common.map
+
+/**
+ * Pure helpers for turning an ordered stop list into a drawable route polyline.
+ * Kept in commonMain so every client renders bus routes identically and the
+ * behaviour is unit-testable without a map engine.
+ */
+object RouteGeometry {
+
+    /**
+     * A route is a loop when it starts and ends at the same terminal (the
+     * Patras University bus PU1: both terminals are Kastelokampos). Compared
+     * case-insensitively and trimmed; blank terminals are never a loop.
+     */
+    fun isLoopTerminals(terminalA: String, terminalB: String): Boolean {
+        val a = terminalA.trim()
+        val b = terminalB.trim()
+        return a.isNotEmpty() && a.equals(b, ignoreCase = true)
+    }
+
+    /**
+     * Close a loop route's polyline by returning to its first point. A loop
+     * drawn straight through its ordered stops otherwise renders as an open arc
+     * with a visible gap on the return leg (PU1 left roughly a kilometre
+     * undrawn). Appends the first point only when [isLoop] and the ends are not
+     * already coincident, so a non-loop route and an already-closed one are
+     * returned unchanged. This is done in geometry, not in seed data, because
+     * station_line_entity is keyed by (station_id, line_id) and a repeated stop
+     * id would collide on that primary key.
+     */
+    fun closeLoop(points: List<LatLng>, isLoop: Boolean): List<LatLng> {
+        if (!isLoop || points.size < 2) return points
+        return if (points.first() == points.last()) points else points + points.first()
+    }
+}

--- a/core/common/src/commonTest/kotlin/com/syrmos/core/common/map/RouteGeometryTest.kt
+++ b/core/common/src/commonTest/kotlin/com/syrmos/core/common/map/RouteGeometryTest.kt
@@ -1,0 +1,52 @@
+package com.syrmos.core.common.map
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RouteGeometryTest {
+
+    @Test
+    fun equalTerminalsAreALoop() {
+        assertTrue(RouteGeometry.isLoopTerminals("Kastelokampos", "Kastelokampos"))
+        assertTrue(RouteGeometry.isLoopTerminals(" Kastelokampos ", "kastelokampos"))
+    }
+
+    @Test
+    fun differentOrBlankTerminalsAreNotALoop() {
+        assertFalse(RouteGeometry.isLoopTerminals("Kastelokampos", "Agios Vasileios"))
+        assertFalse(RouteGeometry.isLoopTerminals("", ""))
+        assertFalse(RouteGeometry.isLoopTerminals("  ", "  "))
+    }
+
+    @Test
+    fun loopPolylineIsClosedByAppendingTheFirstPoint() {
+        val pts = listOf(LatLng(38.29, 21.79), LatLng(38.30, 21.80), LatLng(38.31, 21.78))
+
+        val closed = RouteGeometry.closeLoop(pts, isLoop = true)
+
+        assertEquals(pts.size + 1, closed.size, "a loop must return to its origin")
+        assertEquals(pts.first(), closed.last())
+    }
+
+    @Test
+    fun nonLoopPolylineIsUnchanged() {
+        val pts = listOf(LatLng(38.29, 21.79), LatLng(38.30, 21.80))
+        assertEquals(pts, RouteGeometry.closeLoop(pts, isLoop = false))
+    }
+
+    @Test
+    fun alreadyClosedLoopIsNotDoubleClosed() {
+        val first = LatLng(38.29, 21.79)
+        val pts = listOf(first, LatLng(38.30, 21.80), first)
+        assertEquals(pts, RouteGeometry.closeLoop(pts, isLoop = true))
+    }
+
+    @Test
+    fun degeneratePolylineIsUnchanged() {
+        val one = listOf(LatLng(38.29, 21.79))
+        assertEquals(one, RouteGeometry.closeLoop(one, isLoop = true))
+        assertEquals(emptyList(), RouteGeometry.closeLoop(emptyList(), isLoop = true))
+    }
+}

--- a/core/common/src/commonTest/kotlin/com/syrmos/core/common/map/RouteGeometryTest.kt
+++ b/core/common/src/commonTest/kotlin/com/syrmos/core/common/map/RouteGeometryTest.kt
@@ -49,4 +49,59 @@ class RouteGeometryTest {
         assertEquals(one, RouteGeometry.closeLoop(one, isLoop = true))
         assertEquals(emptyList(), RouteGeometry.closeLoop(emptyList(), isLoop = true))
     }
+
+    // --- displayShape: draw geometry == marker-snap geometry ---
+
+    @Test
+    fun busDisplayShapeIgnoresTheOsmShapeAndUsesStops() {
+        // PU1 regression: the bundled shape omits the western stops, so a marker
+        // snapped to it lands ~1km off route. displayShape must return the loop-
+        // closed stops, not the shape, so draw and snap both use the stops.
+        val paKst = LatLng(38.2896, 21.771523)
+        val puOae = LatLng(38.2810, 21.782000)
+        val stops = listOf(paKst, LatLng(38.30, 21.79), puOae)
+        val incompleteOsm = listOf(LatLng(38.29, 21.7836343), LatLng(38.29, 21.7945585))
+
+        val shape = RouteGeometry.displayShape(
+            isBus = true, isLoop = true, stations = stops, osmShape = incompleteOsm,
+        )!!
+
+        assertEquals(paKst, shape.first(), "bus geometry must start at the first real stop, not the OSM shape")
+        assertEquals(paKst, shape.last(), "a loop bus must close back to its origin stop")
+        assertEquals(stops.size + 1, shape.size)
+        assertTrue(incompleteOsm.none { it in shape }, "the incomplete OSM shape must not leak into bus geometry")
+    }
+
+    @Test
+    fun nonLoopBusDisplayShapeIsItsStraightStops() {
+        val stops = listOf(LatLng(40.56, 22.96), LatLng(40.52, 22.97))
+        assertEquals(
+            stops,
+            RouteGeometry.displayShape(isBus = true, isLoop = false, stations = stops, osmShape = null),
+        )
+    }
+
+    @Test
+    fun railDisplayShapePrefersTheOsmShape() {
+        val stops = listOf(LatLng(37.94, 23.64), LatLng(37.99, 23.74))
+        val osm = listOf(LatLng(37.94, 23.64), LatLng(37.96, 23.69), LatLng(37.99, 23.74))
+        assertEquals(
+            osm,
+            RouteGeometry.displayShape(isBus = false, isLoop = false, stations = stops, osmShape = osm),
+        )
+    }
+
+    @Test
+    fun railWithoutShapeReturnsNullSoCallerCanSpline() {
+        val stops = listOf(LatLng(37.94, 23.64), LatLng(37.99, 23.74))
+        assertEquals(null, RouteGeometry.displayShape(isBus = false, isLoop = false, stations = stops, osmShape = null))
+    }
+
+    @Test
+    fun busWithFewerThanTwoStopsHasNoDisplayShape() {
+        assertEquals(
+            null,
+            RouteGeometry.displayShape(isBus = true, isLoop = false, stations = listOf(LatLng(1.0, 2.0)), osmShape = null),
+        )
+    }
 }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/DataSeeder.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/DataSeeder.kt
@@ -12,7 +12,7 @@ class DataSeeder(
     suspend fun seedIfNeeded() {
         val currentVersion = database.syrmosDatabaseQueries.getMetadata("seed_version")
             .executeAsOneOrNull()
-        if (currentVersion != null && currentVersion >= SEED_VERSION) return
+        if (!shouldReseed(currentVersion, SEED_VERSION)) return
 
         seed()
     }
@@ -251,6 +251,20 @@ class DataSeeder(
         // so their map geometry follows the real stop order. Without a bump an
         // existing install keeps its old rows and the buses stay mis-ordered.
         const val SEED_VERSION = "10"
+
+        /**
+         * Whether the bundled seed must be (re)written. Compares versions
+         * NUMERICALLY: they are stored as strings and SEED_VERSION crossed into
+         * two digits at 10, so a lexicographic String compare reads "9" >= "10"
+         * as true and a version-9 install would never pick up the version-10
+         * data (skipping exactly the bus-ordering repair this bump ships). An
+         * unset or unparseable stored version always reseeds.
+         */
+        internal fun shouldReseed(storedVersion: String?, targetVersion: String): Boolean {
+            val target = targetVersion.toIntOrNull() ?: return true
+            val stored = storedVersion?.toIntOrNull() ?: return true
+            return stored < target
+        }
 
         /**
          * The ordered nested stations to seed into station_line_entity for a

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/DataSeeder.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/DataSeeder.kt
@@ -90,6 +90,41 @@ class DataSeeder(
                 }
             }
 
+            // Lines absent from routes.json (most buses: VL1, DX1, KP1, TL1,
+            // PU1/PU2, X3/2X, ...) would otherwise have no ordered station_line
+            // rows, so getStationsOnLine falls back to the globally-ordered
+            // stations.json, giving their stops a wrong, backtracking order, or
+            // none at all (X3/2X stops live only in the nested lines.json).
+            // Seed their ordering from the nested lines.json stations, inserting
+            // any station that exists only there.
+            val routeLineIds = routes.mapTo(mutableSetOf()) { it.lineId }
+            val knownStationIds = stations.mapTo(mutableSetOf()) { it.id }
+            lines.forEach { line ->
+                nestedStationOrder(line, routeLineIds).forEachIndexed { position, s ->
+                    if (s.id !in knownStationIds) {
+                        database.syrmosDatabaseQueries.insertStation(
+                            id = s.id,
+                            name = s.name,
+                            name_el = s.nameEl,
+                            name_sq = null,
+                            latitude = s.lat,
+                            longitude = s.lng,
+                            is_interchange = 0L,
+                            accessibility = if (s.accessibility) 1L else 0L,
+                            zone = s.zone.toLong(),
+                            region = s.region,
+                            source_confidence = "scheduled",
+                        )
+                        knownStationIds.add(s.id)
+                    }
+                    database.syrmosDatabaseQueries.insertStationLine(
+                        station_id = s.id,
+                        line_id = line.id,
+                        position_on_line = position.toLong(),
+                    )
+                }
+            }
+
             transfers.forEach { transfer ->
                 database.syrmosDatabaseQueries.insertTransfer(
                     station_id = transfer.stationId,
@@ -211,9 +246,39 @@ class DataSeeder(
     }
 
     companion object {
-        // Bumped to 6: national rail + rail-replacement-bus trips are now
-        // expanded into schedule_entity for offline departures. Without a bump
-        // an existing install keeps its old rows and never sees them.
-        const val SEED_VERSION = "9"
+        // Bumped to 10: lines absent from routes.json (most buses) now get
+        // ordered station_line rows seeded from the nested lines.json stations,
+        // so their map geometry follows the real stop order. Without a bump an
+        // existing install keeps its old rows and the buses stay mis-ordered.
+        const val SEED_VERSION = "10"
+
+        /**
+         * The ordered nested stations to seed into station_line_entity for a
+         * line that is ABSENT from routes.json. routes.json only lists 21 of the
+         * 33 lines; the rest (most buses: VL1, DX1, KP1, TL1, PU1/PU2, X3/2X, the
+         * Thessaloniki airport links, ...) would otherwise have no ordered
+         * station_line rows, so getStationsOnLine falls back to the globally
+         * ordered stations.json and the route draws as a backtracking zig-zag or,
+         * for lines whose stops exist only here (X3/2X), draws nothing. Returns
+         * empty for a line already in routes.json (the routes loop seeds it) so a
+         * stop is never double-inserted or reordered.
+         */
+        internal fun nestedStationOrder(
+            line: SeedLine,
+            routeLineIds: Set<String>,
+        ): List<SeedLineStation> =
+            if (line.id in routeLineIds) emptyList() else line.stations
+
+        /**
+         * The final ordered station ids the map will draw for [line] via
+         * getStationsOnLine: routes.json order when present, else the nested
+         * lines.json order. Every drawable line (in particular every bus) must
+         * resolve to at least two ordered stops or its polyline degenerates.
+         */
+        internal fun resolveOrderedStationIds(
+            line: SeedLine,
+            routesByLine: Map<String, List<String>>,
+        ): List<String> =
+            routesByLine[line.id] ?: line.stations.map { it.id }
     }
 }

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/seed/DataSeederOrderingTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/seed/DataSeederOrderingTest.kt
@@ -1,0 +1,172 @@
+package com.syrmos.core.data.seed
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+/**
+ * Guards the seed-ordering fix behind [DataSeeder.nestedStationOrder] and
+ * [DataSeeder.resolveOrderedStationIds].
+ *
+ * routes.json lists only 21 of the 33 lines. Nine of the ten buses (VL1, DX1,
+ * KP1, TL1, PU1/PU2, X3/2X, KB1) are absent from it, so before the fix their
+ * station_line rows were missing and getStationsOnLine fell back to the
+ * globally ordered stations.json: the map drew a backtracking zig-zag, and the
+ * buses whose stops exist only in the nested lines.json (X3/2X) drew nothing.
+ * The fix seeds each absent line's ordered station_line rows from its nested
+ * lines.json stations. These tests pin that behaviour with inline fixtures
+ * shaped exactly like the bundled seed (PSB is the single bus present in
+ * routes.json, so it exercises the routes-wins, do-not-reseed path).
+ */
+class DataSeederOrderingTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // Mirrors schedules-v2/lines.json: PSB is in routes.json below (and its
+    // nested order is deliberately REVERSED to prove routes wins); VL1/X3 are
+    // absent buses that rely on the nested fallback; M1 is a non-bus in routes.
+    private val linesJson = """
+        {"version":1,"updatedAt":"t","lines":[
+          {"id":"M1","name":"Line 1","nameEl":"Γραμμή 1","type":"metro","color":"#0f0",
+           "terminalA":"a","terminalB":"b","stationCount":3,
+           "stations":[
+             {"id":"M1_A","name":"A","nameEl":"Α","lat":37.94,"lng":23.64},
+             {"id":"M1_B","name":"B","nameEl":"Β","lat":37.95,"lng":23.65},
+             {"id":"M1_C","name":"C","nameEl":"Γ","lat":37.96,"lng":23.66}]},
+          {"id":"PSB","name":"Patras Bus","nameEl":"Λεωφορείο","type":"bus","color":"#00f",
+           "terminalA":"a","terminalB":"b","stationCount":3,
+           "stations":[
+             {"id":"PA_KAT","name":"Kato","nameEl":"Κάτω","lat":38.20,"lng":21.75},
+             {"id":"PA_MID","name":"Mid","nameEl":"Μέση","lat":38.17,"lng":21.65},
+             {"id":"PA_KAST","name":"Kastelokampos","nameEl":"Καστελλόκαμπος","lat":38.15,"lng":21.56}]},
+          {"id":"VL1","name":"Volos Bus","nameEl":"Λεωφορείο","type":"bus","color":"#00f",
+           "terminalA":"a","terminalB":"b","stationCount":3,
+           "stations":[
+             {"id":"VL_VOL","name":"Volos","nameEl":"Βόλος","lat":39.3647,"lng":22.9367},
+             {"id":"VL_MID","name":"Mid","nameEl":"Μέση","lat":39.35,"lng":22.80},
+             {"id":"VL_VEL","name":"Velestino","nameEl":"Βελεστίνο","lat":39.38,"lng":22.75}]},
+          {"id":"X3","name":"Airport Express","nameEl":"Εξπρές","type":"bus","color":"#00f",
+           "terminalA":"a","terminalB":"b","stationCount":2,
+           "stations":[
+             {"id":"THS_AIR","name":"Airport","nameEl":"Αεροδρόμιο","lat":40.5197,"lng":22.9709},
+             {"id":"SKG_CEN","name":"Center","nameEl":"Κέντρο","lat":40.6403,"lng":22.9444}]}
+        ]}
+    """.trimIndent()
+
+    // Mirrors routes.json: M1 and PSB only. PSB's route order differs from its
+    // nested order above so we can prove routes.json wins for lines it lists.
+    private val routesJson = """
+        [
+          {"line_id":"M1","station_ids":["M1_A","M1_B","M1_C"]},
+          {"line_id":"PSB","station_ids":["PA_KAST","PA_MID","PA_KAT"]}
+        ]
+    """.trimIndent()
+
+    private fun lines(): List<SeedLine> =
+        json.decodeFromString<SeedLinesPayload>(linesJson).lines
+
+    private fun routesByLine(): Map<String, List<String>> =
+        json.decodeFromString<List<SeedRoute>>(routesJson).associate { it.lineId to it.stationIds }
+
+    private fun routeLineIds(): Set<String> = routesByLine().keys
+
+    @Test
+    fun busAbsentFromRoutesIsSeededFromItsNestedStationOrder() {
+        val vl1 = lines().first { it.id == "VL1" }
+
+        val order = DataSeeder.nestedStationOrder(vl1, routeLineIds())
+
+        assertEquals(
+            listOf("VL_VOL", "VL_MID", "VL_VEL"),
+            order.map { it.id },
+            "an absent bus must be seeded in its nested lines.json order",
+        )
+    }
+
+    @Test
+    fun busPresentInRoutesIsNotReseededFromNestedStations() {
+        val psb = lines().first { it.id == "PSB" }
+
+        // Empty => the nested loop inserts nothing, so the routes.json order is
+        // the only station_line ordering and no stop is double-inserted.
+        assertTrue(
+            DataSeeder.nestedStationOrder(psb, routeLineIds()).isEmpty(),
+            "a line already in routes.json must not be re-seeded from nested stations",
+        )
+    }
+
+    @Test
+    fun routesOrderWinsOverNestedOrderWhenBothExist() {
+        val psb = lines().first { it.id == "PSB" }
+
+        assertEquals(
+            listOf("PA_KAST", "PA_MID", "PA_KAT"),
+            DataSeeder.resolveOrderedStationIds(psb, routesByLine()),
+            "routes.json ordering must win over the (reversed) nested ordering",
+        )
+    }
+
+    @Test
+    fun absentBusResolvesToItsNestedOrder() {
+        val x3 = lines().first { it.id == "X3" }
+
+        // X3's stops exist only in nested lines.json; without the fallback it
+        // would resolve to nothing and draw no line.
+        assertEquals(
+            listOf("THS_AIR", "SKG_CEN"),
+            DataSeeder.resolveOrderedStationIds(x3, routesByLine()),
+            "a bus absent from routes.json must resolve via its nested stations",
+        )
+    }
+
+    @Test
+    fun everyBusResolvesToAtLeastTwoOrderedStops() {
+        val routes = routesByLine()
+
+        lines().filter { it.type == "bus" }.forEach { bus ->
+            val ordered = DataSeeder.resolveOrderedStationIds(bus, routes)
+            assertTrue(
+                ordered.size >= 2,
+                "bus ${bus.id} resolved to ${ordered.size} ordered stop(s); a route needs at least 2",
+            )
+            assertEquals(
+                ordered.size,
+                ordered.toSet().size,
+                "bus ${bus.id} has a duplicate stop in its ordered sequence",
+            )
+        }
+    }
+
+    @Test
+    fun nestedStopsForAbsentBusCarryFiniteCoordinates() {
+        lines()
+            .filter { it.type == "bus" }
+            .flatMap { DataSeeder.nestedStationOrder(it, routeLineIds()) }
+            .forEach { s ->
+                assertTrue(
+                    s.lat.isFinite() && s.lng.isFinite() && (s.lat != 0.0 || s.lng != 0.0),
+                    "nested stop ${s.id} must carry real coordinates, not ${s.lat},${s.lng}",
+                )
+            }
+    }
+
+    @Test
+    fun aBusWithFewerThanTwoStopsIsDetectable() {
+        // Proves the >= 2 guard above has teeth: a degenerate bus is flagged.
+        val degenerate = json.decodeFromString<SeedLinesPayload>(
+            """
+            {"lines":[
+              {"id":"BAD","name":"Bad","nameEl":"Κακό","type":"bus","color":"#f00",
+               "terminalA":"a","terminalB":"b","stationCount":1,
+               "stations":[{"id":"ONLY","name":"Only","nameEl":"Μόνο","lat":38.0,"lng":23.0}]}
+            ]}
+            """.trimIndent(),
+        ).lines.first()
+
+        assertTrue(
+            DataSeeder.resolveOrderedStationIds(degenerate, emptyMap()).size < 2,
+            "a bus with a single nested stop must be detectable as too short to draw",
+        )
+    }
+}

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/seed/DataSeederOrderingTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/seed/DataSeederOrderingTest.kt
@@ -152,6 +152,38 @@ class DataSeederOrderingTest {
     }
 
     @Test
+    fun version9InstallStillReseedsToVersion10() {
+        // The regression Codex caught: a lexicographic String compare reads
+        // "9" >= "10" as true, so a version-9 install would skip the reseed and
+        // keep the broken bus geometry. shouldReseed must compare numerically.
+        assertTrue(
+            DataSeeder.shouldReseed("9", "10"),
+            "a version-9 install must reseed to version 10",
+        )
+    }
+
+    @Test
+    fun sameOrNewerVersionDoesNotReseed() {
+        assertTrue(!DataSeeder.shouldReseed("10", "10"), "same version must not reseed")
+        assertTrue(!DataSeeder.shouldReseed("11", "10"), "a newer version must not reseed")
+    }
+
+    @Test
+    fun missingOrUnparseableVersionReseeds() {
+        assertTrue(DataSeeder.shouldReseed(null, "10"), "a fresh install must seed")
+        assertTrue(DataSeeder.shouldReseed("", "10"))
+        assertTrue(DataSeeder.shouldReseed("garbage", "10"))
+    }
+
+    @Test
+    fun earlierSingleDigitVersionsStillReseed() {
+        // Guards the pre-existing single-digit bumps that happened to work
+        // lexicographically, so numeric comparison does not regress them.
+        assertTrue(DataSeeder.shouldReseed("6", "10"))
+        assertTrue(DataSeeder.shouldReseed("9", "10"))
+    }
+
+    @Test
     fun aBusWithFewerThanTwoStopsIsDetectable() {
         // Proves the >= 2 guard above has teeth: a degenerate bus is flagged.
         val degenerate = json.decodeFromString<SeedLinesPayload>(

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -202,6 +202,26 @@ internal actual fun PlatformMapView(
     var hasFittedBounds by remember { mutableStateOf(false) }
     val mapViewRef = remember { mutableStateOf<MapView?>(null) }
     val routeShapes = remember { loadRouteShapes(context) }
+    // The single polyline each line is BOTH drawn as and has its vehicle markers
+    // snapped to, so the drawn route and the moving markers never diverge. Buses
+    // resolve to their ordered stops (loop-closed for PU1), ignoring incomplete
+    // bundled shapes; rail/tram keep the OSM shape. Built via the shared
+    // RouteGeometry so every client agrees on the geometry.
+    val effectiveShapes: Map<String, List<GeoPoint>> =
+        remember(uiState.lines, uiState.lineStations, routeShapes) {
+            uiState.lines.associate { line ->
+                val stations = uiState.lineStations[line.id].orEmpty()
+                    .map { LatLng(it.latitude, it.longitude) }
+                val osm = routeShapes[line.id]?.map { LatLng(it.latitude, it.longitude) }
+                val shape = RouteGeometry.displayShape(
+                    isBus = line.type == LineType.BUS,
+                    isLoop = RouteGeometry.isLoopTerminals(line.terminalA, line.terminalB),
+                    stations = stations,
+                    osmShape = osm,
+                )
+                line.id to (shape?.map { GeoPoint(it.lat, it.lng) } ?: emptyList())
+            }.filterValues { it.size >= 2 }
+        }
     val lineColors = remember { loadLineColors(context) }
     val lineOverlays = remember { mutableListOf<Polyline>() }
     val stationMarkers = remember { mutableMapOf<String, Marker>() }
@@ -301,27 +321,17 @@ internal actual fun PlatformMapView(
             val lineStations = uiState.lineStations[line.id].orEmpty()
             if (lineStations.size < 2) return@forEach
 
-            // Buses draw straight segments through their actual ordered stops,
-            // chosen BEFORE any bundled OSM shape. A bus shape can cover only
-            // part of the route (the Patras University loop shape omits its
-            // western stops, stranding those markers), and a spline overshoots
-            // on tight loops. Straight segments connect every stop; the stops
-            // are correctly ordered because DataSeeder seeds station_line rows
-            // for routes.json-absent lines from the nested lines.json stations.
-            // A loop bus (PU1: both terminals Kastelokampos) is closed back to
-            // its origin so the return leg is not left as an open gap.
-            // Rail/tram still prefer real OSM track geometry so the Piraeus
-            // loop, M3 airport branch and suburban curves render accurately.
-            val osmShape = routeShapes[line.id]
-            val smoothed: List<GeoPoint> = when {
-                line.type == LineType.BUS ->
-                    RouteGeometry.closeLoop(
-                        lineStations.map { LatLng(it.latitude, it.longitude) },
-                        RouteGeometry.isLoopTerminals(line.terminalA, line.terminalB),
-                    ).map { GeoPoint(it.lat, it.lng) }
-                osmShape != null && osmShape.size >= 2 -> osmShape
-                else -> catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
-            }
+            // The drawn polyline is the SAME effectiveShapes geometry the vehicle
+            // markers snap to, so a bus is never drawn along its stops while its
+            // marker rides an unrelated OSM shape. Buses resolve to their ordered
+            // stops (loop-closed for PU1, whose bundled shape omits the western
+            // stops); rail/tram keep OSM track geometry so the Piraeus loop, M3
+            // airport branch and suburban curves render accurately. Only a line
+            // with no usable geometry falls back to a spline through its stops.
+            val displayShape = effectiveShapes[line.id]
+            val smoothed: List<GeoPoint> =
+                if (displayShape != null && displayShape.size >= 2) displayShape
+                else catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
             val override = displayOverrides[line.id]
             // A line that is built but not open still draws, because the track is
             // real, but it reads as inert: muted grey, thinner, dashed. It carries
@@ -497,7 +507,7 @@ internal actual fun PlatformMapView(
             // badges, which is exactly why the trains looked nothing like web. Line
             // colour comes from the raw lines.json hex, same as web.
             val lineColor = lineColors[train.lineId] ?: train.lineColor.toComposeColor().toArgb()
-            val snappedSimPos = snapToPolyline(train.latitude, train.longitude, train.lineId, routeShapes)
+            val snappedSimPos = snapToPolyline(train.latitude, train.longitude, train.lineId, effectiveShapes)
             val existing = trainMarkers[train.id]
             if (existing != null) {
                 existing.position = snappedSimPos
@@ -546,7 +556,7 @@ internal actual fun PlatformMapView(
             val color = if (notInService) 0xFF9CA3AF.toInt()
                 else uiState.lines.find { it.id == train.lineId }?.color?.toComposeColor()?.toArgb()
                     ?: 0xFF7C4DFF.toInt()
-            val snappedPos = snapToPolyline(train.latitude, train.longitude, train.lineId, routeShapes)
+            val snappedPos = snapToPolyline(train.latitude, train.longitude, train.lineId, effectiveShapes)
             val existing = liveTrainMarkers[train.id]
             if (existing != null) {
                 existing.position = snappedPos

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.syrmos.core.designsystem.component.toComposeColor
+import com.syrmos.core.common.map.LatLng
 import com.syrmos.core.common.map.MapDesignTokens
+import com.syrmos.core.common.map.RouteGeometry
 import com.syrmos.core.model.transit.Direction
 import com.syrmos.core.model.transit.LineType
 import com.syrmos.core.model.transit.SimulatedTrain
@@ -306,12 +308,17 @@ internal actual fun PlatformMapView(
             // on tight loops. Straight segments connect every stop; the stops
             // are correctly ordered because DataSeeder seeds station_line rows
             // for routes.json-absent lines from the nested lines.json stations.
+            // A loop bus (PU1: both terminals Kastelokampos) is closed back to
+            // its origin so the return leg is not left as an open gap.
             // Rail/tram still prefer real OSM track geometry so the Piraeus
             // loop, M3 airport branch and suburban curves render accurately.
             val osmShape = routeShapes[line.id]
             val smoothed: List<GeoPoint> = when {
                 line.type == LineType.BUS ->
-                    lineStations.map { GeoPoint(it.latitude, it.longitude) }
+                    RouteGeometry.closeLoop(
+                        lineStations.map { LatLng(it.latitude, it.longitude) },
+                        RouteGeometry.isLoopTerminals(line.terminalA, line.terminalB),
+                    ).map { GeoPoint(it.lat, it.lng) }
                 osmShape != null && osmShape.size >= 2 -> osmShape
                 else -> catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
             }

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -299,14 +299,21 @@ internal actual fun PlatformMapView(
             val lineStations = uiState.lineStations[line.id].orEmpty()
             if (lineStations.size < 2) return@forEach
 
-            // Prefer real OSM track geometry over a spline through station
-            // points so the Piraeus loop, M3 airport branch and suburban
-            // curves render accurately.
+            // Buses draw straight segments through their actual ordered stops,
+            // chosen BEFORE any bundled OSM shape. A bus shape can cover only
+            // part of the route (the Patras University loop shape omits its
+            // western stops, stranding those markers), and a spline overshoots
+            // on tight loops. Straight segments connect every stop; the stops
+            // are correctly ordered because DataSeeder seeds station_line rows
+            // for routes.json-absent lines from the nested lines.json stations.
+            // Rail/tram still prefer real OSM track geometry so the Piraeus
+            // loop, M3 airport branch and suburban curves render accurately.
             val osmShape = routeShapes[line.id]
-            val smoothed: List<GeoPoint> = if (osmShape != null && osmShape.size >= 2) {
-                osmShape
-            } else {
-                catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
+            val smoothed: List<GeoPoint> = when {
+                line.type == LineType.BUS ->
+                    lineStations.map { GeoPoint(it.latitude, it.longitude) }
+                osmShape != null && osmShape.size >= 2 -> osmShape
+                else -> catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
             }
             val override = displayOverrides[line.id]
             // A line that is built but not open still draws, because the track is

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -19,9 +19,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.syrmos.core.designsystem.component.toComposeColor
-import com.syrmos.core.common.map.LatLng
 import com.syrmos.core.common.map.MapDesignTokens
-import com.syrmos.core.common.map.RouteGeometry
 import com.syrmos.core.model.transit.Direction
 import com.syrmos.core.model.transit.LineType
 import com.syrmos.core.model.transit.SimulatedTrain
@@ -61,18 +59,10 @@ private val ESRI_DARK: ITileSource = esriGrayNoLabels("EsriGrayDark", "World_Dar
 
 private fun tileSourceFor(dark: Boolean): ITileSource = if (dark) ESRI_DARK else ESRI_LIGHT
 
-/**
- * OSM-derived rail route geometry shipped at `assets/files/seed/schedules-v2/shapes.json`.
- * Loaded once at first map mount and used in place of catmullRomSpline(stations)
- * so polylines follow real track (T7 Piraeus loop, M3 airport branch, A4 Megara curve).
- * Falls back to spline-of-stations when a line has no shape.
- */
-@Serializable
-private data class RouteShape(val coordinates: List<List<Double>>)
-
-@Serializable
-private data class RouteShapesPayload(val shapes: Map<String, RouteShape>)
-
+// Vehicle markers snap to the shared effectiveGeometry (the same polyline the
+// route is drawn as), so a marker never floats off its own line. OSM shapes are
+// loaded once in commonMain (LineGeometryRepository) and merged into that shared
+// geometry by MapViewModel, so this file no longer reads shapes.json directly.
 private fun snapToPolyline(lat: Double, lng: Double, lineId: String, shapes: Map<String, List<GeoPoint>>): GeoPoint {
     val poly = shapes[lineId] ?: return GeoPoint(lat, lng)
     if (poly.size < 2) return GeoPoint(lat, lng)
@@ -92,18 +82,6 @@ private fun snapToPolyline(lat: Double, lng: Double, lineId: String, shapes: Map
         if (d < bestDist) { bestDist = d; bestLat = px; bestLng = py }
     }
     return GeoPoint(bestLat, bestLng)
-}
-
-private fun loadRouteShapes(context: Context): Map<String, List<GeoPoint>> {
-    return runCatching {
-        val body = context.assets.open("files/seed/schedules-v2/shapes.json").bufferedReader().use { it.readText() }
-        val payload = Json { ignoreUnknownKeys = true }.decodeFromString<RouteShapesPayload>(body)
-        payload.shapes.mapValues { (_, shape) ->
-            shape.coordinates.mapNotNull { pair ->
-                if (pair.size >= 2) GeoPoint(pair[0], pair[1]) else null
-            }
-        }
-    }.getOrDefault(emptyMap())
 }
 
 /**
@@ -201,26 +179,15 @@ internal actual fun PlatformMapView(
     val context = LocalContext.current
     var hasFittedBounds by remember { mutableStateOf(false) }
     val mapViewRef = remember { mutableStateOf<MapView?>(null) }
-    val routeShapes = remember { loadRouteShapes(context) }
-    // The single polyline each line is BOTH drawn as and has its vehicle markers
-    // snapped to, so the drawn route and the moving markers never diverge. Buses
-    // resolve to their ordered stops (loop-closed for PU1), ignoring incomplete
-    // bundled shapes; rail/tram keep the OSM shape. Built via the shared
-    // RouteGeometry so every client agrees on the geometry.
+    // The single polyline each line is drawn as, has its vehicle markers snapped
+    // to, AND is simulated along: MapViewModel computes it once (buses ride their
+    // stops loop-closed for PU1, rail/tram keep the OSM shape) and shares it here,
+    // so the drawn route, the moving markers and the simulator can never diverge.
     val effectiveShapes: Map<String, List<GeoPoint>> =
-        remember(uiState.lines, uiState.lineStations, routeShapes) {
-            uiState.lines.associate { line ->
-                val stations = uiState.lineStations[line.id].orEmpty()
-                    .map { LatLng(it.latitude, it.longitude) }
-                val osm = routeShapes[line.id]?.map { LatLng(it.latitude, it.longitude) }
-                val shape = RouteGeometry.displayShape(
-                    isBus = line.type == LineType.BUS,
-                    isLoop = RouteGeometry.isLoopTerminals(line.terminalA, line.terminalB),
-                    stations = stations,
-                    osmShape = osm,
-                )
-                line.id to (shape?.map { GeoPoint(it.lat, it.lng) } ?: emptyList())
-            }.filterValues { it.size >= 2 }
+        remember(uiState.effectiveGeometry) {
+            uiState.effectiveGeometry.mapValues { (_, poly) ->
+                poly.map { GeoPoint(it.lat, it.lng) }
+            }
         }
     val lineColors = remember { loadLineColors(context) }
     val lineOverlays = remember { mutableListOf<Polyline>() }
@@ -321,17 +288,14 @@ internal actual fun PlatformMapView(
             val lineStations = uiState.lineStations[line.id].orEmpty()
             if (lineStations.size < 2) return@forEach
 
-            // The drawn polyline is the SAME effectiveShapes geometry the vehicle
-            // markers snap to, so a bus is never drawn along its stops while its
-            // marker rides an unrelated OSM shape. Buses resolve to their ordered
-            // stops (loop-closed for PU1, whose bundled shape omits the western
-            // stops); rail/tram keep OSM track geometry so the Piraeus loop, M3
-            // airport branch and suburban curves render accurately. Only a line
-            // with no usable geometry falls back to a spline through its stops.
-            val displayShape = effectiveShapes[line.id]
-            val smoothed: List<GeoPoint> =
-                if (displayShape != null && displayShape.size >= 2) displayShape
-                else catmullRomSpline(lineStations.map { GeoPoint(it.latitude, it.longitude) })
+            // The drawn polyline is the SAME shared effectiveGeometry the vehicle
+            // markers snap to and the simulator rides, so a bus is never drawn
+            // along its stops while its marker or vehicle follows an unrelated OSM
+            // shape. Buses resolve to their ordered stops (loop-closed for PU1),
+            // rail/tram keep OSM track geometry, and a shapeless line is already
+            // splined upstream. A line with no usable geometry is skipped.
+            val smoothed: List<GeoPoint> = effectiveShapes[line.id] ?: return@forEach
+            if (smoothed.size < 2) return@forEach
             val override = displayOverrides[line.id]
             // A line that is built but not open still draws, because the track is
             // real, but it reads as inert: muted grey, thinner, dashed. It carries
@@ -628,29 +592,6 @@ private fun parseHex(hex: String): Int {
         8 -> s.toLongOrNull(16)?.toInt() ?: fallback
         else -> fallback
     }
-}
-
-private fun catmullRomSpline(points: List<GeoPoint>, segments: Int = 5): List<GeoPoint> {
-    if (points.size < 3) return points
-    val result = mutableListOf(points[0])
-    for (i in 0 until points.size - 1) {
-        val p0 = points[maxOf(i - 1, 0)]
-        val p1 = points[i]
-        val p2 = points[i + 1]
-        val p3 = points[minOf(i + 2, points.size - 1)]
-        for (t in 1..segments) {
-            val f = t.toDouble() / (segments + 1)
-            val lat = cr(p0.latitude, p1.latitude, p2.latitude, p3.latitude, f)
-            val lon = cr(p0.longitude, p1.longitude, p2.longitude, p3.longitude, f)
-            result.add(GeoPoint(lat, lon))
-        }
-        result.add(p2)
-    }
-    return result
-}
-
-private fun cr(a: Double, b: Double, c: Double, d: Double, t: Double): Double {
-    return 0.5 * (2*b + (-a+c)*t + (2*a - 5*b + 4*c - d)*t*t + (-a + 3*b - 3*c + d)*t*t*t)
 }
 
 // Fallback bitmap builders for when PNG drawables are not found

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/FallbackMapView.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/FallbackMapView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeJoin
+import com.syrmos.core.common.map.LatLng
 import com.syrmos.core.designsystem.component.toComposeColor
 import com.syrmos.core.model.alerts.AlertSeverity
 import com.syrmos.core.model.transit.LineType
@@ -134,34 +135,26 @@ private fun DrawScope.drawFallbackMap(
     textMeasurer: TextMeasurer,
 ) {
     for (line in uiState.lines) {
-        val stations = uiState.lineStations[line.id] ?: continue
+        // Draw the SAME shared effectiveGeometry the vehicles ride (buses on their
+        // stops, rail/tram on the OSM shape, shapeless lines splined upstream), so
+        // the drawn route and the moving vehicles agree on iOS and Wasm exactly as
+        // they do on Android. No extra smoothing: effectiveGeometry is final.
+        val poly = uiState.effectiveGeometry[line.id] ?: continue
+        if (poly.size < 2) continue
         val lineColor = line.color.toComposeColor()
         val strokeWidth = (4f * scale).coerceIn(1.5f, 12f)
-        val points = stations.map { s ->
-            latLonToScreen(s.latitude, s.longitude, canvasWidth, canvasHeight, offsetX, offsetY, scale)
+        val points = poly.map { p ->
+            latLonToScreen(p.lat, p.lng, canvasWidth, canvasHeight, offsetX, offsetY, scale)
         }
-        if (points.size >= 2) {
-            val path = Path().apply {
-                moveTo(points[0].x, points[0].y)
-                if (points.size == 2) {
-                    lineTo(points[1].x, points[1].y)
-                } else {
-                    for (i in 1 until points.size) {
-                        val prev = points[i - 1]
-                        val curr = points[i]
-                        val mx = (prev.x + curr.x) / 2f
-                        val my = (prev.y + curr.y) / 2f
-                        quadraticTo(prev.x, prev.y, mx, my)
-                    }
-                    lineTo(points.last().x, points.last().y)
-                }
-            }
-            drawPath(
-                path = path,
-                color = lineColor,
-                style = Stroke(width = strokeWidth, cap = StrokeCap.Round, join = StrokeJoin.Round),
-            )
+        val path = Path().apply {
+            moveTo(points[0].x, points[0].y)
+            for (i in 1 until points.size) lineTo(points[i].x, points[i].y)
         }
+        drawPath(
+            path = path,
+            color = lineColor,
+            style = Stroke(width = strokeWidth, cap = StrokeCap.Round, join = StrokeJoin.Round),
+        )
     }
 
     val dotRadius = (6f * scale).coerceIn(3f, 18f)
@@ -268,6 +261,7 @@ private fun DrawScope.drawFallbackMap(
 
     drawLiveTrains(
         trains = uiState.liveTrains,
+        geometry = uiState.effectiveGeometry,
         canvasWidth = canvasWidth,
         canvasHeight = canvasHeight,
         offsetX = offsetX,
@@ -430,6 +424,7 @@ private fun DrawScope.drawAirportTrain(pos: Offset, color: Color, scale: Float) 
 
 private fun DrawScope.drawLiveTrains(
     trains: List<LiveSuburbanTrain>,
+    geometry: Map<String, List<LatLng>>,
     canvasWidth: Float,
     canvasHeight: Float,
     offsetX: Float,
@@ -439,7 +434,11 @@ private fun DrawScope.drawLiveTrains(
 ) {
     val trainRadius = (6f * scale).coerceIn(3f, 14f)
     for (train in trains) {
-        val pos = latLonToScreen(train.latitude, train.longitude, canvasWidth, canvasHeight, offsetX, offsetY, scale)
+        // Snap the raw GPS fix onto the drawn route so a live vehicle never floats
+        // beside its own line (same polyline the route is drawn as).
+        val snapped = geometry[train.lineId]?.let { snapToPolyline(train.latitude, train.longitude, it) }
+            ?: LatLng(train.latitude, train.longitude)
+        val pos = latLonToScreen(snapped.lat, snapped.lng, canvasWidth, canvasHeight, offsetX, offsetY, scale)
         if (pos.x < -100 || pos.x > canvasWidth + 100 || pos.y < -100 || pos.y > canvasHeight + 100) continue
 
         val lineColor = when (train.lineId) {

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/FallbackMapView.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/FallbackMapView.kt
@@ -251,6 +251,7 @@ private fun DrawScope.drawFallbackMap(
 
     drawSimulatedTrains(
         trains = uiState.simulatedTrains,
+        geometry = uiState.effectiveGeometry,
         canvasWidth = canvasWidth,
         canvasHeight = canvasHeight,
         offsetX = offsetX,
@@ -273,6 +274,7 @@ private fun DrawScope.drawFallbackMap(
 
 private fun DrawScope.drawSimulatedTrains(
     trains: List<SimulatedTrain>,
+    geometry: Map<String, List<LatLng>>,
     canvasWidth: Float,
     canvasHeight: Float,
     offsetX: Float,
@@ -281,7 +283,13 @@ private fun DrawScope.drawSimulatedTrains(
     textMeasurer: TextMeasurer,
 ) {
     for (train in trains) {
-        val pos = latLonToScreen(train.latitude, train.longitude, canvasWidth, canvasHeight, offsetX, offsetY, scale)
+        // Snap onto the drawn polyline: VehicleInterpolation.positionBetween can
+        // return a straight chord (arc-guard fallback) that leaves a curved OSM
+        // route by up to ~2km, so a projected vehicle must be pinned to the same
+        // geometry the route is drawn as, exactly as Android and the live path do.
+        val snapped = geometry[train.lineId]?.let { snapToPolyline(train.latitude, train.longitude, it) }
+            ?: LatLng(train.latitude, train.longitude)
+        val pos = latLonToScreen(snapped.lat, snapped.lng, canvasWidth, canvasHeight, offsetX, offsetY, scale)
         if (pos.x < -100 || pos.x > canvasWidth + 100 || pos.y < -100 || pos.y > canvasHeight + 100) continue
 
         val lineColor = train.lineColor.toComposeColor()

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapRouteGeometry.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapRouteGeometry.kt
@@ -65,3 +65,29 @@ fun catmullRomSpline(points: List<LatLng>, segments: Int = 5): List<LatLng> {
 
 private fun cr(a: Double, b: Double, c: Double, d: Double, t: Double): Double =
     0.5 * (2 * b + (-a + c) * t + (2 * a - 5 * b + 4 * c - d) * t * t + (-a + 3 * b - 3 * c + d) * t * t * t)
+
+/**
+ * The nearest point on [polyline] to ([lat], [lng]), used to pin a live vehicle
+ * marker onto the polyline the route is drawn as so it never floats beside its
+ * own line. Planar nearest-point (lat/lng treated as x/y), which is accurate
+ * enough at city scale. Returns the input unchanged when the polyline is too
+ * short to snap to. Mirrors the Android renderer's snap so both agree.
+ */
+fun snapToPolyline(lat: Double, lng: Double, polyline: List<LatLng>): LatLng {
+    if (polyline.size < 2) return LatLng(lat, lng)
+    var bestDist = Double.MAX_VALUE
+    var bestLat = lat
+    var bestLng = lng
+    for (i in 0 until polyline.size - 1) {
+        val ax = polyline[i].lat; val ay = polyline[i].lng
+        val bx = polyline[i + 1].lat; val by = polyline[i + 1].lng
+        val dx = bx - ax; val dy = by - ay
+        val len2 = dx * dx + dy * dy
+        val t = (if (len2 > 0) ((lat - ax) * dx + (lng - ay) * dy) / len2 else 0.0).coerceIn(0.0, 1.0)
+        val px = ax + t * dx; val py = ay + t * dy
+        val dlat = lat - px; val dlng = lng - py
+        val d = dlat * dlat + dlng * dlng
+        if (d < bestDist) { bestDist = d; bestLat = px; bestLng = py }
+    }
+    return LatLng(bestLat, bestLng)
+}

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapRouteGeometry.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapRouteGeometry.kt
@@ -1,0 +1,67 @@
+package com.syrmos.feature.map
+
+import com.syrmos.core.common.map.LatLng
+import com.syrmos.core.common.map.RouteGeometry
+import com.syrmos.core.model.transit.Line
+import com.syrmos.core.model.transit.LineType
+import com.syrmos.core.model.transit.Station
+
+/**
+ * The single per-line polyline the map both draws and rides: it feeds the drawn
+ * route, the vehicle-marker snapping, AND the train simulator/projector, so a
+ * bus can never be drawn along its stops while its vehicle is interpolated
+ * along an unrelated OSM shape (the PU1 divergence Codex caught).
+ *
+ * Per line:
+ * - bus: its ordered stops, closed into a loop when circular (PU1). Bundled OSM
+ *   bus shapes are deliberately ignored because they can be incomplete and would
+ *   strand the route or fling a vehicle onto the missing segment.
+ * - rail/tram with a real OSM shape: that shape (accurate curves).
+ * - anything else (a missing or degenerate OSM shape): a Catmull-Rom spline
+ *   through the ordered stops, so the drawn line, the snapped marker and the
+ *   simulated vehicle all use the exact same points.
+ *
+ * Lines that resolve to fewer than two points are dropped.
+ */
+fun effectiveLineGeometry(
+    lines: List<Line>,
+    lineStations: Map<String, List<Station>>,
+    osmShapes: Map<String, List<LatLng>>,
+): Map<String, List<LatLng>> =
+    lines.associate { line ->
+        val stations = lineStations[line.id].orEmpty().map { LatLng(it.latitude, it.longitude) }
+        val shape = RouteGeometry.displayShape(
+            isBus = line.type == LineType.BUS,
+            isLoop = RouteGeometry.isLoopTerminals(line.terminalA, line.terminalB),
+            stations = stations,
+            osmShape = osmShapes[line.id],
+        ) ?: catmullRomSpline(stations)
+        line.id to shape
+    }.filterValues { it.size >= 2 }
+
+/**
+ * Catmull-Rom smoothing of an ordered polyline, used only for the rail/tram
+ * fallback when no OSM track geometry is bundled. Returns the input unchanged
+ * for fewer than three points (nothing to smooth).
+ */
+fun catmullRomSpline(points: List<LatLng>, segments: Int = 5): List<LatLng> {
+    if (points.size < 3) return points
+    val result = mutableListOf(points[0])
+    for (i in 0 until points.size - 1) {
+        val p0 = points[maxOf(i - 1, 0)]
+        val p1 = points[i]
+        val p2 = points[i + 1]
+        val p3 = points[minOf(i + 2, points.size - 1)]
+        for (t in 1..segments) {
+            val f = t.toDouble() / (segments + 1)
+            val lat = cr(p0.lat, p1.lat, p2.lat, p3.lat, f)
+            val lng = cr(p0.lng, p1.lng, p2.lng, p3.lng, f)
+            result.add(LatLng(lat, lng))
+        }
+        result.add(p2)
+    }
+    return result
+}
+
+private fun cr(a: Double, b: Double, c: Double, d: Double, t: Double): Double =
+    0.5 * (2 * b + (-a + c) * t + (2 * a - 5 * b + 4 * c - d) * t * t + (-a + 3 * b - 3 * c + d) * t * t * t)

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
@@ -52,6 +52,10 @@ data class MapUiState(
     val mapStations: List<MapStationNode> = emptyList(),
     val lines: List<Line> = emptyList(),
     val lineStations: Map<String, List<Station>> = emptyMap(),
+    // The one polyline per line used to draw the route, snap vehicle markers and
+    // interpolate simulated/projected vehicles, so all three always agree. See
+    // effectiveLineGeometry (buses ride their stops, not incomplete OSM shapes).
+    val effectiveGeometry: Map<String, List<LatLng>> = emptyMap(),
     val selectedStation: MapStationNode? = null,
     val selectedStationLines: List<Line> = emptyList(),
     val selectedStationDepartures: List<StationDepartureUi> = emptyList(),
@@ -114,12 +118,22 @@ class MapViewModel(
                 lineStations[line.id] = ordered
             }
 
+            // One geometry per line, computed once, shared by the renderer and the
+            // train simulator/projector so a bus is never drawn along its stops
+            // while its vehicle rides an unrelated OSM shape.
+            val effectiveGeometry = effectiveLineGeometry(
+                lines = lines,
+                lineStations = lineStations,
+                osmShapes = lineGeometryRepository.getLineGeometry(),
+            )
+
             _uiState.update {
                 it.copy(
                     stations = stations,
                     mapStations = mapStations,
                     lines = lines,
                     lineStations = lineStations,
+                    effectiveGeometry = effectiveGeometry,
                     isLoading = false,
                 )
             }
@@ -228,13 +242,13 @@ class MapViewModel(
 
     private fun runTrainSimulation() {
         scope.launch {
-            // Bundled OSM route geometry (same shapes.json the web map uses). Loaded
-            // once — it is static and memoised — so both simulated and projected
-            // trains ride the real track instead of a straight chord between stops.
-            // Empty map (missing seed) makes the simulator fall back to chords.
-            val geometry: Map<String, List<LatLng>> = lineGeometryRepository.getLineGeometry()
             while (isActive) {
                 val state = _uiState.value
+                // The exact polyline the route is drawn as, so a vehicle is placed
+                // ALONG what the user sees (buses on their stops, not an incomplete
+                // OSM bus shape). Empty until loadMapData populates it; the guard
+                // below waits for lineStations, which is set in the same update.
+                val geometry = state.effectiveGeometry
                 if (state.lines.isNotEmpty() && state.lineStations.isNotEmpty()) {
                     val closedIds = state.stationDisruptions
                         .filterValues { it == AlertSeverity.CLOSURE }

--- a/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/MapRouteGeometryTest.kt
+++ b/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/MapRouteGeometryTest.kt
@@ -125,4 +125,20 @@ class MapRouteGeometryTest {
         assertEquals(LatLng(37.02, 23.05), snapToPolyline(37.02, 23.05, listOf(LatLng(37.0, 23.0))))
         assertEquals(LatLng(37.02, 23.05), snapToPolyline(37.02, 23.05, emptyList()))
     }
+
+    @Test
+    fun snapPullsAChordFixBackOntoACurvedRoute() {
+        // The TP2 class: a projected vehicle that fell to a straight chord between
+        // two stations sits off a curved OSM route. Snapping must pull it back
+        // onto the drawn curve, not leave it on the chord.
+        val curve = listOf(
+            LatLng(38.00, 23.00), LatLng(38.05, 23.02), LatLng(38.10, 23.00),
+            LatLng(38.15, 23.02), LatLng(38.20, 23.00),
+        )
+        // Midpoint of the chord between first and last stations, far off the curve.
+        val chordMid = snapToPolyline(38.10, 23.06, curve)
+        // The nearest curve point is near the (38.10, 23.00) vertex, not the chord.
+        assertTrue(chordMid.lng < 23.04, "snapped point must move back toward the drawn curve")
+        assertTrue(curve.any { kotlin.math.abs(it.lat - chordMid.lat) < 0.06 })
+    }
 }

--- a/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/MapRouteGeometryTest.kt
+++ b/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/MapRouteGeometryTest.kt
@@ -1,0 +1,113 @@
+package com.syrmos.feature.map
+
+import com.syrmos.core.common.map.LatLng
+import com.syrmos.core.model.transit.Line
+import com.syrmos.core.model.transit.LineColor
+import com.syrmos.core.model.transit.LineType
+import com.syrmos.core.model.transit.Station
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * effectiveLineGeometry is the single polyline the map draws, snaps markers to,
+ * AND projects vehicles along. These tests pin the per-type resolution and, in
+ * particular, that a bus rides its stops rather than an incomplete OSM shape:
+ * the PU1 divergence where a projected vehicle rode the discarded shape and
+ * landed a kilometre off its drawn route.
+ */
+class MapRouteGeometryTest {
+
+    private fun line(
+        id: String,
+        type: LineType,
+        terminalA: String = "A",
+        terminalB: String = "B",
+    ) = Line(
+        id = id, name = id, nameEl = id, type = type, color = LineColor.SUBURBAN_PURPLE,
+        terminalA = terminalA, terminalB = terminalB, stationCount = 0,
+    )
+
+    private fun station(id: String, lat: Double, lng: Double, lineId: String) =
+        Station(id = id, name = id, nameEl = id, latitude = lat, longitude = lng, lineIds = listOf(lineId))
+
+    @Test
+    fun busRidesItsStopsNotTheIncompleteOsmShape() {
+        val pu1 = line("PU1", LineType.BUS, terminalA = "Kastelokampos", terminalB = "Kastelokampos")
+        val stops = listOf(
+            station("PA_KST", 38.291426, 21.771523, "PU1"),
+            station("PU_UNR", 38.288, 21.777, "PU1"),
+            station("PU_OAE", 38.2810, 21.782000, "PU1"),
+        )
+        // The real bundled PU1 shape omits the western stops.
+        val osm = mapOf("PU1" to listOf(LatLng(38.2877553, 21.7836374), LatLng(38.29, 21.7945585)))
+
+        val geom = effectiveLineGeometry(listOf(pu1), mapOf("PU1" to stops), osm).getValue("PU1")
+
+        assertEquals(LatLng(38.291426, 21.771523), geom.first(), "a bus must start at its first real stop")
+        assertEquals(geom.first(), geom.last(), "a loop bus must return to its origin")
+        assertEquals(stops.size + 1, geom.size)
+        assertFalse(osm.getValue("PU1").any { it in geom }, "the incomplete OSM shape must not leak into a bus route")
+    }
+
+    @Test
+    fun nonLoopBusIsItsStraightStops() {
+        val vl1 = line("VL1", LineType.BUS, terminalA = "Volos", terminalB = "Larisa")
+        val stops = listOf(station("VL_A", 39.36, 22.93, "VL1"), station("VL_B", 39.63, 22.41, "VL1"))
+
+        val geom = effectiveLineGeometry(listOf(vl1), mapOf("VL1" to stops), emptyMap()).getValue("VL1")
+
+        assertEquals(listOf(LatLng(39.36, 22.93), LatLng(39.63, 22.41)), geom)
+    }
+
+    @Test
+    fun railWithAnOsmShapeKeepsThatShape() {
+        val m3 = line("M3", LineType.METRO)
+        val stops = listOf(station("M3_A", 37.94, 23.64, "M3"), station("M3_B", 37.99, 23.74, "M3"))
+        val osm = mapOf("M3" to listOf(LatLng(37.94, 23.64), LatLng(37.96, 23.69), LatLng(37.99, 23.74)))
+
+        val geom = effectiveLineGeometry(listOf(m3), mapOf("M3" to stops), osm).getValue("M3")
+
+        assertEquals(osm.getValue("M3"), geom, "rail must follow the real OSM track")
+    }
+
+    @Test
+    fun railWithoutAShapeIsSplinedThroughStops() {
+        val a1 = line("A1", LineType.SUBURBAN)
+        val stops = listOf(
+            station("A1_A", 37.90, 23.60, "A1"),
+            station("A1_B", 37.95, 23.70, "A1"),
+            station("A1_C", 38.00, 23.80, "A1"),
+        )
+
+        val geom = effectiveLineGeometry(listOf(a1), mapOf("A1" to stops), emptyMap()).getValue("A1")
+
+        assertTrue(geom.size > stops.size, "a shapeless rail line is smoothed with extra spline points")
+        assertEquals(LatLng(37.90, 23.60), geom.first(), "the spline must start at the first stop")
+        assertEquals(LatLng(38.00, 23.80), geom.last(), "the spline must end at the last stop")
+    }
+
+    @Test
+    fun aLineWithFewerThanTwoUsablePointsIsDropped() {
+        val stub = line("STUB", LineType.BUS)
+        val stops = mapOf("STUB" to listOf(station("ONLY", 37.9, 23.7, "STUB")))
+
+        assertFalse("STUB" in effectiveLineGeometry(listOf(stub), stops, emptyMap()))
+    }
+
+    @Test
+    fun catmullRomLeavesFewerThanThreePointsUntouched() {
+        val two = listOf(LatLng(1.0, 2.0), LatLng(3.0, 4.0))
+        assertEquals(two, catmullRomSpline(two))
+    }
+
+    @Test
+    fun catmullRomKeepsEndpointsAndDensifies() {
+        val pts = listOf(LatLng(0.0, 0.0), LatLng(1.0, 1.0), LatLng(2.0, 0.0))
+        val spline = catmullRomSpline(pts, segments = 5)
+        assertEquals(pts.first(), spline.first())
+        assertEquals(pts.last(), spline.last())
+        assertTrue(spline.size > pts.size)
+    }
+}

--- a/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/MapRouteGeometryTest.kt
+++ b/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/MapRouteGeometryTest.kt
@@ -110,4 +110,19 @@ class MapRouteGeometryTest {
         assertEquals(pts.last(), spline.last())
         assertTrue(spline.size > pts.size)
     }
+
+    @Test
+    fun snapPullsAnOffRouteFixOntoThePolyline() {
+        // A live GPS fix beside a straight west-east leg snaps onto the leg.
+        val leg = listOf(LatLng(37.0, 23.0), LatLng(37.0, 23.10))
+        val snapped = snapToPolyline(37.02, 23.05, leg)
+        assertEquals(37.0, snapped.lat, 1e-9, "snapped point sits on the leg's latitude")
+        assertTrue(snapped.lng in 23.0..23.10, "snapped point stays within the leg")
+    }
+
+    @Test
+    fun snapReturnsInputWhenPolylineTooShort() {
+        assertEquals(LatLng(37.02, 23.05), snapToPolyline(37.02, 23.05, listOf(LatLng(37.0, 23.0))))
+        assertEquals(LatLng(37.02, 23.05), snapToPolyline(37.02, 23.05, emptyList()))
+    }
 }


### PR DESCRIPTION
## Problem
`routes.json` lists only 21 of the 33 lines. Nine of the ten buses (VL1, DX1, KP1, TL1, PU1/PU2, X3/2X, KB1) are absent from it, so on Android they had no ordered `station_line` rows and `getStationsOnLine` fell back to the globally ordered `stations.json`:
- the route drew as a backtracking zig-zag (the Patras university bus looked wrong on the map), and
- the buses whose stops live only in the nested `schedules-v2/lines.json` (X3/2X) drew nothing.

This is the Android half of the bus-geometry work; the web half shipped in #49, which is why the Android straight-geometry change was reverted there pending this seed fix.

## Fix
- **Seed ordering from nested stations.** For every line absent from `routes.json`, seed its ordered `station_line` rows from the line's nested `lines.json` stations, inserting any station that exists only there. `getStationsOnLine` then returns the real stop order with real coordinates.
- **Shared pure decision.** `DataSeeder.nestedStationOrder` / `resolveOrderedStationIds` express the routes-vs-nested choice so a line already in `routes.json` (PSB) is never double-seeded or reordered.
- **Bump `SEED_VERSION` to 10** so existing installs re-seed.
- **Restore straight bus geometry** in `PlatformMapView.android.kt`: buses draw straight segments through their ordered stops before any bundled OSM shape (a bus shape can omit stops, as PU1's does for its western Kastelokampos leg, and a spline overshoots tight loops). Rail and tram still prefer the OSM shape.

## Tests
`DataSeederOrderingTest` (hermetic, inline fixtures shaped like the real seed):
- every bus resolves to at least two ordered, non-duplicate stops with finite coordinates
- `routes.json` order wins over the nested order (PSB, whose nested order is reversed in the fixture)
- a route-absent bus (VL1, X3) resolves via its nested stations
- a single-stop bus is detectable (the >= 2 guard has teeth)

Verified against the real bundled seed: all 10 buses resolve to >= 2 ordered stops, no duplicate stop ids on any line (no `station_line` PK collision).

No local JDK, so Kotlin tests run in CI.

Mirrors the web fix in #49.