### PR TITLE
Add pull-to-refresh to Home + revive dead retry signal (parity P1)

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeScreen.kt
@@ -100,6 +100,7 @@ import com.syrmos.core.network.SyrmosLivePositionsService
 import kotlinx.coroutines.flow.firstOrNull
 import org.koin.compose.koinInject
 
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     viewModel: HomeViewModel,
@@ -229,7 +230,9 @@ fun HomeScreen(
         }
     }
 
-    Box(
+    androidx.compose.material3.pulltorefresh.PullToRefreshBox(
+        isRefreshing = uiState.isRefreshing,
+        onRefresh = { viewModel.refresh() },
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeViewModel.kt
@@ -63,6 +63,8 @@ data class HomeUiState(
     val railNews: List<RailNewsItem> = emptyList(),
     val serviceStatus: STASYServiceStatus? = null,
     val isLoading: Boolean = false,
+    /** True while a user-initiated pull-to-refresh is in flight (drives the spinner). */
+    val isRefreshing: Boolean = false,
     val error: String? = null,
 )
 
@@ -200,6 +202,21 @@ class HomeViewModel(
     fun refreshAnnouncements() {
         scope.launch {
             runCatching { announcementsRepository.refresh() }
+        }
+    }
+
+    /**
+     * User-initiated pull-to-refresh (iOS parity with Home's `.refreshable`).
+     * Re-pulls announcements and nudges live-data freshness so an offline->online
+     * transition recovers immediately instead of waiting for the 60s poll. Toggles
+     * [HomeUiState.isRefreshing] so the pull spinner shows for the duration.
+     */
+    fun refresh() {
+        scope.launch {
+            _uiState.update { it.copy(isRefreshing = true) }
+            runCatching { announcementsRepository.refresh() }
+            LiveDataFreshness.requestRetry()
+            _uiState.update { it.copy(isRefreshing = false) }
         }
     }
 


### PR DESCRIPTION
Parity audit P1/P3. iOS Home has `.refreshable`; Android had no manual refresh (only a 60s poll).

- Wrap the Home content in Material3 `PullToRefreshBox` (drop-in for the container `Box`).
- Pulling calls a new `HomeViewModel.refresh()`: re-pulls announcements and fires `LiveDataFreshness.requestRetry()` — previously a **dead API with no caller** (audit P3) — so an offline→online transition recovers immediately.
- `isRefreshing` drives the pull spinner.

**Held for Codex + on-device verification.** The Home screen has a floating header overlaying the same box, so the pull indicator's placement wants a visual check on device (no local JDK here). Compile-verified by CI. Follow-ups tracked: location-permission empty-state CTA (P1 #6) and an event-driven connectivity monitor (P2).