### PR TITLE
Android: honor trip validDates so seasonal trips hide off their dates

### DIFF
--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/ScheduleRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/ScheduleRepositoryImpl.kt
@@ -17,6 +17,7 @@ class ScheduleRepositoryImpl(
         direction: Direction,
         dayType: DayType,
         currentTime: String,
+        today: String,
         limit: Int = 5,
     ): Flow<List<Departure>> = flow {
         val departures = database.syrmosDatabaseQueries.getNextDepartures(
@@ -25,7 +26,8 @@ class ScheduleRepositoryImpl(
             direction = direction.name.lowercase(),
             day_type = dayType.name.lowercase(),
             departure_time = currentTime,
-            value_ = limit.toLong(),
+            today = today,
+            limit = limit.toLong(),
         ).executeAsList().map { row ->
             Departure(time = row.departure_time, notes = row.notes)
         }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/DataSeeder.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/DataSeeder.kt
@@ -180,6 +180,8 @@ class DataSeeder(
                             day_type = schedule.dayType,
                             departure_time = time,
                             notes = null,
+                            // Band-derived schedules are never date-scoped.
+                            valid_dates = null,
                         )
                     }
                 }
@@ -218,6 +220,9 @@ class DataSeeder(
                     val dayType = mapBundleDayType(trip.dayType)
                     val direction = trip.direction.lowercase()
                     if (dayType == null || direction.isBlank()) return@forEach
+                    // Preserved so getNextDepartures can hide a dated trip on days
+                    // it does not run; blank normalizes to null (no restriction).
+                    val validDates = trip.validDates?.takeIf { it.isNotBlank() }
                     trip.stops.forEach { stop ->
                         if (stop.stationId.isBlank() || stop.departureTime.isBlank()) return@forEach
                         database.syrmosDatabaseQueries.insertSchedule(
@@ -227,6 +232,7 @@ class DataSeeder(
                             day_type = dayType,
                             departure_time = stop.departureTime,
                             notes = null,
+                            valid_dates = validDates,
                         )
                     }
                 }
@@ -246,11 +252,12 @@ class DataSeeder(
     }
 
     companion object {
-        // Bumped to 10: lines absent from routes.json (most buses) now get
-        // ordered station_line rows seeded from the nested lines.json stations,
-        // so their map geometry follows the real stop order. Without a bump an
-        // existing install keeps its old rows and the buses stay mis-ordered.
-        const val SEED_VERSION = "10"
+        // Bumped to 11: trip schedules now carry valid_dates, so a date-scoped
+        // seasonal trip (e.g. Pelion PL1) is hidden on days it does not run.
+        // Without a bump an existing install keeps its old rows, which have
+        // valid_dates NULL, and the seasonal trip keeps showing every matching
+        // day. (Schema migration 3.sqm adds the column; the reseed fills it.)
+        const val SEED_VERSION = "11"
 
         /**
          * Whether the bundled seed must be (re)written. Compares versions

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/SeedDataModels.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/SeedDataModels.kt
@@ -109,6 +109,10 @@ data class SeedLineScheduleFile(
 data class SeedTripEntry(
     @SerialName("direction") val direction: String = "",
     @SerialName("dayType") val dayType: String = "",
+    // Comma-separated ISO dates a dated trip runs on; null/blank = every date
+    // matching dayType. Seeded into schedule_entity.valid_dates so the offline
+    // query can hide a seasonal trip (e.g. Pelion PL1) on days it does not run.
+    @SerialName("validDates") val validDates: String? = null,
     @SerialName("stops") val stops: List<SeedTripStop> = emptyList(),
 )
 

--- a/core/database/src/commonMain/sqldelight/com/syrmos/core/database/SyrmosDatabase.sq
+++ b/core/database/src/commonMain/sqldelight/com/syrmos/core/database/SyrmosDatabase.sq
@@ -50,6 +50,9 @@ CREATE TABLE schedule_entity (
     day_type TEXT NOT NULL,
     departure_time TEXT NOT NULL,
     notes TEXT,
+    -- Comma-separated ISO dates a dated trip runs on; NULL/blank = runs on every
+    -- date matching its day_type. Set only for date-scoped seasonal trips (PL1).
+    valid_dates TEXT,
     FOREIGN KEY (line_id) REFERENCES line_entity(id),
     FOREIGN KEY (station_id) REFERENCES station_entity(id)
 );
@@ -171,8 +174,17 @@ getNextDepartures:
 SELECT departure_time, notes FROM schedule_entity
 WHERE station_id = ? AND line_id = ? AND direction = ? AND day_type = ?
     AND departure_time >= ?
+    -- Date-scoped trips run only on the listed ISO dates; unrestricted rows
+    -- (NULL/blank valid_dates) always match. :today is passed as yyyy-MM-dd.
+    -- Both sides are comma-wrapped so the match is on whole ISO-date tokens
+    -- (mirrors the iOS split(",").contains), never a bare substring: without
+    -- the commas "2026-09-01" would also match a hypothetical "2026-09-011".
+    AND (
+        valid_dates IS NULL OR valid_dates = ''
+        OR (',' || valid_dates || ',') LIKE ('%,' || :today || ',%')
+    )
 ORDER BY departure_time ASC
-LIMIT ?;
+LIMIT :limit;
 
 getAllDepartures:
 SELECT departure_time, notes FROM schedule_entity
@@ -186,8 +198,8 @@ ORDER BY departure_time ASC
 LIMIT 1;
 
 insertSchedule:
-INSERT INTO schedule_entity(line_id, station_id, direction, day_type, departure_time, notes)
-VALUES (?, ?, ?, ?, ?, ?);
+INSERT INTO schedule_entity(line_id, station_id, direction, day_type, departure_time, notes, valid_dates)
+VALUES (?, ?, ?, ?, ?, ?, ?);
 
 -- Frequency
 getFrequencies:

--- a/core/database/src/commonMain/sqldelight/com/syrmos/core/database/migrations/3.sqm
+++ b/core/database/src/commonMain/sqldelight/com/syrmos/core/database/migrations/3.sqm
@@ -1,0 +1,11 @@
+-- Schema 3 -> 4: valid_dates on schedule rows for date-scoped trips.
+--
+-- Nullable with no default (NULL = runs on every date matching its day_type),
+-- so every existing schedule row keeps today's behaviour after the upgrade.
+-- Only date-scoped seasonal trips (e.g. the Pelion railway PL1, which runs on
+-- specific dates) populate it; getNextDepartures hides such a row on days its
+-- comma-separated ISO list does not include. Without this column the first query
+-- referencing valid_dates would crash with "no such column" on an upgraded
+-- install, so the migration must ship with the .sq change.
+
+ALTER TABLE schedule_entity ADD COLUMN valid_dates TEXT;

--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/GetNextDeparturesUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/usecase/GetNextDeparturesUseCase.kt
@@ -122,6 +122,9 @@ class GetNextDeparturesUseCase(
             direction = direction,
             dayType = dayType,
             currentTime = currentTimeString,
+            // Athens ISO date so a date-scoped seasonal trip is hidden off its
+            // valid dates; kotlinx LocalDate.toString() is yyyy-MM-dd.
+            today = currentAthensDate().toString(),
             limit = limit,
         ).map { departures ->
             departures.map { departure ->

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/SyrmosSchedulesService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/SyrmosSchedulesService.kt
@@ -152,6 +152,12 @@ class SyrmosSchedulesService(
         @SerialName("dayType") val dayType: String = "",
         @SerialName("direction") val direction: String = "",
         @SerialName("serviceLabel") val serviceLabel: String = "",
+        // Comma-separated ISO dates (yyyy-MM-dd) this dated trip runs on; null or
+        // blank means it runs on every date matching its dayType. Date-scoped
+        // seasonal services (e.g. the Pelion railway PL1) set it. iOS honors it in
+        // ScheduleProjector; it was being dropped on Android, so such trips showed
+        // on the wrong days.
+        @SerialName("validDates") val validDates: String? = null,
         val stops: List<TripStop> = emptyList(),
     )
 

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
@@ -281,6 +281,9 @@ class MapViewModel(
                         today = scheduleDayTypeString(),
                         nowMinutes = now.hour * 60 + now.minute + now.second / 60.0,
                         geometry = geometry,
+                        // Athens ISO date so a date-scoped seasonal vehicle is
+                        // projected only on the dates it runs.
+                        todayIso = currentAthensDate().toString(),
                     ).filter { it.lineId !in coveredByLive }
                     val visibleTrains = filtered + projected
                     _uiState.update { current ->

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/TrainSimulator.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/TrainSimulator.kt
@@ -154,6 +154,8 @@ private val BAND_PROJECTED_LINES =
 /// timetable" path; if the Pi ever serves their live positions those win per line.
 ///
 /// [today] is the schedule day-type string ("mon_thu" / "fri" / "sat" / "sun").
+/// [todayIso] is the Athens date (yyyy-MM-dd) used to hide date-scoped trips off
+/// their valid dates; empty disables that filter.
 /// [nowMinutes] is minutes since Athens midnight (fractional for smooth glide).
 fun projectScheduledTrains(
     lines: List<Line>,
@@ -162,6 +164,7 @@ fun projectScheduledTrains(
     today: String,
     nowMinutes: Double,
     geometry: Map<String, List<LatLng>> = emptyMap(),
+    todayIso: String = "",
 ): List<SimulatedTrain> {
     if (bundles.isEmpty()) return emptyList()
     val lineById = lines.filter { it.isOperational }.associateBy { it.id }
@@ -177,6 +180,16 @@ fun projectScheduledTrains(
             // dayType is authoritative; an empty dayType runs every day.
             val td = trip.dayType.lowercase()
             if (td.isNotEmpty() && td != today) continue
+            // Date-scoped trips (seasonal, e.g. Pelion PL1) run only on the ISO
+            // dates listed in validDates; hide the vehicle off those dates so the
+            // map matches the offline departures filter. Skipped when todayIso is
+            // unknown (empty) so a missing date never blanks the map.
+            val vd = trip.validDates
+            if (!vd.isNullOrBlank() && todayIso.isNotEmpty() &&
+                todayIso !in vd.split(",").map { it.trim() }
+            ) {
+                continue
+            }
             val rawStops = trip.stops
             if (rawStops.size < 2) continue
             // Chronological stop order. The seed stores stops in canonical

--- a/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/TrainSimulatorTest.kt
+++ b/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/TrainSimulatorTest.kt
@@ -8,6 +8,7 @@ import com.syrmos.core.model.transit.LineStatus
 import com.syrmos.core.model.transit.LineType
 import com.syrmos.core.model.transit.Station
 import com.syrmos.core.network.SyrmosLivePositionsService
+import com.syrmos.core.network.SyrmosSchedulesService
 import kotlinx.datetime.Clock
 import kotlin.math.abs
 import kotlin.test.Test
@@ -419,5 +420,127 @@ class TrainSimulatorTest {
             nearest,
         )
         assertTrue(offTrack < 50.0, "geometry train must lie on the track, off by ${offTrack}m")
+    }
+
+    // --- validDates (date-scoped seasonal trips) --------------------------
+    //
+    // A trip may carry a comma-separated list of ISO dates it actually runs on
+    // (seasonal services like the Pelion railway PL1). projectScheduledTrains
+    // must hide its vehicle on any other date, matching the offline
+    // getNextDepartures SQL filter and the iOS ScheduleProjector. An
+    // unrestricted trip (null/blank validDates) always runs, and an unknown
+    // todayIso ("") disables the filter so a missing date never blanks the map.
+
+    private val pelionLine = Line(
+        id = "PL1",
+        name = "Pelion Railway",
+        nameEl = "Τρενάκι Πηλίου",
+        type = LineType.SUBURBAN,
+        color = LineColor.SUBURBAN_PURPLE,
+        terminalA = "Ano Lechonia",
+        terminalB = "Milies",
+        stationCount = 2,
+    )
+    private val pelionStationA = Station(
+        id = "PL1_A", name = "Ano Lechonia", nameEl = "Άνω Λεχώνια",
+        latitude = 39.33, longitude = 23.03, lineIds = listOf("PL1"),
+    )
+    private val pelionStationB = Station(
+        id = "PL1_B", name = "Milies", nameEl = "Μηλιές",
+        latitude = 39.33, longitude = 23.15, lineIds = listOf("PL1"),
+    )
+    private val pelionStations = mapOf("PL1" to listOf(pelionStationA, pelionStationB))
+
+    // dayType is left empty so the trip runs on every weekday, isolating the
+    // validDates branch as the only thing that can drop it.
+    private fun pelionBundle(validDates: String?) = mapOf(
+        "PL1" to SyrmosSchedulesService.LineSchedule(
+            lineId = "PL1",
+            trips = listOf(
+                SyrmosSchedulesService.TripEntry(
+                    trainNo = "1",
+                    dayType = "",
+                    direction = "outbound",
+                    validDates = validDates,
+                    stops = listOf(
+                        SyrmosSchedulesService.TripStop("PL1_A", 1, "10:00"),
+                        SyrmosSchedulesService.TripStop("PL1_B", 2, "10:20"),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    // 10:10 Athens, squarely inside the 10:00 -> 10:20 trip window.
+    private val pelionNowMinutes = 10.0 * 60 + 10
+
+    @Test
+    fun projectsDatedTripOnItsValidDate() {
+        val result = projectScheduledTrains(
+            lines = listOf(pelionLine),
+            lineStations = pelionStations,
+            bundles = pelionBundle(validDates = "2026-09-01"),
+            today = "",
+            nowMinutes = pelionNowMinutes,
+            todayIso = "2026-09-01",
+        )
+        assertEquals(1, result.size, "Dated trip must project on a date listed in validDates")
+        assertEquals("PL1", result.first().lineId)
+    }
+
+    @Test
+    fun hidesDatedTripOffItsValidDate() {
+        val result = projectScheduledTrains(
+            lines = listOf(pelionLine),
+            lineStations = pelionStations,
+            bundles = pelionBundle(validDates = "2026-09-01,2026-09-08"),
+            today = "",
+            nowMinutes = pelionNowMinutes,
+            todayIso = "2026-09-02",
+        )
+        assertTrue(result.isEmpty(), "Dated trip must be hidden on a date absent from validDates")
+    }
+
+    @Test
+    fun datedTripMatchesWholeTokenNotSubstring() {
+        // "2026-09-01" must not match by being a substring of a longer token.
+        // Comma-boundary matching (mirrored in the SQL) rejects it.
+        val result = projectScheduledTrains(
+            lines = listOf(pelionLine),
+            lineStations = pelionStations,
+            bundles = pelionBundle(validDates = "2026-09-011,2026-09-08"),
+            today = "",
+            nowMinutes = pelionNowMinutes,
+            todayIso = "2026-09-01",
+        )
+        assertTrue(result.isEmpty(), "todayIso must match a whole date token, never a substring")
+    }
+
+    @Test
+    fun unrestrictedTripRunsOnAnyDate() {
+        val result = projectScheduledTrains(
+            lines = listOf(pelionLine),
+            lineStations = pelionStations,
+            bundles = pelionBundle(validDates = null),
+            today = "",
+            nowMinutes = pelionNowMinutes,
+            todayIso = "2026-09-02",
+        )
+        assertEquals(1, result.size, "A trip with no validDates must run on every matching day")
+    }
+
+    @Test
+    fun unknownTodayIsoDoesNotHideDatedTrip() {
+        // todayIso is empty when the date is unknown; the filter must be a no-op
+        // then so we never blank the map for a missing date.
+        val result = projectScheduledTrains(
+            lines = listOf(pelionLine),
+            lineStations = pelionStations,
+            bundles = pelionBundle(validDates = "2026-09-01"),
+            today = "",
+            nowMinutes = pelionNowMinutes,
+            todayIso = "",
+        )
+        assertEquals(1, result.size, "Empty todayIso must disable the validDates filter")
     }
 }


### PR DESCRIPTION
## What

Date-scoped trips (seasonal services such as the Pelion railway PL1) carry a comma-separated `validDates` list of the ISO dates they actually run. iOS already honors it in `ScheduleProjector`, but Android dropped the field, so those trips showed on **every** day matching their `dayType`, both in the offline departures sheet and as a moving vehicle on the map. This threads `validDates` end to end on Android.

## Offline departures path

- Deserialize `validDates` on `TripEntry` (network) and `SeedTripEntry` (seed).
- Add `schedule_entity.valid_dates` (nullable) plus migration `3.sqm`, so an upgraded install gains the column without a `no such column` crash and existing rows keep today's behaviour (NULL = runs on every matching date).
- `insertSchedule` persists it; `DataSeeder` writes `null` for band-derived schedules and the trip's list for per-train trips; `SEED_VERSION` 10 -> 11 forces the reseed that fills the new column.
- `getNextDepartures` filters on `:today` using a **comma-wrapped** `LIKE` so the match is on a whole ISO-date token, never a bare substring (mirrors the iOS `split(",").contains`). `ScheduleRepositoryImpl` and `GetNextDeparturesUseCase` thread the Athens ISO date.

## Map projector path

- `projectScheduledTrains` takes `todayIso` and hides a dated trip's vehicle off its valid dates; an empty `todayIso` disables the filter so a missing date never blanks the map. `MapViewModel` passes `currentAthensDate().toString()`.

## Tests

Five `projectScheduledTrains` cases: on-date projects, off-date hidden, whole-token vs substring (`2026-09-011` must not match `2026-09-01`), unrestricted runs any date, empty `todayIso` is a no-op. The SQL query and migration are validated at compile time by the KMP build.

## Parity

Brings Android in line with the iOS `ScheduleProjector.swift` validDates semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)