### PR TITLE
iOS: one GPS-less train no longer blanks the whole live map (audit #22)

### DIFF
--- a/iosApp/iosApp/Core/Schedule/TransitData.swift
+++ b/iosApp/iosApp/Core/Schedule/TransitData.swift
@@ -852,8 +852,11 @@ final class LiveTrainService: ObservableObject, @unchecked Sendable {
         let nextStationEn: String?
         let delayMinutes: Int
         let serviceType: String
-        let lat: Double
-        let lng: Double
+        // Optional so one GPS-less vehicle row does not fail the whole decode and
+        // blank every live train (matches the Android RailwayGovLiveTrackerService
+        // fix). Coord-less rows are skipped when mapping below.
+        let lat: Double?
+        let lng: Double?
         let speed: Double?
         let course: Double?
         let altitude: Double?
@@ -910,8 +913,12 @@ final class LiveTrainService: ObservableObject, @unchecked Sendable {
                 throw URLError(.badServerResponse)
             }
             let payload = try JSONDecoder().decode(TrainsPayload.self, from: data)
-            let parsed: [LiveTrain] = payload.trains.map { t in
-                LiveTrain(
+            let parsed: [LiveTrain] = payload.trains.compactMap { t -> LiveTrain? in
+                // Skip a coord-less vehicle rather than plot it at (0,0); the
+                // optional lat/lng above already keeps one bad row from failing
+                // the whole payload and blanking every train.
+                guard let lat = t.lat, let lng = t.lng else { return nil }
+                return LiveTrain(
                     id: t.id,
                     lineId: t.lineId,
                     trainNumber: t.trainNumber,
@@ -923,7 +930,7 @@ final class LiveTrainService: ObservableObject, @unchecked Sendable {
                     nextStationEn: t.nextStationEn ?? "",
                     delayMinutes: t.delayMinutes,
                     serviceType: t.serviceType,
-                    coordinate: CLLocationCoordinate2D(latitude: t.lat, longitude: t.lng),
+                    coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lng),
                     speed: t.speed,
                     course: t.course,
                     altitude: t.altitude,


### PR DESCRIPTION
Parity audit finding on the iOS **reference**. The resilient-parsing principle (never let an unexpected public-transport API value break the app) is violated on iOS: `/api/trains` decoded `TrainItem.lat`/`lng` as **required** `Double`, so a single coord-less vehicle row threw the whole `TrainsPayload` decode and **every live train vanished** from the map until the server stopped sending that row. Android already guards this (`RailwayGovLiveTrackerService` makes lat/lng nullable and filters coord-less rows).

## Fix
Make `lat`/`lng` optional and `compactMap`-skip coord-less rows, so one bad vehicle is dropped while the rest render.

## Verification
Built the iOS app for the iPhone 17 simulator (Xcode 26.6) — **BUILD SUCCEEDED**. (A decode unit test would require exposing the private `TrainItem`/`TrainsPayload` structs; tracked as a follow-up.)

Small, locally-verified reference-bug fix (Codex is rate-limited; merging on build-verify + self-review per the session protocol).