### PR TITLE
Airport tab: tap a service to open its station departures (iOS + Android)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/syrmos/app/tab/DeparturesTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/syrmos/app/tab/DeparturesTab.kt
@@ -8,6 +8,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.currentOrThrow
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
 import com.syrmos.core.common.AppLanguage
@@ -15,6 +19,7 @@ import com.syrmos.core.common.LocalizationManager
 import com.syrmos.app.platform.hasAirportCalendarPermission
 import com.syrmos.app.platform.loadAirportCalendarTrips
 import com.syrmos.app.platform.requestAirportCalendarPermission
+import com.syrmos.app.screen.StationDetailScreenRoute
 import com.syrmos.feature.schedule.AirportCalendarTrip
 import com.syrmos.feature.schedule.AirportHubScreen
 import kotlinx.coroutines.launch
@@ -36,8 +41,18 @@ object DeparturesTab : Tab {
             )
         }
 
+    // A per-tab Navigator (mirrors ExploreTab) so tapping an airport service can
+    // push the stop's Station Detail onto the Airport tab's own back stack.
     @Composable
     override fun Content() {
+        Navigator(AirportRootScreen())
+    }
+}
+
+private class AirportRootScreen : Screen {
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
         val scope = rememberCoroutineScope()
         var calendarConnected by remember { mutableStateOf(hasAirportCalendarPermission()) }
         var calendarTrips by remember { mutableStateOf<List<AirportCalendarTrip>>(emptyList()) }
@@ -55,6 +70,7 @@ object DeparturesTab : Tab {
                     if (calendarConnected) calendarTrips = loadAirportCalendarTrips()
                 }
             },
+            onOpenStation = { stationId -> navigator.push(StationDetailScreenRoute(stationId)) },
         )
     }
 }

--- a/feature/schedule/src/commonMain/kotlin/com/syrmos/feature/schedule/AirportHubScreen.kt
+++ b/feature/schedule/src/commonMain/kotlin/com/syrmos/feature/schedule/AirportHubScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DirectionsBus
 import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Train
 import androidx.compose.material.icons.filled.Warning
@@ -89,6 +90,10 @@ fun AirportHubScreen(
     calendarTrips: List<AirportCalendarTrip>,
     calendarConnected: Boolean,
     onConnectCalendar: () -> Unit,
+    // Opens a stop's full departures board (Station Detail). Rail service tiles,
+    // departure rows and Thessaloniki metro-leg cards call it with the relevant
+    // airport-side station id; buses have no station detail so they stay inert.
+    onOpenStation: (String) -> Unit = {},
 ) {
     val sync = koinInject<ScheduleSyncRepository>()
     val offsetsRepo = koinInject<StationOffsetsRepository>()
@@ -196,13 +201,13 @@ fun AirportHubScreen(
         if (hub.hasDirectRail) {
             AirportRouteOverview(lang, selectedRoute, dayOffset, onRouteSelected = { selectedRoute = it })
             PredictiveItinerary(lang, flightMinutes, airportBoundDepartures, selectedTrip?.title)
-            NextAirportServices(lang, dayOffset, airportDepartures, suburbanAirportDepartures, now.time.hour * 60 + now.time.minute)
+            NextAirportServices(lang, dayOffset, airportDepartures, suburbanAirportDepartures, now.time.hour * 60 + now.time.minute, onOpenStation)
             Text(
                 text = airportText(lang, "Airport services", "Υπηρεσίες αεροδρομίου", "Shërbimet e aeroportit", "Servizi aeroportuali"),
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
             )
-            AirportDepartureRows(lang, dayOffset, airportDepartures, suburbanAirportDepartures)
+            AirportDepartureRows(lang, dayOffset, airportDepartures, suburbanAirportDepartures, onOpenStation)
         } else {
             AirportConnections(hub, lang)
             Text(
@@ -210,7 +215,7 @@ fun AirportHubScreen(
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
             )
-            AirportMetroLegs(hub, lang, dayOffset, metroLegDepartures, now.time.hour * 60 + now.time.minute)
+            AirportMetroLegs(hub, lang, dayOffset, metroLegDepartures, now.time.hour * 60 + now.time.minute, onOpenStation)
         }
         AirportAlert(lang)
     }
@@ -364,11 +369,16 @@ private fun AirportConnections(hub: AirportHubData, lang: AppLanguage) {
 }
 
 @Composable
-private fun AirportMetroLegs(hub: AirportHubData, lang: AppLanguage, dayOffset: Int, legDepartures: Map<String, List<ProjectedDeparture>>, nowMinutes: Int) {
+private fun AirportMetroLegs(hub: AirportHubData, lang: AppLanguage, dayOffset: Int, legDepartures: Map<String, List<ProjectedDeparture>>, nowMinutes: Int, onOpenStation: (String) -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         hub.metroLegs.forEach { leg ->
             val deps = legDepartures[leg.stationId].orEmpty()
-            Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surface, shadowElevation = 3.dp) {
+            Surface(
+                modifier = Modifier.clip(RoundedCornerShape(16.dp)).clickable { onOpenStation(leg.stationId) },
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surface,
+                shadowElevation = 3.dp,
+            ) {
                 Column(Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                         Surface(shape = CircleShape, color = leg.color, modifier = Modifier.size(34.dp)) {
@@ -378,6 +388,8 @@ private fun AirportMetroLegs(hub: AirportHubData, lang: AppLanguage, dayOffset: 
                             Text(leg.stationName.t(lang), style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
                             Text(leg.towards.t(lang), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
+                        // Chevron signals the card opens the interchange station's departures.
+                        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
                     }
                     if (deps.isEmpty()) {
                         Text(
@@ -716,25 +728,26 @@ private fun DurationPill(text: String, modifier: Modifier) {
 }
 
 @Composable
-private fun NextAirportServices(lang: AppLanguage, dayOffset: Int, departures: List<ProjectedDeparture>, suburbanDepartures: List<ProjectedDeparture>, nowMinutes: Int) {
+private fun NextAirportServices(lang: AppLanguage, dayOffset: Int, departures: List<ProjectedDeparture>, suburbanDepartures: List<ProjectedDeparture>, nowMinutes: Int, onOpenStation: (String) -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         Text(airportText(lang, "Next services from the airport", "Επόμενα δρομολόγια από το αεροδρόμιο", "Shërbimet e radhës nga aeroporti", "Prossimi servizi dall'aeroporto"), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
         Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             val next = departures.firstOrNull()
             val main = if (next == null) "-" else if (dayOffset == 0) formatMinutes((next.timeMinutes - nowMinutes).coerceAtLeast(0), lang) else next.time
             val following = departures.getOrNull(1)?.time
-            ServiceTile("M3", Icons.Filled.Train, main, "Syntagma", following?.let { airportText(lang, "Then $it", "Έπειτα $it", "Pastaj $it", "Poi $it") } ?: airportText(lang, "No later departure in the current schedule", "Δεν υπάρχει επόμενη αναχώρηση στο τρέχον ωράριο", "Nuk ka nisje tjetër në orarin aktual", "Nessuna partenza successiva nell'orario attuale"), airportText(lang, "Scheduled", "Προγραμματισμένο", "Programuar", "Programmato"), SyrmosColorTokens.metroBlue, Modifier.weight(1f))
+            ServiceTile("M3", Icons.Filled.Train, main, "Syntagma", following?.let { airportText(lang, "Then $it", "Έπειτα $it", "Pastaj $it", "Poi $it") } ?: airportText(lang, "No later departure in the current schedule", "Δεν υπάρχει επόμενη αναχώρηση στο τρέχον ωράριο", "Nuk ka nisje tjetër në orarin aktual", "Nessuna partenza successiva nell'orario attuale"), airportText(lang, "Scheduled", "Προγραμματισμένο", "Programuar", "Programmato"), SyrmosColorTokens.metroBlue, Modifier.weight(1f), onClick = { onOpenStation("M3_AER") })
             val nextA1 = suburbanDepartures.firstOrNull()
             val mainA1 = if (nextA1 == null) "-" else if (dayOffset == 0) formatMinutes((nextA1.timeMinutes - nowMinutes).coerceAtLeast(0), lang) else nextA1.time
             val followingA1 = suburbanDepartures.getOrNull(1)?.time
-            ServiceTile("A1", Icons.Filled.Train, mainA1, airportText(lang, "Piraeus", "Πειραιάς", "Pireus", "Pireo"), followingA1?.let { airportText(lang, "Then $it", "Έπειτα $it", "Pastaj $it", "Poi $it") } ?: airportText(lang, "No later departure in the current schedule", "Δεν υπάρχει επόμενη αναχώρηση στο τρέχον ωράριο", "Nuk ka nisje tjetër në orarin aktual", "Nessuna partenza successiva nell'orario attuale"), airportText(lang, "Scheduled", "Προγραμματισμένο", "Programuar", "Programmato"), SyrmosColorTokens.suburban, Modifier.weight(1f))
+            ServiceTile("A1", Icons.Filled.Train, mainA1, airportText(lang, "Piraeus", "Πειραιάς", "Pireus", "Pireo"), followingA1?.let { airportText(lang, "Then $it", "Έπειτα $it", "Pastaj $it", "Poi $it") } ?: airportText(lang, "No later departure in the current schedule", "Δεν υπάρχει επόμενη αναχώρηση στο τρέχον ωράριο", "Nuk ka nisje tjetër në orarin aktual", "Nessuna partenza successiva nell'orario attuale"), airportText(lang, "Scheduled", "Προγραμματισμένο", "Programuar", "Programmato"), SyrmosColorTokens.suburban, Modifier.weight(1f), onClick = { onOpenStation("A1_AIR") })
         }
     }
 }
 
 @Composable
-private fun ServiceTile(route: String, icon: ImageVector, main: String, destination: String, detail: String, status: String, color: Color, modifier: Modifier) {
-    Surface(modifier = modifier, shape = RoundedCornerShape(18.dp), color = MaterialTheme.colorScheme.surface, shadowElevation = 4.dp) {
+private fun ServiceTile(route: String, icon: ImageVector, main: String, destination: String, detail: String, status: String, color: Color, modifier: Modifier, onClick: (() -> Unit)? = null) {
+    val tileModifier = if (onClick != null) modifier.clip(RoundedCornerShape(18.dp)).clickable { onClick() } else modifier
+    Surface(modifier = tileModifier, shape = RoundedCornerShape(18.dp), color = MaterialTheme.colorScheme.surface, shadowElevation = 4.dp) {
         Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(icon, null, tint = color, modifier = Modifier.size(16.dp))
@@ -742,6 +755,10 @@ private fun ServiceTile(route: String, icon: ImageVector, main: String, destinat
                 Text(route, style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, color = color)
                 Spacer(Modifier.weight(1f))
                 Text(status, style = MaterialTheme.typography.labelSmall, color = color)
+                // Chevron signals the tile opens the station's full departures.
+                if (onClick != null) {
+                    Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(16.dp))
+                }
             }
             Text(main, style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold, color = if (route == "M3") SyrmosColorTokens.warning else color, maxLines = 1)
             Text(destination, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
@@ -751,9 +768,9 @@ private fun ServiceTile(route: String, icon: ImageVector, main: String, destinat
 }
 
 @Composable
-private fun AirportDepartureRows(lang: AppLanguage, dayOffset: Int, departures: List<ProjectedDeparture>, suburbanDepartures: List<ProjectedDeparture>) {
-    val metroRows = departures.take(3).map { AirportRow("M3", "Syntagma", airportText(lang, "Scheduled metro departure", "Προγραμματισμένη αναχώρηση μετρό", "Nisje e programuar e metrosë", "Partenza metro programmata"), it.time, SyrmosColorTokens.metroBlue) }
-    val suburbanRows = suburbanDepartures.take(2).map { AirportRow("A1", airportText(lang, "Piraeus", "Πειραιάς", "Pireus", "Pireo"), airportText(lang, "Scheduled suburban departure", "Προγραμματισμένη αναχώρηση προαστιακού", "Nisje e programuar e trenit periferik", "Partenza suburbano programmata"), it.time, SyrmosColorTokens.suburban) }
+private fun AirportDepartureRows(lang: AppLanguage, dayOffset: Int, departures: List<ProjectedDeparture>, suburbanDepartures: List<ProjectedDeparture>, onOpenStation: (String) -> Unit) {
+    val metroRows = departures.take(3).map { AirportRow("M3", "Syntagma", airportText(lang, "Scheduled metro departure", "Προγραμματισμένη αναχώρηση μετρό", "Nisje e programuar e metrosë", "Partenza metro programmata"), it.time, SyrmosColorTokens.metroBlue, stationId = "M3_AER") }
+    val suburbanRows = suburbanDepartures.take(2).map { AirportRow("A1", airportText(lang, "Piraeus", "Πειραιάς", "Pireus", "Pireo"), airportText(lang, "Scheduled suburban departure", "Προγραμματισμένη αναχώρηση προαστιακού", "Nisje e programuar e trenit periferik", "Partenza suburbano programmata"), it.time, SyrmosColorTokens.suburban, stationId = "A1_AIR") }
     val busRows = listOf(
         AirportRow("X95", "Syntagma", airportText(lang, "24-hour express bus. Check OASA for current times.", "24ωρο λεωφορείο express. Ελέγξτε τον ΟΑΣΑ για τα τρέχοντα δρομολόγια.", "Autobus express 24 orë. Kontrollo OASA për oraret aktuale.", "Bus express 24 ore. Controlla OASA per gli orari attuali."), "24/7", SyrmosColorTokens.warning),
         AirportRow("X93", "Kifisos", airportText(lang, "24-hour express bus. Check OASA for current times.", "24ωρο λεωφορείο express. Ελέγξτε τον ΟΑΣΑ για τα τρέχοντα δρομολόγια.", "Autobus express 24 orë. Kontrollo OASA për oraret aktuale.", "Bus express 24 ore. Controlla OASA per gli orari attuali."), "24/7", SyrmosColorTokens.warning),
@@ -763,7 +780,12 @@ private fun AirportDepartureRows(lang: AppLanguage, dayOffset: Int, departures: 
     val rows = metroRows + suburbanRows + busRows
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         rows.take(9).forEach { row ->
-            Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surface, shadowElevation = 3.dp) {
+            val rowModifier = if (row.stationId != null) {
+                Modifier.clip(RoundedCornerShape(16.dp)).clickable { onOpenStation(row.stationId) }
+            } else {
+                Modifier
+            }
+            Surface(modifier = rowModifier, shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surface, shadowElevation = 3.dp) {
                 Row(Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
                     Surface(shape = CircleShape, color = row.color, modifier = Modifier.size(38.dp)) {
                         Box(contentAlignment = Alignment.Center) { Text(row.route, color = Color.White, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold) }
@@ -774,6 +796,11 @@ private fun AirportDepartureRows(lang: AppLanguage, dayOffset: Int, departures: 
                         Text(row.detail, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                     Text(row.time, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = row.color)
+                    // Chevron signals the row opens the station's full departures.
+                    if (row.stationId != null) {
+                        Spacer(Modifier.width(8.dp))
+                        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
+                    }
                 }
             }
         }
@@ -806,7 +833,9 @@ private fun AirportCard(content: @Composable () -> Unit) {
     }
 }
 
-private data class AirportRow(val route: String, val destination: String, val detail: String, val time: String, val color: Color)
+// stationId is the airport-side stop a row opens in Station Detail; null for
+// buses (no per-stop timetable), which keeps their row non-tappable.
+private data class AirportRow(val route: String, val destination: String, val detail: String, val time: String, val color: Color, val stationId: String? = null)
 
 // MARK: - Multi-airport hubs (mirrors iOS AirportData.swift)
 

--- a/iosApp/iosApp/Features/Timetables/TimetablesView.swift
+++ b/iosApp/iosApp/Features/Timetables/TimetablesView.swift
@@ -848,15 +848,22 @@ private struct AirportNextServicesCard: View {
                 .font(.headline)
 
             HStack(spacing: 10) {
-                AirportNextServiceTile(
+                let m3Tile = AirportNextServiceTile(
                     route: "M3",
                     icon: "tram.fill",
                     destination: "Syntagma",
                     primary: primaryMetroLabel,
                     secondary: followingMetroLabel,
                     status: airportText(language, "Scheduled", "Προγραμματισμένο", "Programuar", "Programmato"),
-                    color: Color.metroBlue
+                    color: Color.metroBlue,
+                    navigable: airportStation(id: "M3_AER") != nil
                 )
+                if let station = airportStation(id: "M3_AER") {
+                    NavigationLink { StationDetailView(station: station) } label: { m3Tile }
+                        .buttonStyle(.plain)
+                } else {
+                    m3Tile
+                }
                 AirportNextServiceTile(
                     route: "X95",
                     icon: "bus.fill",
@@ -889,6 +896,7 @@ private struct AirportNextServiceTile: View {
     let secondary: String
     let status: String
     let color: Color
+    var navigable: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -896,6 +904,11 @@ private struct AirportNextServiceTile: View {
                 Label(route, systemImage: icon).font(.caption.weight(.bold)).foregroundStyle(color)
                 Spacer()
                 Text(status).font(.caption2.weight(.semibold)).foregroundStyle(color)
+                if navigable {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
             }
             Text(primary)
                 .font(.system(size: 28, weight: .bold, design: .rounded))
@@ -920,33 +933,52 @@ private struct AirportDepartureList: View {
     var body: some View {
         VStack(spacing: 8) {
             ForEach(Array(rows.prefix(9).enumerated()), id: \.offset) { _, row in
-                HStack(spacing: 12) {
-                    Text(row.route)
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(.white)
-                        .frame(width: 38, height: 38)
-                        .background(row.color, in: Circle())
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(row.destination).font(.subheadline.weight(.semibold))
-                        Text(row.detail).font(.caption).foregroundStyle(.secondary)
+                if let station = airportStation(id: row.stationId) {
+                    NavigationLink {
+                        StationDetailView(station: station)
+                    } label: {
+                        rowBody(row, navigable: true)
                     }
-                    Spacer()
-                    Text(row.time).font(.headline).monospacedDigit().foregroundStyle(row.color)
+                    .buttonStyle(.plain)
+                } else {
+                    rowBody(row, navigable: false)
                 }
-                .padding(12)
-                .glassCardBackground(cornerRadius: 16)
             }
         }
+    }
+
+    private func rowBody(_ row: AirportListRow, navigable: Bool) -> some View {
+        HStack(spacing: 12) {
+            Text(row.route)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.white)
+                .frame(width: 38, height: 38)
+                .background(row.color, in: Circle())
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.destination).font(.subheadline.weight(.semibold))
+                Text(row.detail).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text(row.time).font(.headline).monospacedDigit().foregroundStyle(row.color)
+            // A chevron signals the row opens the station's full departures.
+            if navigable {
+                Image(systemName: "chevron.right")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(12)
+        .glassCardBackground(cornerRadius: 16)
     }
 
     private var rows: [AirportListRow] {
         let busDetail = airportText(language, "24-hour express bus. Check OASA for current times.", "24ωρο λεωφορείο express. Ελέγξτε τον ΟΑΣΑ για τα τρέχοντα δρομολόγια.", "Autobus express 24 orë. Kontrollo OASA për oraret aktuale.", "Bus express 24 ore. Controlla OASA per gli orari attuali.")
         var output = metroDepartures.prefix(3).map {
-            AirportListRow(route: $0.lineId == "M3_AIR" ? "M3" : $0.lineId, destination: "Syntagma", detail: airportText(language, "Scheduled metro departure", "Προγραμματισμένη αναχώρηση μετρό", "Nisje e programuar e metrosë", "Partenza metro programmata"), time: $0.time, color: Color.metroBlue)
+            AirportListRow(route: $0.lineId == "M3_AIR" ? "M3" : $0.lineId, destination: "Syntagma", detail: airportText(language, "Scheduled metro departure", "Προγραμματισμένη αναχώρηση μετρό", "Nisje e programuar e metrosë", "Partenza metro programmata"), time: $0.time, color: Color.metroBlue, stationId: airportStationId(forRoute: $0.lineId))
         }
         let suburbanDeps = metroDepartures.filter { $0.lineId == "A1" || $0.lineId == "A2" }.prefix(2)
         for dep in suburbanDeps {
-            output.append(AirportListRow(route: dep.lineId, destination: airportText(language, "Piraeus", "Πειραιάς", "Pireus", "Pireo"), detail: airportText(language, "Scheduled suburban departure", "Προγραμματισμένη αναχώρηση προαστιακού", "Nisje e programuar e trenit periferik", "Partenza suburbano programmata"), time: dep.time, color: SyrmosTokens.suburban))
+            output.append(AirportListRow(route: dep.lineId, destination: airportText(language, "Piraeus", "Πειραιάς", "Pireus", "Pireo"), detail: airportText(language, "Scheduled suburban departure", "Προγραμματισμένη αναχώρηση προαστιακού", "Nisje e programuar e trenit periferik", "Partenza suburbano programmata"), time: dep.time, color: SyrmosTokens.suburban, stationId: airportStationId(forRoute: dep.lineId)))
         }
         output.append(AirportListRow(route: "X95", destination: "Syntagma", detail: busDetail, time: "24/7", color: SyrmosTokens.warning))
         output.append(AirportListRow(route: "X93", destination: "Kifisos", detail: busDetail, time: "24/7", color: SyrmosTokens.warning))
@@ -963,6 +995,9 @@ private struct AirportListRow {
     let detail: String
     let time: String
     let color: Color
+    // Airport-side station to open in StationDetailView; nil for buses (no
+    // per-stop timetable), which keeps their row non-navigable.
+    var stationId: String? = nil
 }
 
 // MARK: - Thessaloniki connections (metro + shuttle, or direct bus)
@@ -1045,53 +1080,73 @@ private struct AirportMetroLegsCard: View {
         VStack(spacing: 10) {
             ForEach(hub.metroLegs) { leg in
                 let deps = departuresByStation[leg.stationId] ?? []
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(spacing: 10) {
-                        Text(leg.badge)
-                            .font(.caption.weight(.bold))
-                            .foregroundStyle(.white)
-                            .frame(width: 34, height: 34)
-                            .background(Color(hex: leg.colorHex), in: Circle())
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(leg.stationName.text(language))
-                                .font(.subheadline.weight(.semibold))
-                            Text(leg.towards.text(language))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer(minLength: 0)
+                if let station = airportStation(id: leg.stationId) {
+                    NavigationLink {
+                        StationDetailView(station: station)
+                    } label: {
+                        legCard(leg: leg, deps: deps, navigable: true)
                     }
-
-                    if deps.isEmpty {
-                        Text(airportText(
-                            language,
-                            "No scheduled metro departure in the current window.",
-                            "Καμία προγραμματισμένη αναχώρηση μετρό αυτή τη στιγμή.",
-                            "Asnjë nisje e programuar e metros tani.",
-                            "Nessuna partenza metro programmata al momento."
-                        ))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    } else {
-                        HStack(spacing: 8) {
-                            ForEach(Array(deps.prefix(4).enumerated()), id: \.offset) { _, dep in
-                                Text(dayOffset == 0 ? dep.minutesAwayDisplay(language: language) : dep.time)
-                                    .font(.caption.weight(.bold))
-                                    .monospacedDigit()
-                                    .foregroundStyle(Color(hex: leg.colorHex))
-                                    .padding(.horizontal, 9)
-                                    .padding(.vertical, 5)
-                                    .background(Color(hex: leg.colorHex).opacity(0.12), in: Capsule())
-                            }
-                            Spacer(minLength: 0)
-                        }
-                    }
+                    .buttonStyle(.plain)
+                } else {
+                    legCard(leg: leg, deps: deps, navigable: false)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(12)
-                .glassCardBackground(cornerRadius: 16)
             }
         }
+    }
+
+    private func legCard(leg: AirportMetroLeg, deps: [Departure], navigable: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Text(leg.badge)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 34, height: 34)
+                    .background(Color(hex: leg.colorHex), in: Circle())
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(leg.stationName.text(language))
+                        .font(.subheadline.weight(.semibold))
+                    Text(leg.towards.text(language))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                // Chevron signals the card opens the interchange station's
+                // full departures board.
+                if navigable {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            if deps.isEmpty {
+                Text(airportText(
+                    language,
+                    "No scheduled metro departure in the current window.",
+                    "Καμία προγραμματισμένη αναχώρηση μετρό αυτή τη στιγμή.",
+                    "Asnjë nisje e programuar e metros tani.",
+                    "Nessuna partenza metro programmata al momento."
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            } else {
+                HStack(spacing: 8) {
+                    ForEach(Array(deps.prefix(4).enumerated()), id: \.offset) { _, dep in
+                        Text(dayOffset == 0 ? dep.minutesAwayDisplay(language: language) : dep.time)
+                            .font(.caption.weight(.bold))
+                            .monospacedDigit()
+                            .foregroundStyle(Color(hex: leg.colorHex))
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 5)
+                            .background(Color(hex: leg.colorHex).opacity(0.12), in: Capsule())
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .glassCardBackground(cornerRadius: 16)
     }
 }
 
@@ -1128,6 +1183,24 @@ private struct AirportServiceAlertCard: View {
 
 private func airportSectionTitle(_ title: String) -> some View {
     Text(title).font(.title3.bold()).padding(.top, 2)
+}
+
+// Resolve the airport-side station a service tile/row/leg should open in
+// StationDetailView. Metro maps to the M3 airport station, the suburban lines
+// to their own airport stops; buses (X..) have no station detail, so nil keeps
+// the row non-navigable. Returns nil when the id is unknown so a tap never dead-ends.
+private func airportStationId(forRoute route: String) -> String? {
+    switch route {
+    case "M3", "M3_AIR": return "M3_AER"
+    case "A1": return "A1_AIR"
+    case "A2": return "A2_AIR"
+    default: return nil
+    }
+}
+
+private func airportStation(id: String?) -> TransitStation? {
+    guard let id, !id.isEmpty else { return nil }
+    return StationCoords.allStations.first { $0.id == id }
 }
 
 private func airportText(_ language: AppLanguage, _ english: String, _ greek: String, _ albanian: String, _ italian: String) -> String {


### PR DESCRIPTION
## What

The Airport screen was a **read-only dashboard** on both platforms (confirmed: iOS `TimetablesView` had zero tap handlers, and the Android tab wasn't even inside a navigator). There was no way to drill from "next M3 in 5 min" into the stop's full departures board. This makes the rail cards navigate. Addresses the user report (with screenshots) that the Airport screen needs to be interactive.

## Behaviour

Each rail element now opens **Station Detail** (full departures board + the station's map) for its airport-side stop, chosen so one screen answers "departures / which station / where's the vehicle":

| Card | Opens |
|------|-------|
| M3 / metro rows + the M3 "next service" tile | `M3_AER` |
| A1 suburban rows + the A1 tile | `A1_AIR` / `A2_AIR` |
| Thessaloniki metro-leg cards (Mikra, Nea Elvetia) | the leg's station id (`TM2_MIK` / `TM1_NEL`) |

A right chevron marks every tappable card. **Buses (X93/X95/X96/X97) stay inert** — they have no per-stop timetable or station in our data yet (the pending airport-bus telematics work), so there's nothing to open.

## How

- **iOS**: the tiles/rows/legs become `NavigationLink`s inside the existing `NavigationStack`, resolving the `TransitStation` from `StationCoords.allStations` (an unknown id falls back to a plain, non-navigable row so a tap never dead-ends).
- **Android**: `DeparturesTab` now hosts its own `Navigator` (mirroring `ExploreTab`) so a tap can push `StationDetailScreenRoute` onto the Airport tab's back stack; `AirportHubScreen` gains an `onOpenStation` callback threaded to the tiles, rows and legs.

## Verification

iOS build succeeds and the taps navigate on the simulator; Android builds in CI. The repo has no UI-test harness (SwiftUI `NavigationLink` / Compose `Navigator`), so this navigation wiring is verified functionally rather than by unit test, consistent with prior UI-wiring PRs (#59, #60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)