### PR TITLE
Android: cache rail news so the section is not blank offline (parity #19)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
@@ -29,7 +29,7 @@ val featureModule = module {
             announcementsRepository = get(),
             liveTrackerService = get(),
             weatherRepository = get(),
-            railNewsService = get(),
+            railNews = get(),
         )
     }
     factory {

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/di/DataModule.kt
@@ -9,7 +9,10 @@ import com.syrmos.core.data.repository.TransitPatternRepositoryImpl
 import com.syrmos.core.data.seed.DataSeeder
 import com.syrmos.core.data.seed.LinesRefresher
 import com.syrmos.core.data.sync.AnnouncementsRepository
+import com.syrmos.core.data.sync.DatabaseRailNewsCache
 import com.syrmos.core.data.sync.FaresRepository
+import com.syrmos.core.data.sync.RailNewsCache
+import com.syrmos.core.data.sync.RailNewsRepository
 import com.syrmos.core.data.sync.ScheduleSyncRepository
 import com.syrmos.core.data.sync.StationOffsetsRepository
 import com.syrmos.core.data.sync.VisualOverridesRepository
@@ -25,6 +28,8 @@ val dataModule = module {
     single { VisualOverridesRepository(service = get(), resourceReader = get()) }
     single { AnnouncementsRepository(service = get(), resourceReader = get()) }
     single { WeatherRepository(weatherService = get(), database = get()) }
+    single<RailNewsCache> { DatabaseRailNewsCache(database = get()) }
+    single { RailNewsRepository(railNewsService = get(), cache = get()) }
     single { LineRepositoryImpl(database = get(), resourceReader = get()) }
     single { StationRepositoryImpl(database = get(), resourceReader = get()) }
     single { ScheduleRepositoryImpl(database = get()) }

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/RailNewsRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/sync/RailNewsRepository.kt
@@ -1,0 +1,94 @@
+package com.syrmos.core.data.sync
+
+import com.syrmos.core.database.SyrmosDatabase
+import com.syrmos.core.network.RailNewsItem
+import com.syrmos.core.network.RailNewsService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Rail news with an offline cache. [RailNewsService] returns an empty list on
+ * any network failure, which used to blank the news section on Android the
+ * moment the device went offline (iOS keeps the last payload in UserDefaults).
+ *
+ * This repository writes every non-empty fetch to a persistent cache and, when
+ * a fetch comes back empty, serves the last good payload instead of nothing.
+ * The cache is behind [RailNewsCache] so the fetch/cache decision is unit-
+ * testable without a database (the DB-backed implementation mirrors
+ * WeatherRepository's thin, degrade-to-null persistence).
+ */
+class RailNewsRepository(
+    private val railNewsService: RailNewsService,
+    private val cache: RailNewsCache,
+) {
+    fun fetchNews(): Flow<List<RailNewsItem>> = flow {
+        val fresh = railNewsService.fetchNews().firstOrNull().orEmpty()
+        emit(resolve(fresh, cache))
+    }
+
+    companion object {
+        /**
+         * A non-empty fetch is authoritative: cache it and use it. An empty
+         * fetch means "no network / feed down" (the service swallows errors to
+         * an empty list), so fall back to the last cached payload rather than
+         * showing a blank section. Pure over [cache] so it is testable with a
+         * fake.
+         */
+        internal fun resolve(
+            fresh: List<RailNewsItem>,
+            cache: RailNewsCache,
+        ): List<RailNewsItem> {
+            if (fresh.isNotEmpty()) {
+                cache.save(fresh)
+                return fresh
+            }
+            return cache.load()
+        }
+    }
+}
+
+/**
+ * Persistence seam for the rail-news offline cache. Synchronous because the
+ * backing store is SQLDelight (non-suspending, like WeatherRepository's cache),
+ * which keeps the fetch/cache decision testable without a coroutine builder.
+ */
+interface RailNewsCache {
+    fun save(items: List<RailNewsItem>)
+    fun load(): List<RailNewsItem>
+}
+
+/**
+ * Stores the news payload as a JSON blob in metadata_entity. Degrades to a
+ * no-op / empty read when there is no database (parity with WeatherRepository's
+ * nullable database), and never throws: a decode failure just yields no cache.
+ */
+class DatabaseRailNewsCache(
+    private val database: SyrmosDatabase? = null,
+) : RailNewsCache {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun save(items: List<RailNewsItem>) {
+        val db = database ?: return
+        runCatching {
+            db.syrmosDatabaseQueries.setMetadata(CACHE_KEY, json.encodeToString(items))
+        }
+    }
+
+    override fun load(): List<RailNewsItem> {
+        val db = database ?: return emptyList()
+        return runCatching {
+            val raw = db.syrmosDatabaseQueries.getMetadata(CACHE_KEY).executeAsOneOrNull()
+                ?: return emptyList()
+            json.decodeFromString<List<RailNewsItem>>(raw)
+        }.getOrDefault(emptyList())
+    }
+
+    private companion object {
+        // Versioned so a future RailNewsItem shape change starts from a clean
+        // cache instead of failing to decode an old blob on every launch.
+        const val CACHE_KEY = "rail_news_cache_v1"
+    }
+}

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/sync/RailNewsRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/sync/RailNewsRepositoryTest.kt
@@ -1,0 +1,58 @@
+package com.syrmos.core.data.sync
+
+import com.syrmos.core.network.RailNewsItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The rail-news offline cache decision (audit #19). A non-empty fetch is
+ * authoritative and is cached; an empty fetch (the service returns an empty
+ * list on any network failure) must fall back to the last cached payload
+ * instead of blanking the news section.
+ */
+class RailNewsRepositoryTest {
+
+    private class FakeNewsCache(private var stored: List<RailNewsItem> = emptyList()) : RailNewsCache {
+        var saveCount = 0
+        override fun save(items: List<RailNewsItem>) {
+            stored = items
+            saveCount++
+        }
+        override fun load(): List<RailNewsItem> = stored
+    }
+
+    private fun item(id: String) = RailNewsItem(
+        id = id,
+        title = "Title $id",
+        titleEn = "Title $id",
+        url = "https://example.com/$id",
+        publishedAt = "2026-09-01T10:00:00Z",
+    )
+
+    @Test
+    fun freshNonEmptyIsCachedAndReturned() {
+        val cache = FakeNewsCache()
+        val fresh = listOf(item("a"), item("b"))
+        val result = RailNewsRepository.resolve(fresh, cache)
+        assertEquals(fresh, result, "a non-empty fetch is returned as-is")
+        assertEquals(1, cache.saveCount, "a non-empty fetch is written to the cache")
+        assertEquals(fresh, cache.load(), "the cache now holds the fresh payload")
+    }
+
+    @Test
+    fun emptyFetchFallsBackToCache() {
+        val cached = listOf(item("old"))
+        val cache = FakeNewsCache(cached)
+        val result = RailNewsRepository.resolve(emptyList(), cache)
+        assertEquals(cached, result, "an empty fetch serves the last cached payload")
+        assertEquals(0, cache.saveCount, "an empty fetch never overwrites the cache")
+    }
+
+    @Test
+    fun emptyFetchWithNoCacheReturnsEmpty() {
+        val cache = FakeNewsCache()
+        val result = RailNewsRepository.resolve(emptyList(), cache)
+        assertTrue(result.isEmpty(), "no fetch and no cache yields an empty list, never a crash")
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/RailNewsService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/RailNewsService.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
+@Serializable
 data class RailNewsItem(
     val id: String,
     val title: String,

--- a/core/network/src/commonTest/kotlin/com/syrmos/core/network/RailNewsItemSerializationTest.kt
+++ b/core/network/src/commonTest/kotlin/com/syrmos/core/network/RailNewsItemSerializationTest.kt
@@ -1,0 +1,44 @@
+package com.syrmos.core.network
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * RailNewsItem must round-trip through JSON so the offline cache
+ * (RailNewsRepository / DatabaseRailNewsCache, audit #19) can persist and
+ * restore the last good news payload. Pins the @Serializable contract and the
+ * multilingual fields the cache relies on.
+ */
+class RailNewsItemSerializationTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun listRoundTripsThroughJson() {
+        val original = listOf(
+            RailNewsItem(
+                id = "1",
+                title = "Απεργία στο μετρό",
+                titleEn = "Metro strike",
+                titleSq = "Grevë në metro",
+                titleIt = "Sciopero metro",
+                summary = "Λεπτομέρειες",
+                summaryEn = "Details",
+                url = "https://example.com/1",
+                publishedAt = "2026-09-01T08:00:00Z",
+                categories = listOf("strike", "metro"),
+            ),
+            RailNewsItem(
+                id = "2",
+                title = "Νέο δρομολόγιο",
+                titleEn = "New service",
+                url = "https://example.com/2",
+                publishedAt = "2026-09-01T09:30:00Z",
+            ),
+        )
+        val decoded = json.decodeFromString<List<RailNewsItem>>(json.encodeToString(original))
+        assertEquals(original, decoded, "the cached list must decode back identically")
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.syrmos.feature.home
 import com.syrmos.core.common.DataFreshness
 import com.syrmos.core.common.LiveDataFreshness
 import com.syrmos.core.data.sync.AnnouncementsRepository
+import com.syrmos.core.data.sync.RailNewsRepository
 import com.syrmos.core.data.sync.WeatherRepository
 import com.syrmos.core.model.weather.WeatherSnapshot
 import com.syrmos.core.domain.usecase.FindNearestStationUseCase
@@ -18,7 +19,6 @@ import com.syrmos.core.model.transit.Line
 import com.syrmos.core.model.transit.LiveSuburbanTrain
 import com.syrmos.core.model.transit.Station
 import com.syrmos.core.network.RailNewsItem
-import com.syrmos.core.network.RailNewsService
 import com.syrmos.core.network.STASYAnnouncement
 import com.syrmos.core.network.STASYServiceStatus
 import com.syrmos.core.network.RailwayGovLiveTrackerService
@@ -77,7 +77,7 @@ class HomeViewModel(
     private val announcementsRepository: AnnouncementsRepository,
     private val liveTrackerService: RailwayGovLiveTrackerService,
     private val weatherRepository: WeatherRepository,
-    private val railNewsService: RailNewsService,
+    private val railNews: RailNewsRepository,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -134,7 +134,7 @@ class HomeViewModel(
 
     private fun observeRailNews() {
         scope.launch {
-            railNewsService.fetchNews()
+            railNews.fetchNews()
                 .catch { /* ignore */ }
                 .collect { news ->
                     _uiState.update { it.copy(railNews = news) }


### PR DESCRIPTION
## What

`RailNewsService` returns an empty list on any network failure, so the Home news section went **blank** the moment Android lost connectivity. iOS keeps the last payload in `UserDefaults` and keeps showing it. Closes audit row **#19**.

## How

A `RailNewsRepository` sits between the service and `HomeViewModel`:
- A non-empty fetch is authoritative: written to a persistent cache and shown.
- An empty fetch (offline / feed down) serves the **last cached** payload instead of nothing.
- The cache is behind a small `RailNewsCache` seam so the fetch/cache decision is unit-tested with a fake; the DB-backed `DatabaseRailNewsCache` stores a JSON blob in `metadata_entity` and degrades to empty when there is no database, mirroring `WeatherRepository`'s thin, nullable persistence.

`RailNewsItem` is now `@Serializable` so the payload can round-trip. `HomeViewModel` consumes the repository instead of the service; DI wires both.

## Tests

- `RailNewsRepositoryTest`: `resolve()` caches a non-empty fetch and returns it; falls back to the cache on an empty fetch without overwriting; returns empty (no crash) with neither.
- `RailNewsItemSerializationTest`: a `RailNewsItem` list round-trips through JSON with all multilingual fields intact.

## Parity

Android now matches the iOS behaviour of showing the last known news offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)