### PR TITLE
Fix Android schedule sync never pulling changed line bundles (parity P0)

### DIFF
--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepository.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 
 /**
@@ -34,14 +36,22 @@ class ScheduleSyncRepository(
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
+    // Serializes the whole cache state transition (hydrate + each refresh's
+    // snapshot -> fetch -> commit). Without it two concurrent refreshes (e.g. a
+    // cold-start sync overlapping a Settings "Check now") each snapshot the
+    // bundle map, fetch different lines, and clobber each other on commit,
+    // marking a stale line as fresh. Not reentrant, so guarded methods never
+    // call one another under the lock.
+    private val mutex = Mutex()
+
     /**
      * Hydrate the in-memory cache from the bundled snapshot (`files/seed/schedules-v2/`).
      * Generated at build time by `scripts/snapshot-api-to-seed.py`. Safe to call multiple
      * times — only loads if the cache is currently empty so a live refresh isn't clobbered.
      */
-    suspend fun hydrateFromBundleIfNeeded() {
-        if (_lineBundles.value.isNotEmpty()) return
-        val reader = resourceReader ?: return
+    suspend fun hydrateFromBundleIfNeeded(): Unit = mutex.withLock {
+        if (_lineBundles.value.isNotEmpty()) return@withLock
+        val reader = resourceReader ?: return@withLock
         // Metro/tram/suburban + Thessaloniki + national rail + rail-replacement
         // buses. The national/bus bundles carry per-trip timetables that the map's
         // schedule projector interpolates into moving vehicles.
@@ -105,9 +115,16 @@ class ScheduleSyncRepository(
      * Returns true when at least one line was refreshed, false otherwise
      * (no network, server unreachable, or nothing changed).
      */
-    suspend fun refresh(): RefreshOutcome {
+    suspend fun refresh(): RefreshOutcome = mutex.withLock {
         _isRefreshing.value = true
         try {
+            doRefresh()
+        } finally {
+            _isRefreshing.value = false
+        }
+    }
+
+    private suspend fun doRefresh(): RefreshOutcome {
         val previousEtag = _manifest.value?.etag
         val result = schedulesService.fetchManifest(previousEtag).firstOrNull()
             ?: return RefreshOutcome.Failure("no result")
@@ -157,9 +174,6 @@ class ScheduleSyncRepository(
                 }
                 RefreshOutcome.Refreshed(fetched.size)
             }
-        }
-        } finally {
-            _isRefreshing.value = false
         }
     }
 

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepository.kt
@@ -71,6 +71,10 @@ class ScheduleSyncRepository(
             val manifest = json.decodeFromString<Manifest>(manifestBody)
             _manifest.value = manifest
             _scheduleVersion.value = manifest.version
+            // The cached bundles are exactly the snapshot the bundled manifest
+            // describes, so their hashes start as the bundled manifest's hashes.
+            // A server line whose hash later differs from this is what we re-fetch.
+            lineHashes = manifest.perLineHashes
         }
     }
 
@@ -82,6 +86,14 @@ class ScheduleSyncRepository(
 
     private val _lineBundles = MutableStateFlow<Map<String, LineSchedule>>(emptyMap())
     val lineBundles: StateFlow<Map<String, LineSchedule>> = _lineBundles.asStateFlow()
+
+    // The per-line content hashes the CACHED bundles correspond to: seeded from
+    // the bundled manifest on hydrate, updated as lines are re-fetched, and
+    // compared against the server manifest to decide what changed. Without a
+    // stored hash the old filter compared the server hash to itself (always
+    // equal), so a changed line was never pulled and Android could not update a
+    // timetable without an app release.
+    private var lineHashes: Map<String, String> = emptyMap()
 
     private val _lastSyncAt = MutableStateFlow<Instant?>(null)
     val lastSyncAt: StateFlow<Instant?> = _lastSyncAt.asStateFlow()
@@ -116,20 +128,23 @@ class ScheduleSyncRepository(
                     return RefreshOutcome.UpToDate
                 }
                 val current = _lineBundles.value.toMutableMap()
-                val toFetch = manifest.perLineHashes.entries
-                    .filter { (lid, hash) ->
-                        // Re-fetch when first time, hash changed, or bundle missing.
-                        current[lid]?.let { _ -> manifest.perLineHashes[lid] != hash } ?: true
-                    }
+                val toFetch = linesToFetch(
+                    cachedLineIds = current.keys,
+                    storedHashes = lineHashes,
+                    manifestHashes = manifest.perLineHashes,
+                )
 
+                val newHashes = lineHashes.toMutableMap()
                 var refreshed = 0
-                for ((lineId, _) in toFetch) {
+                for (lineId in toFetch) {
                     val bundle = schedulesService.fetchLineBundle(lineId).firstOrNull()
                     if (bundle != null) {
                         current[lineId] = bundle
+                        manifest.perLineHashes[lineId]?.let { newHashes[lineId] = it }
                         refreshed++
                     }
                 }
+                lineHashes = newHashes
                 _manifest.value = manifest
                 _scheduleVersion.value = manifest.version
                 _lineBundles.value = current
@@ -147,5 +162,24 @@ class ScheduleSyncRepository(
         data class Refreshed(val linesRefreshed: Int) : RefreshOutcome
         data object Skipped : RefreshOutcome
         data class Failure(val reason: String) : RefreshOutcome
+    }
+
+    companion object {
+        /**
+         * Which line ids must be pulled from the server: every line missing from
+         * the cache, plus every line whose cached content hash differs from the
+         * server manifest's hash. The previous inline filter compared
+         * `manifest.perLineHashes[lid]` to that same entry's value (always
+         * equal), so a changed line was never fetched and, with all lines
+         * pre-hydrated from the bundle, nothing was ever fetched at all.
+         */
+        internal fun linesToFetch(
+            cachedLineIds: Set<String>,
+            storedHashes: Map<String, String>,
+            manifestHashes: Map<String, String>,
+        ): List<String> =
+            manifestHashes.entries
+                .filter { (lid, serverHash) -> lid !in cachedLineIds || storedHashes[lid] != serverHash }
+                .map { it.key }
     }
 }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepository.kt
@@ -134,22 +134,28 @@ class ScheduleSyncRepository(
                     manifestHashes = manifest.perLineHashes,
                 )
 
-                val newHashes = lineHashes.toMutableMap()
-                var refreshed = 0
+                val fetched = mutableSetOf<String>()
                 for (lineId in toFetch) {
                     val bundle = schedulesService.fetchLineBundle(lineId).firstOrNull()
                     if (bundle != null) {
                         current[lineId] = bundle
-                        manifest.perLineHashes[lineId]?.let { newHashes[lineId] = it }
-                        refreshed++
+                        fetched += lineId
                     }
                 }
-                lineHashes = newHashes
-                _manifest.value = manifest
-                _scheduleVersion.value = manifest.version
+                lineHashes = hashesAfterFetch(lineHashes, manifest.perLineHashes, fetched)
                 _lineBundles.value = current
                 _lastSyncAt.value = Clock.System.now()
-                RefreshOutcome.Refreshed(refreshed)
+                // Only advance the cached manifest/etag when every attempted line
+                // landed. On a partial failure keep the previous manifest so the
+                // next refresh re-runs the per-line diff via the Fresh path: our
+                // stored etag stays behind the server's, so a 304 / etag-equal
+                // short-circuit can never strand the still-stale line until the
+                // server happens to publish another manifest.
+                if (shouldAdvanceManifest(toFetch, fetched)) {
+                    _manifest.value = manifest
+                    _scheduleVersion.value = manifest.version
+                }
+                RefreshOutcome.Refreshed(fetched.size)
             }
         }
         } finally {
@@ -181,5 +187,31 @@ class ScheduleSyncRepository(
             manifestHashes.entries
                 .filter { (lid, serverHash) -> lid !in cachedLineIds || storedHashes[lid] != serverHash }
                 .map { it.key }
+
+        /**
+         * The stored per-line hashes after a fetch round: a line that fetched
+         * successfully takes the server hash; a line that failed (not in
+         * [fetchedLineIds]) keeps its previous hash so the next [linesToFetch]
+         * still reports it as stale and retries it.
+         */
+        internal fun hashesAfterFetch(
+            storedHashes: Map<String, String>,
+            manifestHashes: Map<String, String>,
+            fetchedLineIds: Set<String>,
+        ): Map<String, String> =
+            storedHashes.toMutableMap().apply {
+                fetchedLineIds.forEach { lid -> manifestHashes[lid]?.let { this[lid] = it } }
+            }
+
+        /**
+         * Advance the cached manifest/etag only when every attempted line landed
+         * (an empty attempt list counts as success). On a partial failure the
+         * manifest must stay behind so the next refresh re-runs the diff instead
+         * of short-circuiting on an advanced etag and stranding the stale line.
+         */
+        internal fun shouldAdvanceManifest(
+            attemptedLineIds: List<String>,
+            fetchedLineIds: Set<String>,
+        ): Boolean = attemptedLineIds.all { it in fetchedLineIds }
     }
 }

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepositoryTest.kt
@@ -1,0 +1,75 @@
+package com.syrmos.core.data.sync
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the per-line schedule-sync diff. The shipped filter compared the server
+ * manifest hash to itself, so a changed line was never pulled and, with all
+ * lines pre-hydrated from the bundle, Android could not update a timetable
+ * without an app release. linesToFetch fixes it by comparing the CACHED hash to
+ * the server hash.
+ */
+class ScheduleSyncRepositoryTest {
+
+    @Test
+    fun nothingToFetchWhenAllLinesCachedAndHashesMatch() {
+        val hashes = mapOf("M1" to "a", "M2" to "b", "T6" to "c")
+        val toFetch = ScheduleSyncRepository.linesToFetch(
+            cachedLineIds = hashes.keys,
+            storedHashes = hashes,
+            manifestHashes = hashes,
+        )
+        assertTrue(toFetch.isEmpty(), "up-to-date lines must not be re-fetched")
+    }
+
+    @Test
+    fun refetchesOnlyTheChangedLine() {
+        // The regression: cached hash for M1 is stale vs the server manifest.
+        // The old self-comparison returned nothing here; the fix returns [M1].
+        val stored = mapOf("M1" to "old", "M2" to "b", "T6" to "c")
+        val server = mapOf("M1" to "new", "M2" to "b", "T6" to "c")
+        val toFetch = ScheduleSyncRepository.linesToFetch(
+            cachedLineIds = stored.keys,
+            storedHashes = stored,
+            manifestHashes = server,
+        )
+        assertEquals(listOf("M1"), toFetch)
+    }
+
+    @Test
+    fun fetchesLinesMissingFromCache() {
+        val stored = mapOf("M1" to "a")
+        val server = mapOf("M1" to "a", "M2" to "b")
+        val toFetch = ScheduleSyncRepository.linesToFetch(
+            cachedLineIds = setOf("M1"),
+            storedHashes = stored,
+            manifestHashes = server,
+        )
+        assertEquals(listOf("M2"), toFetch)
+    }
+
+    @Test
+    fun fetchesWhenCachedButHashUnknown() {
+        // Bundle present in cache but no stored hash for it (null != serverHash).
+        val toFetch = ScheduleSyncRepository.linesToFetch(
+            cachedLineIds = setOf("M1"),
+            storedHashes = emptyMap(),
+            manifestHashes = mapOf("M1" to "a"),
+        )
+        assertEquals(listOf("M1"), toFetch)
+    }
+
+    @Test
+    fun fetchesANewManifestLineAndTheChangedOneTogether() {
+        val stored = mapOf("M1" to "a", "M2" to "b")
+        val server = mapOf("M1" to "a", "M2" to "B2", "M3" to "c")
+        val toFetch = ScheduleSyncRepository.linesToFetch(
+            cachedLineIds = setOf("M1", "M2"),
+            storedHashes = stored,
+            manifestHashes = server,
+        ).toSet()
+        assertEquals(setOf("M2", "M3"), toFetch, "changed M2 + new M3, but not unchanged M1")
+    }
+}

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/sync/ScheduleSyncRepositoryTest.kt
@@ -72,4 +72,44 @@ class ScheduleSyncRepositoryTest {
         ).toSet()
         assertEquals(setOf("M2", "M3"), toFetch, "changed M2 + new M3, but not unchanged M1")
     }
+
+    // --- partial-failure retry (the stranding Codex flagged) ---
+
+    @Test
+    fun aFailedLineKeepsItsStaleHashAndIsRetriedNextRound() {
+        val server = mapOf("M1" to "new", "M2" to "b")
+        val stored = mapOf("M1" to "old", "M2" to "b")
+        val attempted = ScheduleSyncRepository.linesToFetch(setOf("M1", "M2"), stored, server)
+        assertEquals(listOf("M1"), attempted)
+
+        // M1 fetch failed this round (fetched is empty).
+        val after = ScheduleSyncRepository.hashesAfterFetch(stored, server, fetchedLineIds = emptySet())
+        assertEquals("old", after["M1"], "a failed line must keep its stale hash")
+
+        // Next round still reports M1 as needing a fetch (not stranded).
+        val retry = ScheduleSyncRepository.linesToFetch(setOf("M1", "M2"), after, server)
+        assertEquals(listOf("M1"), retry)
+    }
+
+    @Test
+    fun aSucceededLineTakesTheServerHashAndIsNotRefetched() {
+        val server = mapOf("M1" to "new")
+        val stored = mapOf("M1" to "old")
+        val after = ScheduleSyncRepository.hashesAfterFetch(stored, server, fetchedLineIds = setOf("M1"))
+        assertEquals("new", after["M1"])
+        assertTrue(ScheduleSyncRepository.linesToFetch(setOf("M1"), after, server).isEmpty())
+    }
+
+    @Test
+    fun manifestAdvancesOnlyWhenEveryAttemptedLineLanded() {
+        assertTrue(
+            ScheduleSyncRepository.shouldAdvanceManifest(emptyList(), emptySet()),
+            "nothing to fetch counts as success",
+        )
+        assertTrue(ScheduleSyncRepository.shouldAdvanceManifest(listOf("M1"), setOf("M1")))
+        assertTrue(
+            !ScheduleSyncRepository.shouldAdvanceManifest(listOf("M1", "M2"), setOf("M1")),
+            "a partial failure must not advance the manifest",
+        )
+    }
 }


### PR DESCRIPTION
## Problem (parity audit P0)
`ScheduleSyncRepository.refresh()` filtered the per-line diff with `manifest.perLineHashes[lid] != hash`, where `hash` **is** `manifest.perLineHashes[lid]` — always equal, so the predicate is always false. `LineSchedule` also stores no hash to compare against. Since `hydrateFromBundleIfNeeded()` pre-loads all 33 lines, `toFetch` was always empty and `/api/schedules/{lineId}` was **never called**. Android could not pick up a server timetable change without shipping a new app version; iOS updates on next sync via a stored per-line etag (`SyrmosSchedulesService.swift:106-112`).

## Fix
Track the content hashes the cached bundles correspond to — seeded from the bundled manifest on hydrate, updated as lines are re-fetched — and compare the **cached** hash against the server manifest. Extracted the decision into a pure, unit-testable `linesToFetch(cachedLineIds, storedHashes, manifestHashes)`: a line is pulled when it is missing from the cache or its cached hash differs from the server's.

## Tests
`ScheduleSyncRepositoryTest`: up-to-date (nothing fetched), the regression (a changed line is now fetched where the old self-comparison fetched nothing), missing-from-cache, unknown cached hash, and changed+new together.

No local JDK, so Kotlin tests run in CI. First fix from the Android↔iOS parity audit.