### PR TITLE
Android: accent- and case-insensitive station search (parity #17)

### DIFF
--- a/core/common/src/commonMain/kotlin/com/syrmos/core/common/extensions/TextExtensions.kt
+++ b/core/common/src/commonMain/kotlin/com/syrmos/core/common/extensions/TextExtensions.kt
@@ -1,0 +1,49 @@
+package com.syrmos.core.common.extensions
+
+/**
+ * Normalizes text for accent- and case-insensitive substring search across the
+ * app's Greek, English and Albanian station names and codes. It lowercases,
+ * then folds Greek tonos/dialytika and final sigma plus the common Latin
+ * diacritics that turn up in transliterated and Albanian names, so a user
+ * typing "attiki" matches "Αττική", "οδος" matches "Οδός", and "dhespoti"
+ * matches "Dhëspoti".
+ *
+ * This is the single search normalizer shared by every predicate (see
+ * `StationRepositoryImpl.matchesQuery` and `MapStationNode`). Apply it to BOTH
+ * the query and the field before a `contains()` check. It deliberately does not
+ * strip spaces or punctuation, keeping substring semantics intuitive; callers
+ * that need a compact key (e.g. clustering) strip separately.
+ *
+ * A single pass over the lowercased chars keeps it allocation-light versus a
+ * chain of `replace()` calls. All folded code points are in the BMP, so plain
+ * Char iteration is safe.
+ */
+fun String.normalizeForSearch(): String {
+    val lowered = lowercase()
+    val sb = StringBuilder(lowered.length)
+    for (ch in lowered) {
+        sb.append(
+            when (ch) {
+                // Greek tonos + dialytika + final sigma.
+                'ά' -> 'α'
+                'έ' -> 'ε'
+                'ή' -> 'η'
+                'ί', 'ϊ', 'ΐ' -> 'ι'
+                'ό' -> 'ο'
+                'ύ', 'ϋ', 'ΰ' -> 'υ'
+                'ώ' -> 'ω'
+                'ς' -> 'σ'
+                // Latin diacritics (transliterated Greek + Albanian ë/ç).
+                'à', 'á', 'â', 'ã', 'ä', 'å' -> 'a'
+                'è', 'é', 'ê', 'ë' -> 'e'
+                'ì', 'í', 'î', 'ï' -> 'i'
+                'ò', 'ó', 'ô', 'õ', 'ö' -> 'o'
+                'ù', 'ú', 'û', 'ü' -> 'u'
+                'ñ' -> 'n'
+                'ç' -> 'c'
+                else -> ch
+            },
+        )
+    }
+    return sb.toString()
+}

--- a/core/common/src/commonTest/kotlin/com/syrmos/core/common/extensions/TextExtensionsTest.kt
+++ b/core/common/src/commonTest/kotlin/com/syrmos/core/common/extensions/TextExtensionsTest.kt
@@ -1,0 +1,51 @@
+package com.syrmos.core.common.extensions
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the shared search normalizer used by every station-search predicate
+ * (audit #17). It must lowercase and fold Greek tonos/dialytika, final sigma,
+ * and the common Latin diacritics, while leaving spaces and plain ASCII intact.
+ */
+class TextExtensionsTest {
+
+    @Test
+    fun foldsGreekTonos() {
+        assertEquals("αττικη", "Αττική".normalizeForSearch())
+        assertEquals("αγια μαρινα", "Αγία Μαρίνα".normalizeForSearch())
+        assertEquals("μοναστηρακι", "Μοναστηράκι".normalizeForSearch())
+    }
+
+    @Test
+    fun foldsFinalSigma() {
+        assertEquals("οδοσ", "Οδός".normalizeForSearch())
+        assertEquals("λεωφοροσ", "Λεωφόρος".normalizeForSearch())
+    }
+
+    @Test
+    fun foldsDialytika() {
+        // ϊ/ΐ -> ι, ϋ/ΰ -> υ
+        assertEquals("μαι", "μαΐ".normalizeForSearch())
+        assertEquals("υ", "ΰ".normalizeForSearch())
+    }
+
+    @Test
+    fun foldsLatinDiacritics() {
+        assertEquals("dhespoti", "Dhëspoti".normalizeForSearch())
+        assertEquals("cafe", "Café".normalizeForSearch())
+        assertEquals("aegais", "Aegaís".normalizeForSearch())
+    }
+
+    @Test
+    fun leavesPlainAsciiAndSpacesIntact() {
+        assertEquals("syntagma square", "Syntagma Square".normalizeForSearch())
+        assertEquals("m1_att", "M1_ATT".normalizeForSearch())
+    }
+
+    @Test
+    fun isIdempotent() {
+        val once = "Αγία Παρασκευή".normalizeForSearch()
+        assertEquals(once, once.normalizeForSearch())
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/StationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/repository/StationRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.syrmos.core.data.repository
 
 import com.syrmos.core.common.extensions.distanceInMeters
+import com.syrmos.core.common.extensions.normalizeForSearch
 import com.syrmos.core.database.SyrmosDatabase
 import com.syrmos.core.database.mapper.toDomain
 import com.syrmos.core.data.seed.ResourceReader
@@ -73,28 +74,35 @@ class StationRepositoryImpl(
     }
 
     fun searchStations(query: String): Flow<List<Station>> = flow {
-        val pattern = "%$query%"
-        // Match Greek (name_el), English (name), Albanian (name_sq) names and the
-        // station code (id), mirroring the iOS Browse-All filter. The DB path had
-        // only name/name_el, so Albanian names and station codes never matched.
-        val stations = database.syrmosDatabaseQueries.searchStations(pattern, pattern, pattern, pattern)
-            .executeAsList()
-            .map { entity ->
-                val lineIds = database.syrmosDatabaseQueries.getLinesAtStation(entity.id)
-                    .executeAsList()
-                    .map { it.id }
-                entity.toDomain(lineIds)
-            }
-        emit(
-            stations.ifEmpty {
-                val normalized = query.trim().lowercase()
-                // Defense-in-depth: never contains("") against every station (it
-                // matches all). The use-case already guards this, but keep the
-                // repo honest if called directly.
-                if (normalized.isEmpty()) emptyList()
-                else readSeedStations().filter { matchesQuery(it, normalized) }
-            },
-        )
+        // Filter in memory with a diacritic- and case-folding predicate, matching
+        // the iOS in-memory Browse-All filter. The old SQL LIKE path could not do
+        // this: SQLite LIKE is case-insensitive for ASCII only, so a stored Greek
+        // name (Αττική) never matched a typed lowercase query, and no path folded
+        // tonos. Matching the entity rows (which already carry name/name_el/
+        // name_sq/id) means the per-row lineId fan-out only runs for the handful
+        // of stations that actually matched.
+        val normalized = query.trim().normalizeForSearch()
+        // Defense-in-depth: never contains("") against every station (it matches
+        // all). The use-case already guards this, but keep the repo honest if
+        // called directly.
+        if (normalized.isEmpty()) {
+            emit(emptyList())
+            return@flow
+        }
+        val entities = database.syrmosDatabaseQueries.getAllStations().executeAsList()
+        val matched = if (entities.isNotEmpty()) {
+            entities
+                .filter { matchesNormalized(it.name, it.name_el, it.name_sq, it.id, normalized) }
+                .map { entity ->
+                    val lineIds = database.syrmosDatabaseQueries.getLinesAtStation(entity.id)
+                        .executeAsList()
+                        .map { it.id }
+                    entity.toDomain(lineIds)
+                }
+        } else {
+            readSeedStations().filter { matchesQuery(it, normalized) }
+        }
+        emit(matched)
     }
 
     fun findNearestStations(
@@ -186,15 +194,31 @@ class StationRepositoryImpl(
 
     companion object {
         /**
-         * Whether [station] matches an already-normalized (trimmed, lowercased)
-         * search query across its English, Greek and Albanian names and its
-         * station code. Mirrors the iOS Browse-All filter so all three platforms
-         * match the same stations.
+         * Whether [station] matches an already-[normalizeForSearch]d search
+         * query across its English, Greek and Albanian names and its station
+         * code. Mirrors the iOS Browse-All filter so all platforms match the
+         * same stations.
          */
         internal fun matchesQuery(station: Station, normalizedQuery: String): Boolean =
-            station.name.lowercase().contains(normalizedQuery) ||
-                station.nameEl.lowercase().contains(normalizedQuery) ||
-                station.nameSq?.lowercase()?.contains(normalizedQuery) == true ||
-                station.id.lowercase().contains(normalizedQuery)
+            matchesNormalized(station.name, station.nameEl, station.nameSq, station.id, normalizedQuery)
+
+        /**
+         * Field-level match used by both the DB and seed paths. Both the fields
+         * and the (already-normalized) query are folded with [normalizeForSearch]
+         * so case and diacritics are ignored uniformly, e.g. a typed "attiki"
+         * matches the stored "Αττική" and "οδος" matches "Οδός". The caller MUST
+         * pass a query that has already been through [normalizeForSearch].
+         */
+        internal fun matchesNormalized(
+            name: String,
+            nameEl: String,
+            nameSq: String?,
+            id: String,
+            normalizedQuery: String,
+        ): Boolean =
+            name.normalizeForSearch().contains(normalizedQuery) ||
+                nameEl.normalizeForSearch().contains(normalizedQuery) ||
+                nameSq?.normalizeForSearch()?.contains(normalizedQuery) == true ||
+                id.normalizeForSearch().contains(normalizedQuery)
     }
 }

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/repository/StationSearchMatchTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/repository/StationSearchMatchTest.kt
@@ -1,5 +1,6 @@
 package com.syrmos.core.data.repository
 
+import com.syrmos.core.common.extensions.normalizeForSearch
 import com.syrmos.core.model.transit.Station
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -53,5 +54,39 @@ class StationSearchMatchTest {
         val noSq = station.copy(nameSq = null)
         assertTrue(StationRepositoryImpl.matchesQuery(noSq, "attik"), "English still matches")
         assertFalse(StationRepositoryImpl.matchesQuery(noSq, "atik"), "no Albanian to match")
+    }
+
+    // --- diacritic folding (audit #17) ------------------------------------
+    //
+    // The stored Greek names carry tonos (Αγία, Μαρίνα); a user typically types
+    // without them. The real entry point normalizes the query, so these mirror
+    // that by folding the query the same way before matching.
+
+    private val agiaMarina = Station(
+        id = "M3_AGM",
+        name = "Agia Marina",
+        nameEl = "Αγία Μαρίνα",
+        nameSq = null,
+        latitude = 38.07,
+        longitude = 23.71,
+        lineIds = listOf("M3"),
+    )
+
+    @Test
+    fun matchesGreekNameTypedWithoutTonos() {
+        val q = "αγια μαρινα".normalizeForSearch()
+        assertTrue(StationRepositoryImpl.matchesQuery(agiaMarina, q))
+    }
+
+    @Test
+    fun matchesGreekNameTypedWithTonos() {
+        val q = "Αγία".normalizeForSearch()
+        assertTrue(StationRepositoryImpl.matchesQuery(agiaMarina, q))
+    }
+
+    @Test
+    fun foldsLatinDiacriticsInAlbanianName() {
+        val albanian = station.copy(nameSq = "Dhëspoti")
+        assertTrue(StationRepositoryImpl.matchesQuery(albanian, "dhespoti".normalizeForSearch()))
     }
 }

--- a/core/database/src/commonMain/sqldelight/com/syrmos/core/database/SyrmosDatabase.sq
+++ b/core/database/src/commonMain/sqldelight/com/syrmos/core/database/SyrmosDatabase.sq
@@ -132,10 +132,10 @@ SELECT * FROM station_entity WHERE id = ?;
 getInterchangeStations:
 SELECT * FROM station_entity WHERE is_interchange = 1 ORDER BY name;
 
-searchStations:
-SELECT * FROM station_entity
-WHERE name LIKE ? OR name_el LIKE ? OR name_sq LIKE ? OR id LIKE ?
-ORDER BY name;
+-- Station search runs in memory in StationRepositoryImpl (see searchStations):
+-- SQLite LIKE is case-insensitive for ASCII only and cannot fold Greek tonos,
+-- so a shared normalizeForSearch() predicate over getAllStations() replaces the
+-- old LIKE query. Kept as a comment so the missing query is not a mystery.
 
 insertStation:
 INSERT OR REPLACE INTO station_entity(id, name, name_el, name_sq, latitude, longitude, is_interchange, accessibility, zone, region, source_confidence)

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapStationNode.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapStationNode.kt
@@ -1,5 +1,6 @@
 package com.syrmos.feature.map
 
+import com.syrmos.core.common.extensions.normalizeForSearch
 import com.syrmos.core.model.transit.Station
 import kotlin.math.atan2
 import kotlin.math.cos
@@ -83,21 +84,11 @@ private fun List<Station>.clusterByProximity(radiusMeters: Double = 300.0): List
     return clusters
 }
 
-private fun String.normalizeStationText(): String {
-    return lowercase()
-        .replace("ά", "α")
-        .replace("έ", "ε")
-        .replace("ή", "η")
-        .replace("ί", "ι")
-        .replace("ϊ", "ι")
-        .replace("ΐ", "ι")
-        .replace("ό", "ο")
-        .replace("ύ", "υ")
-        .replace("ϋ", "υ")
-        .replace("ΰ", "υ")
-        .replace("ώ", "ω")
-        .replace(Regex("[^\\p{L}\\p{Nd}]+"), "")
-}
+// Clustering key: the shared search normalizer (case + tonos + diacritic
+// folding) reduced to a compact alphanumeric token. Delegating keeps the
+// tonos table in one place (core/common) instead of duplicating it here.
+private fun String.normalizeStationText(): String =
+    normalizeForSearch().replace(Regex("[^\\p{L}\\p{Nd}]+"), "")
 
 private fun List<Station>.latitudeBucket(): Int = (map { it.latitude }.average() * 10000).toInt()
 


### PR DESCRIPTION
## What

Station search could not match Greek names reliably. Two defects:

1. **Greek case never matched.** The primary path was a SQLite `LIKE` query, but `LIKE` is case-insensitive for **ASCII only**. A stored Greek name (`Αττική`, capitalised) never matched a typed lowercase query, so Greek search silently fell through to the seed fallback or returned nothing.
2. **No tonos folding.** No path folded Greek tonos, so `αγια` never matched the stored `Αγία` and `οδος` never matched `Οδός`. iOS has the same tonos gap (audit row **#17** flags both platforms); this closes it on Android with a shared normalizer iOS can adopt later.

## How

A single shared normalizer, every predicate routed through it:

- **`core/common` `String.normalizeForSearch()`** lowercases, then folds Greek tonos/dialytika and final sigma plus the common Latin diacritics (for transliterated and Albanian `ë`/`ç` names). Single pass over the lowered chars.
- **`StationRepositoryImpl.searchStations`** now filters **in memory** over the `station_entity` rows with that predicate (both query and field folded), mirroring the iOS in-memory Browse-All filter. The per-row `lineId` lookup runs only for the handful of matches. The unused `LIKE` query is removed.
- **`matchesQuery`** delegates to a shared `matchesNormalized` so the DB and seed paths match identically.
- **`MapStationNode`**'s clustering normalizer delegates to `normalizeForSearch` instead of duplicating the tonos table.

## Tests

- `TextExtensionsTest`: tonos, final sigma, dialytika, Latin diacritics, plain ASCII/space passthrough, idempotence.
- `StationSearchMatchTest`: Greek typed **with or without** tonos now matches; Albanian names with diacritics match; all prior name/nameEl/nameSq/id assertions still hold.

## Parity

Brings Android search in line with the iOS in-memory filter and goes one step further (tonos folding) that iOS can pick up from the shared normalizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)