### PR TITLE
Match Albanian names + station codes in Android station search (parity P1)

### DIFF
--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/StationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/StationRepositoryImpl.kt
@@ -44,7 +44,10 @@ class StationRepositoryImpl(
 
     fun searchStations(query: String): Flow<List<Station>> = flow {
         val pattern = "%$query%"
-        val stations = database.syrmosDatabaseQueries.searchStations(pattern, pattern)
+        // Match Greek (name_el), English (name), Albanian (name_sq) names and the
+        // station code (id), mirroring the iOS Browse-All filter. The DB path had
+        // only name/name_el, so Albanian names and station codes never matched.
+        val stations = database.syrmosDatabaseQueries.searchStations(pattern, pattern, pattern, pattern)
             .executeAsList()
             .map { entity ->
                 val lineIds = database.syrmosDatabaseQueries.getLinesAtStation(entity.id)
@@ -59,10 +62,7 @@ class StationRepositoryImpl(
                 // matches all). The use-case already guards this, but keep the
                 // repo honest if called directly.
                 if (normalized.isEmpty()) emptyList()
-                else readSeedStations().filter {
-                    it.name.lowercase().contains(normalized) ||
-                        it.nameEl.lowercase().contains(normalized)
-                }
+                else readSeedStations().filter { matchesQuery(it, normalized) }
             },
         )
     }
@@ -138,6 +138,10 @@ class StationRepositoryImpl(
                 id = seed.id,
                 name = seed.name,
                 nameEl = seed.nameEl,
+                // Carry the Albanian name so the offline search fallback can
+                // match it; the seed has name_sq for ~200 stations and it was
+                // being dropped here.
+                nameSq = seed.nameSq,
                 latitude = seed.latitude,
                 longitude = seed.longitude,
                 lineIds = seed.lineIds,
@@ -148,5 +152,19 @@ class StationRepositoryImpl(
         }.also {
             seedStations = it
         }
+    }
+
+    companion object {
+        /**
+         * Whether [station] matches an already-normalized (trimmed, lowercased)
+         * search query across its English, Greek and Albanian names and its
+         * station code. Mirrors the iOS Browse-All filter so all three platforms
+         * match the same stations.
+         */
+        internal fun matchesQuery(station: Station, normalizedQuery: String): Boolean =
+            station.name.lowercase().contains(normalizedQuery) ||
+                station.nameEl.lowercase().contains(normalizedQuery) ||
+                station.nameSq?.lowercase()?.contains(normalizedQuery) == true ||
+                station.id.lowercase().contains(normalizedQuery)
     }
 }

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/repository/StationSearchMatchTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/repository/StationSearchMatchTest.kt
@@ -1,0 +1,57 @@
+package com.syrmos.core.data.repository
+
+import com.syrmos.core.model.transit.Station
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The station-search predicate must match English, Greek and Albanian names and
+ * the station code, mirroring the iOS Browse-All filter. Before the fix the
+ * Android DB query and seed fallback matched only name/name_el, so Albanian
+ * names and station codes never matched.
+ */
+class StationSearchMatchTest {
+
+    private val station = Station(
+        id = "M1_ATT",
+        name = "Attiki",
+        nameEl = "Αττική",
+        nameSq = "Atiki",
+        latitude = 37.999,
+        longitude = 23.722,
+        lineIds = listOf("M1", "M2"),
+    )
+
+    @Test
+    fun matchesEnglishName() {
+        assertTrue(StationRepositoryImpl.matchesQuery(station, "attik"))
+    }
+
+    @Test
+    fun matchesGreekName() {
+        assertTrue(StationRepositoryImpl.matchesQuery(station, "αττικ"))
+    }
+
+    @Test
+    fun matchesAlbanianName() {
+        assertTrue(StationRepositoryImpl.matchesQuery(station, "atik"))
+    }
+
+    @Test
+    fun matchesStationCode() {
+        assertTrue(StationRepositoryImpl.matchesQuery(station, "m1_att"))
+    }
+
+    @Test
+    fun doesNotMatchUnrelatedQuery() {
+        assertFalse(StationRepositoryImpl.matchesQuery(station, "piraeus"))
+    }
+
+    @Test
+    fun handlesMissingAlbanianNameWithoutCrashing() {
+        val noSq = station.copy(nameSq = null)
+        assertTrue(StationRepositoryImpl.matchesQuery(noSq, "attik"), "English still matches")
+        assertFalse(StationRepositoryImpl.matchesQuery(noSq, "atik"), "no Albanian to match")
+    }
+}

--- a/core/database/src/commonMain/sqldelight/com/syrmos/core/database/SyrmosDatabase.sq
+++ b/core/database/src/commonMain/sqldelight/com/syrmos/core/database/SyrmosDatabase.sq
@@ -131,7 +131,7 @@ SELECT * FROM station_entity WHERE is_interchange = 1 ORDER BY name;
 
 searchStations:
 SELECT * FROM station_entity
-WHERE name LIKE ? OR name_el LIKE ?
+WHERE name LIKE ? OR name_el LIKE ? OR name_sq LIKE ? OR id LIKE ?
 ORDER BY name;
 
 insertStation:


### PR DESCRIPTION
## Problem (parity audit P1)
Android station search queried only `name`/`name_el` (SQL `searchStations`) and the offline seed fallback matched only `name`/`nameEl`. So Albanian station names (`name_sq`, ~200 stations) and station codes (`id`) never matched — while iOS Browse-All matches `name`/`nameEl`/`nameSq`/`id`.

## Fix
- Add `name_sq` and `id` to the `searchStations` SQL query.
- Carry `name_sq` through `readSeedStations` (it was dropped when mapping the seed `Station`).
- Route the seed fallback through a shared, pure `matchesQuery` predicate covering all four fields.

The DB already stores `name_sq` (DataSeeder inserts it), so the new SQL clause has data to match. `LinesRefresher` needs no change — its insert is guarded to *new* nested stations only and never clobbers an existing row's `name_sq` (that audit sub-finding was a false positive).

## Tests
`StationSearchMatchTest`: matches English/Greek/Albanian names and the station code, case-insensitive, rejects unrelated queries, null-safe when a station has no Albanian name.

Parity-audit fix. Diacritic-insensitive (tonos-folding) search is a separate P3 follow-up (needs a normalized column). No local JDK — tests run in CI.