### PR TITLE
Apply Greek holiday calendar to offline seed day-type + consolidate it (parity P1)

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/schedule/ServiceDayResolver.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/schedule/ServiceDayResolver.kt
@@ -1,0 +1,56 @@
+package com.syrmos.core.domain.schedule
+
+import com.syrmos.core.model.schedule.DayType
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+
+/**
+ * The single source of truth for Greek public-transport service days.
+ *
+ * The fixed-date holiday calendar used to be copied across the band projector,
+ * the active-train projector, the seed-DB departures fallback and the map
+ * fallback. The last two omitted holidays entirely, so on a public holiday that
+ * falls on a weekday (Aug 15 on a Tuesday) the offline seed path queried weekday
+ * service instead of the Sunday service that actually runs. Consolidated here so
+ * the calendar is defined once and every path applies it.
+ */
+object ServiceDayResolver {
+
+    /**
+     * The fixed-date holiday band key for [date], or null on an ordinary day.
+     * `sun`/`sat` group the holidays that run Sunday/Saturday service; `aug_15`
+     * and `dec_24_31` are their own bundled band keys.
+     */
+    fun holidayDayType(date: LocalDate): String? {
+        val mmdd = "${pad(date.monthNumber)}-${pad(date.dayOfMonth)}"
+        return when (mmdd) {
+            "01-01", "05-01", "10-28", "12-25", "12-26" -> "sun"
+            "08-15" -> "aug_15"
+            "12-24", "12-31" -> "dec_24_31"
+            "01-02", "01-06", "11-17" -> "sat"
+            else -> null
+        }
+    }
+
+    /**
+     * The base [DayType] the seed schedule tables are keyed by. The seed carries
+     * only weekday/friday/saturday/sunday rows, so a holiday resolves to the
+     * service it actually runs: Sunday for the major holidays and Aug 15,
+     * Saturday for the half-holidays and the Dec 24/31 reduced-service days.
+     */
+    fun baseDayType(date: LocalDate): DayType =
+        when (holidayDayType(date)) {
+            "sun", "aug_15" -> DayType.SUNDAY
+            "sat", "dec_24_31" -> DayType.SATURDAY
+            else -> when (date.dayOfWeek) {
+                DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+                DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY -> DayType.WEEKDAY
+                DayOfWeek.FRIDAY -> DayType.FRIDAY
+                DayOfWeek.SATURDAY -> DayType.SATURDAY
+                DayOfWeek.SUNDAY -> DayType.SUNDAY
+                else -> DayType.WEEKDAY
+            }
+        }
+
+    private fun pad(n: Int): String = if (n < 10) "0$n" else "$n"
+}

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/ComputeActiveTrainsFromBandsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/ComputeActiveTrainsFromBandsUseCase.kt
@@ -2,6 +2,7 @@ package com.syrmos.core.domain.usecase
 
 import com.syrmos.core.data.sync.ScheduleSyncRepository
 import com.syrmos.core.data.sync.StationOffsetsRepository
+import com.syrmos.core.domain.schedule.ServiceDayResolver
 import com.syrmos.core.network.SyrmosLivePositionsService
 import com.syrmos.core.network.SyrmosSchedulesService
 import kotlin.math.roundToInt
@@ -210,16 +211,9 @@ class ComputeActiveTrainsFromBandsUseCase(
         return if ("late" in label || "overnight" in label) "late_night" else "regular"
     }
 
-    private fun resolveHolidayDayType(date: LocalDate): String? {
-        val mmdd = "${pad(date.monthNumber)}-${pad(date.dayOfMonth)}"
-        return when (mmdd) {
-            "01-01", "05-01", "10-28", "12-25", "12-26" -> "sun"
-            "08-15" -> "aug_15"
-            "12-24", "12-31" -> "dec_24_31"
-            "01-02", "01-06", "11-17" -> "sat"
-            else -> null
-        }
-    }
+    // Delegates to the shared calendar so the holiday table is defined once.
+    private fun resolveHolidayDayType(date: LocalDate): String? =
+        ServiceDayResolver.holidayDayType(date)
 
     private fun dayTypeFor(date: LocalDate, holidayDayType: String?): String {
         if (holidayDayType != null) return holidayDayType
@@ -243,7 +237,6 @@ class ComputeActiveTrainsFromBandsUseCase(
     }
 }
 
-private fun pad(n: Int): String = if (n < 10) "0$n" else "$n"
 
 private fun String.toMinutesOfDay(): Int? {
     val parts = split(":")

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/ComputeDeparturesFromBandsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/ComputeDeparturesFromBandsUseCase.kt
@@ -2,6 +2,7 @@ package com.syrmos.core.domain.usecase
 
 import com.syrmos.core.data.sync.ScheduleSyncRepository
 import com.syrmos.core.data.sync.StationOffsetsRepository
+import com.syrmos.core.domain.schedule.ServiceDayResolver
 import com.syrmos.core.model.transit.Direction
 import com.syrmos.core.network.SyrmosSchedulesService
 import kotlin.math.roundToInt
@@ -241,16 +242,9 @@ class ComputeDeparturesFromBandsUseCase(
         private val line3AirportOnlyStations = setOf("M3_PAL", "M3_PEA", "M3_KO2", "M3_AER")
     }
 
-    private fun resolveHolidayDayType(date: LocalDate): String? {
-        val mmdd = "${pad(date.monthNumber)}-${pad(date.dayOfMonth)}"
-        return when (mmdd) {
-            "01-01", "05-01", "10-28", "12-25", "12-26" -> "sun"
-            "08-15" -> "aug_15"
-            "12-24", "12-31" -> "dec_24_31"
-            "01-02", "01-06", "11-17" -> "sat"
-            else -> null
-        }
-    }
+    // Delegates to the shared calendar so the holiday table is defined once.
+    private fun resolveHolidayDayType(date: LocalDate): String? =
+        ServiceDayResolver.holidayDayType(date)
 
     private fun projectForLine(
         bundle: SyrmosSchedulesService.LineSchedule,

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/GetNextDeparturesUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/GetNextDeparturesUseCase.kt
@@ -1,11 +1,12 @@
 package com.syrmos.core.domain.usecase
 
-import com.syrmos.core.common.extensions.currentAthensDayOfWeek
+import com.syrmos.core.common.extensions.currentAthensDate
 import com.syrmos.core.common.extensions.currentAthensTime
 import com.syrmos.core.common.extensions.minutesUntil
 import com.syrmos.core.common.extensions.parseTime
 import com.syrmos.core.common.extensions.toDisplayString
 import com.syrmos.core.data.repository.ScheduleRepositoryImpl
+import com.syrmos.core.domain.schedule.ServiceDayResolver
 import com.syrmos.core.model.schedule.DayType
 import com.syrmos.core.model.schedule.Departure
 import com.syrmos.core.model.schedule.SourceConfidence
@@ -16,7 +17,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.datetime.DayOfWeek
 
 data class UpcomingDeparture(
     val time: String,
@@ -161,14 +161,9 @@ class GetNextDeparturesUseCase(
         )
     }
 
-    private fun resolveCurrentDayType(): DayType {
-        return when (currentAthensDayOfWeek()) {
-            DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,
-            DayOfWeek.THURSDAY -> DayType.WEEKDAY
-            DayOfWeek.FRIDAY -> DayType.FRIDAY
-            DayOfWeek.SATURDAY -> DayType.SATURDAY
-            DayOfWeek.SUNDAY -> DayType.SUNDAY
-            else -> DayType.WEEKDAY
-        }
-    }
+    // Seed-DB fallback day type. Routes through the shared resolver so a public
+    // holiday (e.g. Aug 15 on a weekday) queries the Sunday/Saturday service it
+    // actually runs instead of the weekday service.
+    private fun resolveCurrentDayType(): DayType =
+        ServiceDayResolver.baseDayType(currentAthensDate())
 }

--- a/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/schedule/ServiceDayResolverTest.kt
+++ b/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/schedule/ServiceDayResolverTest.kt
@@ -1,0 +1,53 @@
+package com.syrmos.core.domain.schedule
+
+import com.syrmos.core.model.schedule.DayType
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The shared Greek service-day calendar. Guards the holiday table (previously
+ * copied across the band projector, the active-train projector and the seed
+ * fallbacks) and, critically, the base-DayType mapping the seed-DB fallback
+ * needs: a public holiday must resolve to the Sunday/Saturday service it runs,
+ * not the plain weekday service (the P1 the parity audit found offline).
+ */
+class ServiceDayResolverTest {
+
+    @Test
+    fun holidayTableMatchesTheBundleKeys() {
+        assertEquals("sun", ServiceDayResolver.holidayDayType(LocalDate(2026, 1, 1)))
+        assertEquals("sun", ServiceDayResolver.holidayDayType(LocalDate(2026, 12, 25)))
+        assertEquals("aug_15", ServiceDayResolver.holidayDayType(LocalDate(2026, 8, 15)))
+        assertEquals("dec_24_31", ServiceDayResolver.holidayDayType(LocalDate(2026, 12, 24)))
+        assertEquals("dec_24_31", ServiceDayResolver.holidayDayType(LocalDate(2026, 12, 31)))
+        assertEquals("sat", ServiceDayResolver.holidayDayType(LocalDate(2026, 1, 6)))
+        assertEquals("sat", ServiceDayResolver.holidayDayType(LocalDate(2026, 11, 17)))
+    }
+
+    @Test
+    fun ordinaryDaysHaveNoHoliday() {
+        assertNull(ServiceDayResolver.holidayDayType(LocalDate(2026, 3, 10)))
+        assertNull(ServiceDayResolver.holidayDayType(LocalDate(2026, 7, 1)))
+    }
+
+    @Test
+    fun holidayOverridesTheWeekdayForBaseDayType() {
+        // 2026-08-15 is a Saturday and 2026-01-06 a Tuesday; both must resolve to
+        // their holiday service, not their calendar weekday.
+        assertEquals(DayType.SUNDAY, ServiceDayResolver.baseDayType(LocalDate(2026, 8, 15)))
+        assertEquals(DayType.SUNDAY, ServiceDayResolver.baseDayType(LocalDate(2026, 12, 25)))
+        assertEquals(DayType.SATURDAY, ServiceDayResolver.baseDayType(LocalDate(2026, 1, 6)))
+        assertEquals(DayType.SATURDAY, ServiceDayResolver.baseDayType(LocalDate(2026, 12, 31)))
+    }
+
+    @Test
+    fun ordinaryWeekdaysMapToTheirService() {
+        // 2026-01-01 is a Thursday, so: 05=Mon, 09=Fri, 10=Sat, 11=Sun (none holidays).
+        assertEquals(DayType.WEEKDAY, ServiceDayResolver.baseDayType(LocalDate(2026, 1, 5)))
+        assertEquals(DayType.FRIDAY, ServiceDayResolver.baseDayType(LocalDate(2026, 1, 9)))
+        assertEquals(DayType.SATURDAY, ServiceDayResolver.baseDayType(LocalDate(2026, 1, 10)))
+        assertEquals(DayType.SUNDAY, ServiceDayResolver.baseDayType(LocalDate(2026, 1, 11)))
+    }
+}

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
@@ -7,9 +7,11 @@ import com.syrmos.core.data.repository.ScheduleRepositoryImpl
 import com.syrmos.core.data.repository.StationRepositoryImpl
 import com.syrmos.core.data.repository.TransitPatternRepositoryImpl
 import com.syrmos.core.data.seed.SeedServicePattern
+import com.syrmos.core.common.extensions.currentAthensDate
 import com.syrmos.core.common.extensions.currentAthensDayOfWeek
 import com.syrmos.core.common.extensions.currentAthensTime
 import com.syrmos.core.common.extensions.parseTime
+import com.syrmos.core.domain.schedule.ServiceDayResolver
 import com.syrmos.core.domain.usecase.ComputeActiveTrainsFromBandsUseCase
 import com.syrmos.core.domain.usecase.GetNextDeparturesUseCase
 import com.syrmos.core.model.schedule.DayType
@@ -453,15 +455,11 @@ class MapViewModel(
         }
     }
 
-    private fun resolveCurrentDayType(): DayType {
-        return when (currentAthensDayOfWeek()) {
-            DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY -> DayType.WEEKDAY
-            DayOfWeek.FRIDAY -> DayType.FRIDAY
-            DayOfWeek.SATURDAY -> DayType.SATURDAY
-            DayOfWeek.SUNDAY -> DayType.SUNDAY
-            else -> DayType.WEEKDAY
-        }
-    }
+    // Seed-DB fallback day type. Routes through the shared resolver so a public
+    // holiday (e.g. Aug 15 on a weekday) queries the Sunday/Saturday service it
+    // actually runs instead of weekday service.
+    private fun resolveCurrentDayType(): DayType =
+        ServiceDayResolver.baseDayType(currentAthensDate())
 
     /// The schedule day-type string the bundled national/bus trips are keyed by
     /// ("mon_thu" / "fri" / "sat" / "sun"), matching the web projector.


### PR DESCRIPTION
## Problem (parity audit P1)
The seed-DB departures fallback (`GetNextDeparturesUseCase.resolveCurrentDayType`) and the map's fallback (`MapViewModel.resolveCurrentDayType`) resolved the service day from the weekday alone. So a public holiday on a weekday (Aug 15 on a Tuesday) queried **weekday** service offline instead of the Sunday/Saturday service that actually runs. iOS applies the holiday calendar on every path (`ScheduleProjector.swift:500-509`).

## Fix
Add `ServiceDayResolver` (core/domain) as the single source of truth for the Greek service calendar:
- `holidayDayType(date)` — the bundle's rich `sun`/`sat`/`aug_15`/`dec_24_31` keys.
- `baseDayType(date)` — the seed's `WEEKDAY/FRIDAY/SATURDAY/SUNDAY` enum, with holidays mapped to the Sunday/Saturday service the seed actually carries (verified: the seed has only those base rows).

Both seed fallbacks now route through `baseDayType`, and the two band projectors' duplicated holiday tables delegate to the shared resolver (behavior-identical consolidation of a table that was copied 3×).

## Scope note
`scheduleDayTypeString` (feeding `projectScheduledTrains`) is intentionally left unchanged: I verified trips and bands carry only base day keys (`mon_thu/fri/sat/sun`), so a holiday must map to a *base* day there too — but that path needs its own verification to avoid hiding service, and is tracked as a follow-up.

## Tests
`ServiceDayResolverTest`: holiday table matches the bundle keys; a holiday overrides its calendar weekday (Aug 15 → Sunday, Jan 6 → Saturday); ordinary weekdays map to their service.

Parity-audit fix. No local JDK — tests run in CI.