### PR TITLE
Align Home subtitle + news-header copy with iOS scope (parity P2)

### DIFF
--- a/core/common/src/commonMain/kotlin/com/syrmos/core/common/Localization.kt
+++ b/core/common/src/commonMain/kotlin/com/syrmos/core/common/Localization.kt
@@ -70,11 +70,13 @@ enum class L {
     DEST_DIAKOPTO, DEST_DIAKOPTO_HOOK;
 
     fun text(lang: AppLanguage): String = when (this) {
+        // Scope is all of Greece (national rail, Thessaloniki, Patras), not just
+        // Athens, matching the iOS subtitle. Proper Greek/Albanian diacritics kept.
         APP_SUBTITLE -> when (lang) {
-            AppLanguage.GREEK -> "Ζωντανοί χρόνοι σιδηροδρόμων Αθήνας"
-            AppLanguage.ALBANIAN -> "Oraret e drejtpërdrejta të hekurudhave të Athinës"
-            AppLanguage.ITALIAN -> "Orari ferroviari di Atene in tempo reale"
-            else -> "Live Athens rail times"
+            AppLanguage.GREEK -> "Ζωντανοί χρόνοι σιδηροδρόμων Ελλάδας"
+            AppLanguage.ALBANIAN -> "Oraret e drejtpërdrejta të hekurudhave të Greqisë"
+            AppLanguage.ITALIAN -> "Orari ferroviari della Grecia in tempo reale"
+            else -> "Live Greece rail times"
         }
         METRO -> when (lang) {
             AppLanguage.GREEK -> "Μετρό"
@@ -106,11 +108,13 @@ enum class L {
             AppLanguage.ITALIAN -> "Avviso che interessa questa linea"
             else -> "Alert affecting this line"
         }
+        // The feed covers the whole rail network (STASY metro/tram + Hellenic
+        // Train + OSETH), not just metro/tram, matching the iOS header scope.
         LATEST_FROM_STASY -> when (lang) {
-            AppLanguage.GREEK -> "Ενημέρωση Μετρό & Τραμ"
-            AppLanguage.ALBANIAN -> "Përditësime Metro & Tramvaj"
-            AppLanguage.ITALIAN -> "Aggiornamenti Metro e Tram"
-            else -> "Metro & Tram updates"
+            AppLanguage.GREEK -> "Ενημερώσεις σιδηροδρομικού δικτύου"
+            AppLanguage.ALBANIAN -> "Përditësime të rrjetit hekurudhor"
+            AppLanguage.ITALIAN -> "Aggiornamenti rete ferroviaria"
+            else -> "Rail network updates"
         }
         READ_MORE -> when (lang) {
             AppLanguage.GREEK -> "Διαβάστε περισσότερα"

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/StationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/StationRepositoryImpl.kt
@@ -44,7 +44,10 @@ class StationRepositoryImpl(
 
     fun searchStations(query: String): Flow<List<Station>> = flow {
         val pattern = "%$query%"
-        val stations = database.syrmosDatabaseQueries.searchStations(pattern, pattern)
+        // Match Greek (name_el), English (name), Albanian (name_sq) names and the
+        // station code (id), mirroring the iOS Browse-All filter. The DB path had
+        // only name/name_el, so Albanian names and station codes never matched.
+        val stations = database.syrmosDatabaseQueries.searchStations(pattern, pattern, pattern, pattern)
             .executeAsList()
             .map { entity ->
                 val lineIds = database.syrmosDatabaseQueries.getLinesAtStation(entity.id)
@@ -59,10 +62,7 @@ class StationRepositoryImpl(
                 // matches all). The use-case already guards this, but keep the
                 // repo honest if called directly.
                 if (normalized.isEmpty()) emptyList()
-                else readSeedStations().filter {
-                    it.name.lowercase().contains(normalized) ||
-                        it.nameEl.lowercase().contains(normalized)
-                }
+                else readSeedStations().filter { matchesQuery(it, normalized) }
             },
         )
     }
@@ -138,6 +138,10 @@ class StationRepositoryImpl(
                 id = seed.id,
                 name = seed.name,
                 nameEl = seed.nameEl,
+                // Carry the Albanian name so the offline search fallback can
+                // match it; the seed has name_sq for ~200 stations and it was
+                // being dropped here.
+                nameSq = seed.nameSq,
                 latitude = seed.latitude,
                 longitude = seed.longitude,
                 lineIds = seed.lineIds,
@@ -148,5 +152,19 @@ class StationRepositoryImpl(
         }.also {
             seedStations = it
         }
+    }
+
+    companion object {
+        /**
+         * Whether [station] matches an already-normalized (trimmed, lowercased)
+         * search query across its English, Greek and Albanian names and its
+         * station code. Mirrors the iOS Browse-All filter so all three platforms
+         * match the same stations.
+         */
+        internal fun matchesQuery(station: Station, normalizedQuery: String): Boolean =
+            station.name.lowercase().contains(normalizedQuery) ||
+                station.nameEl.lowercase().contains(normalizedQuery) ||
+                station.nameSq?.lowercase()?.contains(normalizedQuery) == true ||
+                station.id.lowercase().contains(normalizedQuery)
     }
 }

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/repository/StationSearchMatchTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/repository/StationSearchMatchTest.kt
@@ -1,0 +1,57 @@
+package com.syrmos.core.data.repository
+
+import com.syrmos.core.model.transit.Station
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The station-search predicate must match English, Greek and Albanian names and
+ * the station code, mirroring the iOS Browse-All filter. Before the fix the
+ * Android DB query and seed fallback matched only name/name_el, so Albanian
+ * names and station codes never matched.
+ */
+class StationSearchMatchTest {
+
+    private val station = Station(
+        id = "M1_ATT",
+        name = "Attiki",
+        nameEl = "Αττική",
+        nameSq = "Atiki",
+        latitude = 37.999,
+        longitude = 23.722,
+        lineIds = listOf("M1", "M2"),
+    )
+
+    @Test
+    fun matchesEnglishName() {
+        assertTrue(StationRepositoryImpl.matchesQuery(station, "attik"))
+    }
+
+    @Test
+    fun matchesGreekName() {
+        assertTrue(StationRepositoryImpl.matchesQuery(station, "αττικ"))
+    }
+
+    @Test
+    fun matchesAlbanianName() {
+        assertTrue(StationRepositoryImpl.matchesQuery(station, "atik"))
+    }
+
+    @Test
+    fun matchesStationCode() {
+        assertTrue(StationRepositoryImpl.matchesQuery(station, "m1_att"))
+    }
+
+    @Test
+    fun doesNotMatchUnrelatedQuery() {
+        assertFalse(StationRepositoryImpl.matchesQuery(station, "piraeus"))
+    }
+
+    @Test
+    fun handlesMissingAlbanianNameWithoutCrashing() {
+        val noSq = station.copy(nameSq = null)
+        assertTrue(StationRepositoryImpl.matchesQuery(noSq, "attik"), "English still matches")
+        assertFalse(StationRepositoryImpl.matchesQuery(noSq, "atik"), "no Albanian to match")
+    }
+}

--- a/core/database/src/commonMain/sqldelight/com/syrmos/core/database/SyrmosDatabase.sq
+++ b/core/database/src/commonMain/sqldelight/com/syrmos/core/database/SyrmosDatabase.sq
@@ -131,7 +131,7 @@ SELECT * FROM station_entity WHERE is_interchange = 1 ORDER BY name;
 
 searchStations:
 SELECT * FROM station_entity
-WHERE name LIKE ? OR name_el LIKE ?
+WHERE name LIKE ? OR name_el LIKE ? OR name_sq LIKE ? OR id LIKE ?
 ORDER BY name;
 
 insertStation:


### PR DESCRIPTION
Parity audit P2 (content-string mismatches). Two Home strings understated the app's scope vs iOS:
- Subtitle `Live Athens rail times` → `Live Greece rail times` (the app covers national rail, Thessaloniki, Patras).
- News header `Metro & Tram updates` → `Rail network updates` (the feed covers STASY metro/tram + Hellenic Train + OSETH).

Aligned across en/el/sq/it, keeping proper Greek/Albanian diacritics (iOS's own strings drop some accents; Android's orthography is kept).

The 5th-tab label (`Departures` vs iOS `Airport`) is intentionally left for now and tracked as an intentional-difference pending product confirmation — a prominent nav rename should be an explicit product call. String-only change; CI compiles.