### PR TITLE
iOS: one malformed announcement no longer drops the whole feed (audit #24)

### DIFF
--- a/iosApp/iosApp/Core/Networking/STASYService.swift
+++ b/iosApp/iosApp/Core/Networking/STASYService.swift
@@ -252,18 +252,23 @@ final class STASYService: ObservableObject {
     }
 
     private struct APIAnnouncement: Decodable {
-        let id: String
-        let title: String
+        // These were required, so one malformed row (a missing id/title/date/
+        // summary/url/category) failed the whole APIPayload decode and dropped
+        // every announcement AND the service-status badge. Optional + defaulted +
+        // blank-title-skipped when mapping, matching the resilient Android
+        // STASYAnnouncementService.
+        let id: String?
+        let title: String?
         let titleEn: String?
         let titleSq: String?
         let titleIt: String?
-        let date: String
-        let summary: String
+        let date: String?
+        let summary: String?
         let summaryEn: String?
         let summarySq: String?
         let summaryIt: String?
-        let url: String
-        let category: String
+        let url: String?
+        let category: String?
         let affectedLines: [String]?
         let affectedStationIds: [String]?
         let severity: String?
@@ -295,20 +300,25 @@ final class STASYService: ObservableObject {
             let payload = try JSONDecoder().decode(APIPayload.self, from: data)
             serviceStatus = payload.status
             cacheStatus(payload.status)
-            let parsed: [STASYAnnouncement] = payload.announcements.map { item in
-                STASYAnnouncement(
-                    id: item.id,
-                    title: item.title,
+            let parsed: [STASYAnnouncement] = payload.announcements.compactMap { item -> STASYAnnouncement? in
+                // Skip a blank-title row rather than render an empty alert
+                // (matches Android's blank-title filter); other rows survive one
+                // bad sibling now that the fields are optional.
+                let title = item.title ?? ""
+                guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+                return STASYAnnouncement(
+                    id: item.id ?? "",
+                    title: title,
                     titleEn: item.titleEn ?? "",
                     titleSq: item.titleSq ?? "",
                     titleIt: item.titleIt ?? "",
-                    date: item.date,
-                    summary: item.summary,
+                    date: item.date ?? "",
+                    summary: item.summary ?? "",
                     summaryEn: item.summaryEn ?? "",
                     summarySq: item.summarySq ?? "",
                     summaryIt: item.summaryIt ?? "",
-                    url: URL(string: item.url),
-                    category: AnnouncementCategory(rawValue: item.category == "serviceAlert" ? "Έκτακτες Ανακοινώσεις" : "Ανακοινώσεις") ?? .general,
+                    url: URL(string: item.url ?? ""),
+                    category: AnnouncementCategory(rawValue: (item.category ?? "") == "serviceAlert" ? "Έκτακτες Ανακοινώσεις" : "Ανακοινώσεις") ?? .general,
                     affectedLines: item.affectedLines ?? [],
                     affectedStationIds: item.affectedStationIds ?? [],
                     severity: item.severity ?? "info",

--- a/iosApp/iosApp/Core/Networking/STASYService.swift
+++ b/iosApp/iosApp/Core/Networking/STASYService.swift
@@ -277,6 +277,34 @@ final class STASYService: ObservableObject {
         let serviceUntilTime: String?
     }
 
+    /// Maps one decoded API row to a domain announcement, skipping blank-title
+    /// rows. Shared by the network and cache paths so both survive a single
+    /// malformed row instead of dropping the whole feed + status badge.
+    private static func mapAnnouncement(_ item: APIAnnouncement) -> STASYAnnouncement? {
+        let title = item.title ?? ""
+        guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return STASYAnnouncement(
+            id: item.id ?? "",
+            title: title,
+            titleEn: item.titleEn ?? "",
+            titleSq: item.titleSq ?? "",
+            titleIt: item.titleIt ?? "",
+            date: item.date ?? "",
+            summary: item.summary ?? "",
+            summaryEn: item.summaryEn ?? "",
+            summarySq: item.summarySq ?? "",
+            summaryIt: item.summaryIt ?? "",
+            url: URL(string: item.url ?? ""),
+            category: AnnouncementCategory(rawValue: (item.category ?? "") == "serviceAlert" ? "Έκτακτες Ανακοινώσεις" : "Ανακοινώσεις") ?? .general,
+            affectedLines: item.affectedLines ?? [],
+            affectedStationIds: item.affectedStationIds ?? [],
+            severity: item.severity ?? "info",
+            validFrom: item.validFrom,
+            validUntil: item.validUntil,
+            serviceUntilTime: item.serviceUntilTime
+        )
+    }
+
     /// Latest STASY service-status badge, populated by `fetchAnnouncements`.
     @Published var serviceStatus: APIStatus?
 
@@ -300,33 +328,7 @@ final class STASYService: ObservableObject {
             let payload = try JSONDecoder().decode(APIPayload.self, from: data)
             serviceStatus = payload.status
             cacheStatus(payload.status)
-            let parsed: [STASYAnnouncement] = payload.announcements.compactMap { item -> STASYAnnouncement? in
-                // Skip a blank-title row rather than render an empty alert
-                // (matches Android's blank-title filter); other rows survive one
-                // bad sibling now that the fields are optional.
-                let title = item.title ?? ""
-                guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-                return STASYAnnouncement(
-                    id: item.id ?? "",
-                    title: title,
-                    titleEn: item.titleEn ?? "",
-                    titleSq: item.titleSq ?? "",
-                    titleIt: item.titleIt ?? "",
-                    date: item.date ?? "",
-                    summary: item.summary ?? "",
-                    summaryEn: item.summaryEn ?? "",
-                    summarySq: item.summarySq ?? "",
-                    summaryIt: item.summaryIt ?? "",
-                    url: URL(string: item.url ?? ""),
-                    category: AnnouncementCategory(rawValue: (item.category ?? "") == "serviceAlert" ? "Έκτακτες Ανακοινώσεις" : "Ανακοινώσεις") ?? .general,
-                    affectedLines: item.affectedLines ?? [],
-                    affectedStationIds: item.affectedStationIds ?? [],
-                    severity: item.severity ?? "info",
-                    validFrom: item.validFrom,
-                    validUntil: item.validUntil,
-                    serviceUntilTime: item.serviceUntilTime
-                )
-            }
+            let parsed: [STASYAnnouncement] = payload.announcements.compactMap(Self.mapAnnouncement)
             announcements = parsed
             lastUpdated = Date()
             // The feed came back from the API, so we're online. Flip the
@@ -478,27 +480,6 @@ final class STASYService: ObservableObject {
               let payload = try? JSONDecoder().decode(APIPayload.self, from: data)
         else { return }
         serviceStatus = payload.status
-        announcements = payload.announcements.map { item in
-            STASYAnnouncement(
-                id: item.id,
-                title: item.title,
-                titleEn: item.titleEn ?? "",
-                titleSq: item.titleSq ?? "",
-                titleIt: item.titleIt ?? "",
-                date: item.date,
-                summary: item.summary,
-                summaryEn: item.summaryEn ?? "",
-                summarySq: item.summarySq ?? "",
-                summaryIt: item.summaryIt ?? "",
-                url: URL(string: item.url),
-                category: AnnouncementCategory(rawValue: item.category == "serviceAlert" ? "Έκτακτες Ανακοινώσεις" : "Ανακοινώσεις") ?? .general,
-                affectedLines: item.affectedLines ?? [],
-                affectedStationIds: item.affectedStationIds ?? [],
-                severity: item.severity ?? "info",
-                validFrom: item.validFrom,
-                validUntil: item.validUntil,
-                serviceUntilTime: item.serviceUntilTime
-            )
-        }
+        announcements = payload.announcements.compactMap(Self.mapAnnouncement)
     }
 }


### PR DESCRIPTION
Parity-audit resilience finding on the iOS **reference**. `APIAnnouncement` decoded `id`/`title`/`date`/`summary`/`url`/`category` as **required**, so a single malformed row failed the entire `APIPayload` decode and dropped **every announcement plus the service-status badge** (until cache fallback). Android's `STASYAnnouncementService` already defaults these + skips blank-title rows.

## Fix
Make those fields optional and route BOTH the network decode and the cache-load decode through one shared, resilient `mapAnnouncement` (safe defaults + `compactMap`-skip blank-title rows), so one bad row is dropped while the rest of the feed + the status badge survive.

## Verification
iOS simulator build (Xcode 26.6) — **BUILD SUCCEEDED**. (Note: an earlier revision of this PR did not compile because a second, cache-load decode path used the same fields non-optionally; that is fixed by the shared helper. CI's iOS job is the gate.)

Companion to #61; same resilient-decode theme. Merging on CI green + build-verify (Codex rate-limited).