### PR TITLE
Add shared proximity InterchangeResolver (parity P0, step 1/2)

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/interchange/InterchangeResolver.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/interchange/InterchangeResolver.kt
@@ -1,0 +1,50 @@
+package com.syrmos.core.domain.interchange
+
+import com.syrmos.core.common.extensions.distanceInMeters
+import com.syrmos.core.model.transit.Line
+import com.syrmos.core.model.transit.Station
+
+/** A line serving the same physical hub, paired with the station id to open on it. */
+data class InterchangeTarget(val line: Line, val stationId: String)
+
+/**
+ * Resolves the other lines serving the same physical hub as a station, each
+ * paired with the station id to open on that line, nearest hub first.
+ *
+ * Ported from iOS `SyrmosData.interchangeTargets` (PR #48). Computed purely by
+ * PROXIMITY across every line: any line with a stop within [RADIUS_METERS] of
+ * the hub is a real transfer. It never reads the hub station's stored
+ * `lineIds` (doing so creates invalid (stationId, lineId) pairs and phantom
+ * departures, the trap the iOS work hit over three review passes); instead it
+ * resolves each candidate line's OWN nearest station id. That keeps it complete
+ * for every region with no hand-maintained table, and correct even when a hub's
+ * per-line ids use different suffixes (e.g. M3_AER vs A1_AIR).
+ *
+ * Only operational, scheduled lines are offered, so a tapped transfer always
+ * opens a boardable timetable (dropping suspended lines like DK1 and
+ * scheduleless shuttles like X3/2X that would open an empty timetable).
+ */
+object InterchangeResolver {
+
+    const val RADIUS_METERS = 150
+
+    fun resolve(
+        hubLatitude: Double,
+        hubLongitude: Double,
+        currentLineId: String,
+        lines: List<Line>,
+        stationsByLine: Map<String, List<Station>>,
+        hasSchedule: (lineId: String) -> Boolean,
+    ): List<InterchangeTarget> {
+        val targets = mutableListOf<Triple<Line, String, Int>>()
+        for (line in lines) {
+            if (line.id == currentLineId || !line.isOperational || !hasSchedule(line.id)) continue
+            val nearest = stationsByLine[line.id].orEmpty().minByOrNull {
+                distanceInMeters(hubLatitude, hubLongitude, it.latitude, it.longitude)
+            } ?: continue
+            val meters = distanceInMeters(hubLatitude, hubLongitude, nearest.latitude, nearest.longitude)
+            if (meters <= RADIUS_METERS) targets += Triple(line, nearest.id, meters)
+        }
+        return targets.sortedBy { it.third }.map { InterchangeTarget(it.first, it.second) }
+    }
+}

--- a/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/interchange/InterchangeResolverTest.kt
+++ b/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/interchange/InterchangeResolverTest.kt
@@ -1,0 +1,92 @@
+package com.syrmos.core.domain.interchange
+
+import com.syrmos.core.model.transit.Line
+import com.syrmos.core.model.transit.LineColor
+import com.syrmos.core.model.transit.LineStatus
+import com.syrmos.core.model.transit.LineType
+import com.syrmos.core.model.transit.Station
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Proximity interchange resolution, ported from iOS. A transfer is any line
+ * with a stop within 150 m of the hub, resolved to THAT line's own nearest
+ * station id (never the hub's stored lineIds), operational and scheduled only,
+ * nearest first.
+ */
+class InterchangeResolverTest {
+
+    private fun line(id: String, status: LineStatus = LineStatus.OPERATIONAL) = Line(
+        id = id, name = id, nameEl = id, type = LineType.METRO, color = LineColor.BLUE,
+        terminalA = "a", terminalB = "b", stationCount = 0, status = status,
+    )
+
+    private fun station(id: String, lat: Double, lng: Double, lineId: String) =
+        Station(id = id, name = id, nameEl = id, latitude = lat, longitude = lng, lineIds = listOf(lineId))
+
+    // Hub near Syntagma. 0.00025 deg lon ~= 22 m; 0.0005 deg lat ~= 55 m;
+    // 0.003 deg lat ~= 333 m (all at ~38 N).
+    private val hubLat = 37.9838
+    private val hubLng = 23.7280
+
+    private val lines = listOf(
+        line("M1"),                              // current line -> excluded
+        line("M2"),                              // 22 m -> nearest, included
+        line("M3"),                              // 55 m -> included, after M2
+        line("DK1", LineStatus.SUSPENDED),       // 9 m but not operational -> excluded
+        line("X3"),                              // 9 m but no schedule -> excluded
+        line("A9"),                              // 333 m -> too far, excluded
+    )
+
+    private val stationsByLine = mapOf(
+        "M1" to listOf(station("M1_SYN", 37.9838, 23.7280, "M1")),
+        "M2" to listOf(station("M2_FAR", 37.9900, 23.7400, "M2"), station("M2_SYN", 37.9838, 23.72825, "M2")),
+        "M3" to listOf(station("M3_SYN", 37.9843, 23.7280, "M3")),
+        "DK1" to listOf(station("DK1_SYN", 37.9838, 23.72809, "DK1")),
+        "X3" to listOf(station("X3_SYN", 37.9838, 23.72791, "X3")),
+        "A9" to listOf(station("A9_FAR", 37.9868, 23.7280, "A9")),
+    )
+
+    private val hasSchedule: (String) -> Boolean = { it != "X3" }
+
+    @Test
+    fun returnsOnlyOperationalScheduledNearbyLinesNearestFirst() {
+        val targets = InterchangeResolver.resolve(
+            hubLatitude = hubLat,
+            hubLongitude = hubLng,
+            currentLineId = "M1",
+            lines = lines,
+            stationsByLine = stationsByLine,
+            hasSchedule = hasSchedule,
+        )
+        assertEquals(listOf("M2", "M3"), targets.map { it.line.id }, "M2 (22m) before M3 (55m); others excluded")
+    }
+
+    @Test
+    fun resolvesEachLinesOwnNearestStationId() {
+        val targets = InterchangeResolver.resolve(
+            hubLat, hubLng, "M1", lines, stationsByLine, hasSchedule,
+        )
+        // Not the hub's id, not M2's far stop: each line's own nearest stop.
+        assertEquals(mapOf("M2" to "M2_SYN", "M3" to "M3_SYN"), targets.associate { it.line.id to it.stationId })
+    }
+
+    @Test
+    fun currentLineIsNeverATarget() {
+        val targets = InterchangeResolver.resolve(
+            hubLat, hubLng, currentLineId = "M2", lines = lines,
+            stationsByLine = stationsByLine, hasSchedule = hasSchedule,
+        )
+        assertEquals(false, targets.any { it.line.id == "M2" })
+    }
+
+    @Test
+    fun emptyWhenNoLineHasANearbyScheduledStop() {
+        val targets = InterchangeResolver.resolve(
+            hubLatitude = 40.0, hubLongitude = 22.0, // far from every stop
+            currentLineId = "M1", lines = lines,
+            stationsByLine = stationsByLine, hasSchedule = hasSchedule,
+        )
+        assertEquals(emptyList(), targets)
+    }
+}


### PR DESCRIPTION
First of two PRs porting the iOS proximity-interchange feature (PR #48) to Android.

## This PR: the pure resolver
`InterchangeResolver` (core/domain) resolves the lines serving the same physical hub as a station, each paired with the station id to open on that line, nearest first. Computed by **proximity** across every line (any operational, scheduled line with a stop within 150 m), resolving each line's **own** nearest station id — never the hub's stored `lineIds`, which is the phantom-departures trap the iOS port hit over three review passes.

Pure + fully unit-tested; reuses `core/common` `distanceInMeters`.

## Step 2 (follow-up PR)
Wire it into a `GetInterchangeTargets` use case (needs per-line stations + a `hasSchedule` bundle signal), expose it in `StationDetailUiState`, and render an actionable transfers section navigating to the tapped line's timetable at that station — mirroring iOS `StationDetailView`.

## Tests
`InterchangeResolverTest`: operational+scheduled+nearby only; nearest-first; per-line station-id resolution (not the hub's id); current line excluded; empty when none nearby. No local JDK — tests run in CI.