### PR TITLE
Android: one malformed live row no longer blanks the whole live map (parity #25)

### DIFF
--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/SyrmosLivePositionsService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/SyrmosLivePositionsService.kt
@@ -3,9 +3,12 @@ package com.syrmos.core.network
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 
 /**
  * Talks to the API's `/api/live-positions` and `/api/station-offsets`
@@ -22,36 +25,36 @@ import kotlinx.serialization.json.Json
 class SyrmosLivePositionsService(
     private val httpClient: HttpClient,
 ) {
-    private val json = Json { ignoreUnknownKeys = true }
 
     suspend fun fetchActiveTrains(lineIds: List<String>): LivePositionsResponse? = runCatching {
         val ids = lineIds.joinToString(",")
         val response = httpClient.get("$BASE_URL/api/live-positions?lineIds=$ids")
-        val body = response.bodyAsText()
-        json.decodeFromString<LivePositionsResponse>(body)
+        parseLivePositions(response.bodyAsText())
     }.getOrNull()
 
     suspend fun fetchStationOffsets(): StationOffsetsResponse? = runCatching {
         val response = httpClient.get("$BASE_URL/api/station-offsets")
-        val body = response.bodyAsText()
-        json.decodeFromString<StationOffsetsResponse>(body)
+        parseStationOffsets(response.bodyAsText())
     }.getOrNull()
 
     @Serializable
     data class LivePositionsResponse(
-        val generatedAt: String,
+        val generatedAt: String = "",
         val lineIds: List<String> = emptyList(),
         val trains: List<LiveTrain> = emptyList(),
     )
 
+    // Every field carries a safe default so a row missing one still decodes
+    // (see parseLivePositions); a row with no line/direction is dropped there
+    // because it can't be placed on the map.
     @Serializable
     data class LiveTrain(
-        val lineId: String,
-        val directionKey: String,
-        val originDepartureMinute: Double,
-        val elapsedMinutes: Double,
-        val totalTravelMinutes: Int,
-        val serviceType: String,
+        val lineId: String = "",
+        val directionKey: String = "",
+        val originDepartureMinute: Double = 0.0,
+        val elapsedMinutes: Double = 0.0,
+        val totalTravelMinutes: Int = 0,
+        val serviceType: String = "regular",
     )
 
     @Serializable
@@ -63,8 +66,8 @@ class SyrmosLivePositionsService(
 
     @Serializable
     data class OffsetLine(
-        val lineId: String,
-        val direction: String,
+        val lineId: String = "",
+        val direction: String = "",
         val origin: String = "",
         val destination: String = "",
         val stops: List<OffsetStop> = emptyList(),
@@ -72,13 +75,54 @@ class SyrmosLivePositionsService(
 
     @Serializable
     data class OffsetStop(
-        val stationId: String,
+        val stationId: String = "",
         val stationEn: String = "",
-        val stopSequence: Int,
-        val minutesFromOrigin: Int,
+        val stopSequence: Int = 0,
+        val minutesFromOrigin: Int = 0,
     )
 
     companion object {
         private const val BASE_URL = "https://api-syrmos.peterdsp.dev"
+        private val json = Json { ignoreUnknownKeys = true }
+
+        /**
+         * Decode the live-positions payload row by row so ONE malformed vehicle
+         * (a missing or wrong-typed field) is skipped instead of throwing and
+         * nulling the whole response, which would silently drop the entire live
+         * map back to the schedule simulator. Mirrors the iOS resilience fixes
+         * for the trains feed and announcements: tolerate partial rows, drop the
+         * useless ones (no line or direction), keep the rest. A body that is not
+         * a JSON object still throws, so the caller's runCatching falls back to
+         * the bundled/simulated layer exactly as before.
+         */
+        internal fun parseLivePositions(body: String): LivePositionsResponse {
+            val root = json.parseToJsonElement(body).jsonObject
+            val trains = (root["trains"] as? JsonArray).orEmpty()
+                .mapNotNull { el -> runCatching { json.decodeFromJsonElement(LiveTrain.serializer(), el) }.getOrNull() }
+                .filter { it.lineId.isNotBlank() && it.directionKey.isNotBlank() }
+            return LivePositionsResponse(
+                generatedAt = (root["generatedAt"] as? JsonPrimitive)?.contentOrNull ?: "",
+                lineIds = (root["lineIds"] as? JsonArray).orEmpty()
+                    .mapNotNull { (it as? JsonPrimitive)?.contentOrNull },
+                trains = trains,
+            )
+        }
+
+        /**
+         * Same row-by-row tolerance for the station-offsets table: a single
+         * malformed line entry is skipped instead of voiding every line's
+         * offsets (which would leave the live dots with nowhere to interpolate).
+         */
+        internal fun parseStationOffsets(body: String): StationOffsetsResponse {
+            val root = json.parseToJsonElement(body).jsonObject
+            val lines = (root["lines"] as? JsonArray).orEmpty()
+                .mapNotNull { el -> runCatching { json.decodeFromJsonElement(OffsetLine.serializer(), el) }.getOrNull() }
+                .filter { it.lineId.isNotBlank() && it.direction.isNotBlank() }
+            return StationOffsetsResponse(
+                updatedAt = (root["updatedAt"] as? JsonPrimitive)?.contentOrNull ?: "",
+                source = (root["source"] as? JsonPrimitive)?.contentOrNull ?: "",
+                lines = lines,
+            )
+        }
     }
 }

--- a/core/network/src/commonTest/kotlin/com/syrmos/core/network/SyrmosLivePositionsDecodeTest.kt
+++ b/core/network/src/commonTest/kotlin/com/syrmos/core/network/SyrmosLivePositionsDecodeTest.kt
@@ -1,0 +1,115 @@
+package com.syrmos.core.network
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the live-positions / station-offsets decode
+ * resilience (audit #25). The feed is decoded row by row so a single
+ * malformed vehicle or offset line is skipped instead of throwing and
+ * nulling the whole response, which used to drop the entire live map
+ * silently back to the schedule simulator. Mirrors the iOS resilience
+ * fixes for the trains feed (#22) and announcements (#24).
+ */
+class SyrmosLivePositionsDecodeTest {
+
+    @Test
+    fun validPayloadDecodesEveryTrain() {
+        val body = """
+            {
+              "generatedAt": "2026-09-01T10:00:00Z",
+              "lineIds": ["M3", "T6"],
+              "trains": [
+                {"lineId":"M3","directionKey":"outbound","originDepartureMinute":0.0,"elapsedMinutes":5.0,"totalTravelMinutes":20,"serviceType":"regular"},
+                {"lineId":"T6","directionKey":"inbound","originDepartureMinute":8.0,"elapsedMinutes":3.0,"totalTravelMinutes":40,"serviceType":"regular"}
+              ]
+            }
+        """.trimIndent()
+        val result = SyrmosLivePositionsService.parseLivePositions(body)
+        assertEquals("2026-09-01T10:00:00Z", result.generatedAt)
+        assertEquals(listOf("M3", "T6"), result.lineIds)
+        assertEquals(2, result.trains.size)
+    }
+
+    @Test
+    fun oneWrongTypedTrainRowDoesNotVoidTheRest() {
+        // The middle row has a string where totalTravelMinutes must be an Int.
+        // It must be skipped, leaving the two good rows intact - the old
+        // atomic decode returned null (empty live map) for the whole payload.
+        val body = """
+            {
+              "trains": [
+                {"lineId":"M3","directionKey":"outbound","originDepartureMinute":0.0,"elapsedMinutes":5.0,"totalTravelMinutes":20,"serviceType":"regular"},
+                {"lineId":"M2","directionKey":"outbound","originDepartureMinute":0.0,"elapsedMinutes":5.0,"totalTravelMinutes":"oops","serviceType":"regular"},
+                {"lineId":"T6","directionKey":"inbound","originDepartureMinute":0.0,"elapsedMinutes":5.0,"totalTravelMinutes":40,"serviceType":"regular"}
+              ]
+            }
+        """.trimIndent()
+        val result = SyrmosLivePositionsService.parseLivePositions(body)
+        assertEquals(listOf("M3", "T6"), result.trains.map { it.lineId })
+    }
+
+    @Test
+    fun trainRowMissingOptionalFieldStillDecodes() {
+        // serviceType omitted -> default "regular", row survives.
+        val body = """
+            {"trains":[{"lineId":"M3","directionKey":"outbound","originDepartureMinute":0.0,"elapsedMinutes":5.0,"totalTravelMinutes":20}]}
+        """.trimIndent()
+        val result = SyrmosLivePositionsService.parseLivePositions(body)
+        assertEquals(1, result.trains.size)
+        assertEquals("regular", result.trains.first().serviceType)
+    }
+
+    @Test
+    fun trainRowMissingLineOrDirectionIsDropped() {
+        // A row that decodes but has no line/direction can't be placed on the
+        // map, so it is filtered out (not kept as a zero-valued ghost).
+        val body = """
+            {"trains":[
+              {"directionKey":"outbound","originDepartureMinute":0.0,"elapsedMinutes":5.0,"totalTravelMinutes":20,"serviceType":"regular"},
+              {"lineId":"M3","originDepartureMinute":0.0,"elapsedMinutes":5.0,"totalTravelMinutes":20,"serviceType":"regular"},
+              {"lineId":"M3","directionKey":"outbound","originDepartureMinute":0.0,"elapsedMinutes":5.0,"totalTravelMinutes":20,"serviceType":"regular"}
+            ]}
+        """.trimIndent()
+        val result = SyrmosLivePositionsService.parseLivePositions(body)
+        assertEquals(1, result.trains.size, "Only the row with both line and direction is usable")
+    }
+
+    @Test
+    fun emptyTrainsPayloadDecodesToEmpty() {
+        val result = SyrmosLivePositionsService.parseLivePositions("""{"trains":[]}""")
+        assertTrue(result.trains.isEmpty())
+    }
+
+    @Test
+    fun oneMalformedOffsetLineDoesNotVoidTheTable() {
+        // The M2 line entry has a stop whose stopSequence is a non-numeric
+        // string; that line is dropped but M3's offsets survive.
+        val body = """
+            {
+              "updatedAt": "2026-09-01T10:00:00Z",
+              "source": "pi",
+              "lines": [
+                {"lineId":"M3","direction":"outbound","stops":[{"stationId":"M3_A","stopSequence":1,"minutesFromOrigin":0}]},
+                {"lineId":"M2","direction":"outbound","stops":[{"stationId":"M2_A","stopSequence":"x","minutesFromOrigin":0}]}
+              ]
+            }
+        """.trimIndent()
+        val result = SyrmosLivePositionsService.parseStationOffsets(body)
+        assertEquals(listOf("M3"), result.lines.map { it.lineId })
+        assertEquals("pi", result.source)
+    }
+
+    @Test
+    fun offsetLineMissingIdentityIsDropped() {
+        val body = """
+            {"lines":[
+              {"direction":"outbound","stops":[]},
+              {"lineId":"M3","direction":"outbound","stops":[{"stationId":"M3_A","stopSequence":1,"minutesFromOrigin":0}]}
+            ]}
+        """.trimIndent()
+        val result = SyrmosLivePositionsService.parseStationOffsets(body)
+        assertEquals(listOf("M3"), result.lines.map { it.lineId })
+    }
+}


### PR DESCRIPTION
## What

`/api/live-positions` and `/api/station-offsets` were decoded **atomically** in `SyrmosLivePositionsService`: `decodeFromString<LivePositionsResponse>` parsed the entire `trains` list in one shot, so a single vehicle row with a missing or wrong-typed field threw, the service's `runCatching` returned `null`, and the map **silently dropped its whole live layer** back to the schedule simulator. The station-offsets table had the same brittleness (one bad line entry voided every line's offsets, leaving the live dots with nowhere to interpolate).

Closes audit row **#25**. Mirrors the iOS resilience fixes for the trains feed (#22) and announcements (#24) that already merged.

## How

Decode **row by row**:
- Every `LiveTrain` / `OffsetLine` / `OffsetStop` field carries a safe default, so a row missing a non-identity field still decodes.
- `parseLivePositions` / `parseStationOffsets` decode each array element under its own `runCatching` and skip the ones that still fail (wrong type), keeping the good rows.
- Rows with no line/direction are dropped (can't be placed on the map) rather than kept as zero-valued ghosts.
- A body that is not a JSON object still throws, so the caller's `runCatching` falls back to the bundled/simulated layer exactly as before.

The parse functions are companion members so they unit-test without an HTTP engine.

## Tests

`SyrmosLivePositionsDecodeTest`: valid payload decodes all; one wrong-typed row keeps the rest; missing optional field defaults; missing line/direction dropped; empty list; one malformed offset line keeps the table; offset line missing identity dropped.

## Parity

Brings Android's live-feed decode in line with the iOS reference's tolerant, skip-bad-rows behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)