### PR TITLE
Android: resolve Athens time via IANA tz, not hand-rolled DST (parity #20)

### DIFF
--- a/core/common/src/commonMain/kotlin/com/syrmos/core/common/extensions/DateTimeExtensions.kt
+++ b/core/common/src/commonMain/kotlin/com/syrmos/core/common/extensions/DateTimeExtensions.kt
@@ -1,31 +1,23 @@
 package com.syrmos.core.common.extensions
 
 import kotlinx.datetime.Clock
-import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 
-private fun athensDateTime(clock: Clock): LocalDateTime {
-    val instant = clock.now()
-    val utc = instant.toLocalDateTime(TimeZone.UTC)
-    val lastSundayOfMarch = 31 - ((LocalDate(utc.year, 3, 31).dayOfWeek.ordinal + 1) % 7)
-    val lastSundayOfOctober = 31 - ((LocalDate(utc.year, 10, 31).dayOfWeek.ordinal + 1) % 7)
-    val daylightSaving = when (utc.monthNumber) {
-        in 4..9 -> true
-        3 -> utc.dayOfMonth > lastSundayOfMarch ||
-            (utc.dayOfMonth == lastSundayOfMarch && utc.time >= LocalTime(1, 0))
-        10 -> utc.dayOfMonth < lastSundayOfOctober ||
-            (utc.dayOfMonth == lastSundayOfOctober && utc.time < LocalTime(1, 0))
-        else -> false
-    }
-    val offsetHours = if (daylightSaving) 3 else 2
-    return instant.plus(offsetHours, DateTimeUnit.HOUR).toLocalDateTime(TimeZone.UTC)
-}
+// The IANA tz database is the single source of DST truth, shared with the band
+// projector (ComputeDeparturesFromBandsUseCase also resolves this zone). It
+// replaces a hand-rolled last-Sunday-of-March/October calculation that risked
+// drift around the transition hour and was a second, divergent mechanism.
+// Available on every target the app builds (the web/wasmJs build already
+// resolves this same zone).
+private val athensZone = TimeZone.of("Europe/Athens")
+
+private fun athensDateTime(clock: Clock): LocalDateTime =
+    clock.now().toLocalDateTime(athensZone)
 
 // All three read the clock through an injectable [Clock] that defaults to
 // Clock.System, so production is unchanged but tests can pin "now" to a fixed

--- a/core/common/src/commonTest/kotlin/com/syrmos/core/common/extensions/DateTimeExtensionsTest.kt
+++ b/core/common/src/commonTest/kotlin/com/syrmos/core/common/extensions/DateTimeExtensionsTest.kt
@@ -24,6 +24,15 @@ class DateTimeExtensionsTest {
     }
 
     @Test
+    fun athens_time_is_standard_offset_in_winter() {
+        // 09:00 UTC on 2026-01-15. Athens is UTC+2 (EET) in January, so 11:00
+        // local. Pins standard time, catching any DST rule that wrongly applies
+        // the summer offset outside the March-October window.
+        val winterMorning = FixedClock(Instant.parse("2026-01-15T09:00:00Z"))
+        assertEquals(LocalTime(11, 0), currentAthensTime(winterMorning))
+    }
+
+    @Test
     fun athens_date_reflects_the_frozen_instant() {
         assertEquals(LocalDate(2026, 7, 8), currentAthensDate(summerMorning))
         assertEquals(Month.JULY, currentAthensDate(summerMorning).month)


### PR DESCRIPTION
## What

`currentAthensTime` / `currentAthensDate` / `currentAthensDayOfWeek` computed the UTC→Athens offset **by hand**: find the last Sunday of March and October, then decide whether DST is active. That is a second, divergent time mechanism (the band projector already uses `kotlinx.datetime.TimeZone.of("Europe/Athens")`) and it risked **transition-hour drift** and edge-year errors. Closes audit row **#20**.

## How

Delegate `athensDateTime()` to the IANA `Europe/Athens` zone, the same zone the projector resolves. DST transitions now come from the tz database instead of arithmetic, unifying the two mechanisms. The zone resolves on every target the app builds (the wasmJs/web build already uses it, so the KMP + Web CI job proves availability).

Net: `-13` lines of manual DST math, replaced by a one-line delegation.

## Tests

The existing suite already pins **both** DST transitions (last Sunday of March and October) and the summer offset. All stay green because the IANA data matches what the hand-rolled code was approximating. Added a **winter (standard time, UTC+2)** case, which the suite lacked, to guard the off-season offset.

## Parity

Both platforms now resolve Athens time through the OS/library IANA zone; no bespoke DST arithmetic remains on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)