### PR TITLE
iOS: close circular bus routes so the return leg is drawn (audit #23)

### DIFF
--- a/iosApp/Syrmos.xcodeproj/project.pbxproj
+++ b/iosApp/Syrmos.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		D7E8F9A0B1C2D3E4F5060708 /* iosApp/Core/Diagnostics/Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E8F9A0B1C2D3E4F5060709 /* iosApp/Core/Diagnostics/Diagnostics.swift */; };
 		DA7A0001F00D0001F00D0001 /* iosApp/Core/Schedule/DataFreshness.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0002F00D0002F00D0002 /* iosApp/Core/Schedule/DataFreshness.swift */; };
 		DA7A0003F00D0003F00D0003 /* HomeFeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0004F00D0004F00D0004 /* HomeFeaturesTests.swift */; };
+		DA7A0030F00D0030F00D0030 /* MapRouteGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */; };
 		DA7A0011F00D0011F00D0011 /* iosApp/Features/Assistant/AriadneParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0012F00D0012F00D0012 /* iosApp/Features/Assistant/AriadneParser.swift */; };
 		DA7A0013F00D0013F00D0013 /* iosApp/Features/Assistant/AriadneModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0014F00D0014F00D0014 /* iosApp/Features/Assistant/AriadneModel.swift */; };
 		DA7A0015F00D0015F00D0015 /* iosApp/Features/Assistant/AriadneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0016F00D0016F00D0016 /* iosApp/Features/Assistant/AriadneView.swift */; };
@@ -290,6 +291,7 @@
 		D7E8F9A0B1C2D3E4F5060709 /* iosApp/Core/Diagnostics/Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Diagnostics/Diagnostics.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0002F00D0002F00D0002 /* iosApp/Core/Schedule/DataFreshness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Schedule/DataFreshness.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0004F00D0004F00D0004 /* HomeFeaturesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeFeaturesTests.swift; sourceTree = "<group>"; };
+		DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MapRouteGeometryTests.swift; sourceTree = "<group>"; };
 		DA7A0012F00D0012F00D0012 /* iosApp/Features/Assistant/AriadneParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneParser.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0014F00D0014F00D0014 /* iosApp/Features/Assistant/AriadneModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneModel.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0016F00D0016F00D0016 /* iosApp/Features/Assistant/AriadneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneView.swift; sourceTree = SOURCE_ROOT; };
@@ -379,6 +381,7 @@
 			children = (
 				87C1AB3CF938A60DF7285C1F /* ScheduleProjectorTests.swift */,
 				DA7A0004F00D0004F00D0004 /* HomeFeaturesTests.swift */,
+				DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */,
 				DA7A0019F00D0019F00D0019 /* AriadneParserTests.swift */,
 				B9C311F839BA02691F04AB93 /* NearbyStationDestinationTests.swift */,
 				BF6FDC539EEBEA3DCEA3416B /* SuburbanProjectionTests.swift */,
@@ -1003,6 +1006,7 @@
 			files = (
 				3CC04D0831F54B17495246AC /* ScheduleProjectorTests.swift in Sources */,
 				DA7A0003F00D0003F00D0003 /* HomeFeaturesTests.swift in Sources */,
+				DA7A0030F00D0030F00D0030 /* MapRouteGeometryTests.swift in Sources */,
 				DA7A0018F00D0018F00D0018 /* AriadneParserTests.swift in Sources */,
 				ECAA824BE3E518277AB18AB6 /* NearbyStationDestinationTests.swift in Sources */,
 				28B86D763BF517E19CF4DB5D /* SuburbanProjectionTests.swift in Sources */,

--- a/iosApp/iosApp/Views/Map/MapView.swift
+++ b/iosApp/iosApp/Views/Map/MapView.swift
@@ -115,7 +115,15 @@ enum PreloadedData {
             // markers off the drawn line), and a Catmull-Rom spline overshoots
             // on tight loops. Straight segments always connect every stop.
             guard anchors.count >= 2 else { return nil }
-            coords = anchors
+            // Close a circular bus route (both terminals identical, e.g. the
+            // Patras University PU1 whose terminals are both Kastelokampos) by
+            // returning to the first stop; drawn straight it otherwise leaves
+            // the return leg (~1km on PU1) undrawn. Mirrors the shared
+            // RouteGeometry.closeLoop used by Android and web.
+            coords = MapRouteGeometry.closeLoop(
+                anchors,
+                isLoop: MapRouteGeometry.isLoopTerminals(line.terminalA, line.terminalB)
+            )
         } else if let osm = SyrmosRouteShapesStore.shared.coordinates(for: line.id), osm.count >= 2 {
             // Rail/tram: prefer OSM geometry so the polyline follows the track
             // (T7 Piraeus loop, M3 airport branch, A4 Megara curve).
@@ -2520,5 +2528,28 @@ private func mapLocalized(_ language: AppLanguage, _ en: String, _ el: String, _
     case .greek: return el
     case .albanian: return sq
     case .italian: return it
+    }
+}
+
+// Swift port of the shared RouteGeometry loop helpers (core/common), so a
+// circular bus route draws its return leg on iOS the same way it does on
+// Android and web. Internal (not private) so iosAppTests can pin the behaviour.
+enum MapRouteGeometry {
+    /// A route is a loop when it starts and ends at the same terminal (PU1:
+    /// both terminals are Kastelokampos). Trimmed, case-insensitive; a blank
+    /// terminal is never a loop.
+    static func isLoopTerminals(_ terminalA: String, _ terminalB: String) -> Bool {
+        let a = terminalA.trimmingCharacters(in: .whitespacesAndNewlines)
+        let b = terminalB.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !a.isEmpty && a.caseInsensitiveCompare(b) == .orderedSame
+    }
+
+    /// Append the first point to close a loop, unless it is not a loop, has
+    /// fewer than two points, or is already closed. Matches
+    /// RouteGeometry.closeLoop so the drawn shape is identical across platforms.
+    static func closeLoop(_ points: [CLLocationCoordinate2D], isLoop: Bool) -> [CLLocationCoordinate2D] {
+        guard isLoop, points.count >= 2, let first = points.first, let last = points.last else { return points }
+        if first.latitude == last.latitude && first.longitude == last.longitude { return points }
+        return points + [first]
     }
 }

--- a/iosApp/iosAppTests/MapRouteGeometryTests.swift
+++ b/iosApp/iosAppTests/MapRouteGeometryTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+import CoreLocation
+@testable import Syrmos
+
+/// Mirrors the shared RouteGeometryTest (core/common) so the iOS loop-closing
+/// port stays in lockstep with Android/web. A circular bus route (both
+/// terminals identical, e.g. PU1 Kastelokampos) must have its return leg drawn.
+final class MapRouteGeometryTests: XCTestCase {
+
+    private func c(_ lat: Double, _ lon: Double) -> CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+
+    // MARK: isLoopTerminals
+
+    func testLoopWhenTerminalsMatch() {
+        XCTAssertTrue(MapRouteGeometry.isLoopTerminals("Kastelokampos", "Kastelokampos"))
+    }
+
+    func testLoopIsCaseInsensitiveAndTrimmed() {
+        XCTAssertTrue(MapRouteGeometry.isLoopTerminals(" Kastelokampos ", "kastelokampos"))
+    }
+
+    func testNotLoopWhenTerminalsDiffer() {
+        XCTAssertFalse(MapRouteGeometry.isLoopTerminals("Piraeus", "Kifissia"))
+    }
+
+    func testBlankTerminalsAreNeverLoop() {
+        XCTAssertFalse(MapRouteGeometry.isLoopTerminals("", ""))
+        XCTAssertFalse(MapRouteGeometry.isLoopTerminals("   ", "   "))
+    }
+
+    // MARK: closeLoop
+
+    func testClosesLoopByAppendingFirstPoint() {
+        let pts = [c(38.28, 21.78), c(38.29, 21.79), c(38.30, 21.80)]
+        let closed = MapRouteGeometry.closeLoop(pts, isLoop: true)
+        XCTAssertEqual(closed.count, 4)
+        XCTAssertEqual(closed.last?.latitude, pts.first?.latitude)
+        XCTAssertEqual(closed.last?.longitude, pts.first?.longitude)
+    }
+
+    func testNonLoopIsUnchanged() {
+        let pts = [c(38.28, 21.78), c(38.29, 21.79)]
+        XCTAssertEqual(MapRouteGeometry.closeLoop(pts, isLoop: false).count, 2)
+    }
+
+    func testAlreadyClosedLoopIsUnchanged() {
+        let pts = [c(38.28, 21.78), c(38.29, 21.79), c(38.28, 21.78)]
+        XCTAssertEqual(MapRouteGeometry.closeLoop(pts, isLoop: true).count, 3)
+    }
+
+    func testFewerThanTwoPointsIsUnchanged() {
+        let pts = [c(38.28, 21.78)]
+        XCTAssertEqual(MapRouteGeometry.closeLoop(pts, isLoop: true).count, 1)
+    }
+}


### PR DESCRIPTION
## What

A loop bus route (both terminals the same, e.g. the Patras University **PU1** whose terminals are both Kastelokampos) drew as an **open arc**: the map builds a bus polyline from the ordered stops as straight segments, but never returned to the first stop, leaving roughly a kilometre of the return leg undrawn. Android and web already close the loop via the shared `RouteGeometry.closeLoop`; iOS did not. Closes audit row **#23** (the last of the three iOS reference bugs, after #22/#24).

## How

Port `isLoopTerminals` + `closeLoop` to Swift (`MapRouteGeometry`) and apply it to the bus branch of `MapView`'s route builder. A route is a loop when its trimmed terminals match case-insensitively; the first point is appended only when it **is** a loop, has ≥ 2 points and is **not already closed**, so non-loop and already-closed routes are unchanged. Loop closure is done in geometry, not seed data, because `station_line_entity` is keyed by `(station_id, line_id)` and a repeated stop id would collide.

## Tests

`MapRouteGeometryTests` mirrors the shared `RouteGeometryTest`: loop when terminals match, case-insensitive/trimmed, not a loop when they differ or are blank; `closeLoop` appends for a loop and is a no-op for non-loop, already-closed and single-point inputs. Registered in the `iosAppTests` target; the suite **passes locally** (`** TEST SUCCEEDED **`, 8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)