### PR TITLE
Android: fast per-call timeouts on live + departures calls (parity #15)

### DIFF
--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/NetworkTimeouts.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/NetworkTimeouts.kt
@@ -1,0 +1,18 @@
+package com.syrmos.core.network
+
+/**
+ * Per-request timeout for the LIVE and DEPARTURES calls (live-positions,
+ * station-offsets, projected departures, railway.gov live trains).
+ *
+ * The shared HttpClient carries a 30s default so background sync (manifest,
+ * per-line bundles, fares) can ride out a slow link. But the live/departures
+ * calls feed an interactive, self-refreshing UI: when the Pi is unreachable
+ * (down, LAN-only, captive portal) a user should drop to the bundled seed /
+ * simulated layer in a few seconds, not stare at a spinner for 30. iOS already
+ * uses per-call 6-10s timeouts here; this brings Android to parity.
+ *
+ * Kept well below the 30s client default on purpose: raising it back toward the
+ * default would defeat the fast fallback, so [NetworkTimeoutsTest] pins it to
+ * the fast range.
+ */
+internal const val LIVE_REQUEST_TIMEOUT_MS = 8_000L

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/RailwayGovLiveTrackerService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/RailwayGovLiveTrackerService.kt
@@ -3,6 +3,7 @@ package com.syrmos.core.network
 import com.syrmos.core.common.LiveDataFreshness
 import com.syrmos.core.model.transit.LiveSuburbanTrain
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.currentCoroutineContext
@@ -39,7 +40,12 @@ class RailwayGovLiveTrackerService(
     fun observeSuburbanTrains(lineIds: Set<String>? = null): Flow<List<LiveSuburbanTrain>> = flow {
         while (currentCoroutineContext().isActive) {
             try {
-                val response = httpClient.get(TRAINS_URL)
+                // Fast per-call timeout: this is a live poll feeding the map, so
+                // a stalled request should fail quickly and let the loop retry /
+                // fall back, not hang on the 30s client default.
+                val response = httpClient.get(TRAINS_URL) {
+                    timeout { requestTimeoutMillis = LIVE_REQUEST_TIMEOUT_MS }
+                }
                 val body = response.bodyAsText()
                 val payload = json.decodeFromString<TrainsPayload>(body)
                 val trains = payload.trains

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/SyrmosLivePositionsService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/SyrmosLivePositionsService.kt
@@ -1,6 +1,7 @@
 package com.syrmos.core.network
 
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.Serializable
@@ -28,12 +29,18 @@ class SyrmosLivePositionsService(
 
     suspend fun fetchActiveTrains(lineIds: List<String>): LivePositionsResponse? = runCatching {
         val ids = lineIds.joinToString(",")
-        val response = httpClient.get("$BASE_URL/api/live-positions?lineIds=$ids")
+        // Fast per-call timeout: a stalled live poll should drop to the
+        // simulated layer in seconds, not hang the map for the 30s default.
+        val response = httpClient.get("$BASE_URL/api/live-positions?lineIds=$ids") {
+            timeout { requestTimeoutMillis = LIVE_REQUEST_TIMEOUT_MS }
+        }
         parseLivePositions(response.bodyAsText())
     }.getOrNull()
 
     suspend fun fetchStationOffsets(): StationOffsetsResponse? = runCatching {
-        val response = httpClient.get("$BASE_URL/api/station-offsets")
+        val response = httpClient.get("$BASE_URL/api/station-offsets") {
+            timeout { requestTimeoutMillis = LIVE_REQUEST_TIMEOUT_MS }
+        }
         parseStationOffsets(response.bodyAsText())
     }.getOrNull()
 

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/SyrmosSchedulesService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/SyrmosSchedulesService.kt
@@ -1,6 +1,7 @@
 package com.syrmos.core.network
 
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -94,6 +95,10 @@ class SyrmosSchedulesService(
     ): Flow<ProjectedDeparturesPayload?> = flow {
         val payload = runCatching {
             val response = httpClient.get(DEPARTURES_NEXT_URL) {
+                // Fast per-call timeout: the departures sheet must fall back to
+                // the local projector / seed in seconds when the Pi is
+                // unreachable, not wait out the 30s client default.
+                timeout { requestTimeoutMillis = LIVE_REQUEST_TIMEOUT_MS }
                 parameter("stationId", stationId)
                 parameter("lineIds", lineIds.joinToString(","))
                 parameter("limit", limit)

--- a/core/network/src/commonTest/kotlin/com/syrmos/core/network/NetworkTimeoutsTest.kt
+++ b/core/network/src/commonTest/kotlin/com/syrmos/core/network/NetworkTimeoutsTest.kt
@@ -1,0 +1,32 @@
+package com.syrmos.core.network
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Guards the live/departures per-call timeout (audit #15). The whole point is a
+ * fast fallback to the bundled/simulated layer when the Pi is unreachable, so
+ * the value must stay in the iOS-parity 6-10s band and well below the 30s
+ * HttpClient default. Raising it back toward the default would silently reinstate
+ * the ~30s hang, so this test fails if it drifts.
+ */
+class NetworkTimeoutsTest {
+
+    private val clientDefaultMs = 30_000L
+
+    @Test
+    fun liveTimeoutStaysInTheFastFallbackBand() {
+        assertTrue(
+            LIVE_REQUEST_TIMEOUT_MS in 6_000L..10_000L,
+            "live/departures timeout must stay 6-10s (iOS parity), was $LIVE_REQUEST_TIMEOUT_MS",
+        )
+    }
+
+    @Test
+    fun liveTimeoutIsWellBelowTheClientDefault() {
+        assertTrue(
+            LIVE_REQUEST_TIMEOUT_MS < clientDefaultMs,
+            "live timeout must be shorter than the 30s client default or the fast fallback is lost",
+        )
+    }
+}


### PR DESCRIPTION
## What

The shared `HttpClient` carries a single **30s** timeout. That's right for background sync (manifest, per-line bundles, fares) but wrong for the interactive **live/departures** calls: when the Pi is unreachable (down, LAN-only, captive portal) the map and the departures sheet hung for **~30s** before falling back to the bundled seed / simulated layer. iOS already uses per-call 6-10s timeouts here. Closes audit row **#15**.

## How

Add an **8s** per-request timeout (`LIVE_REQUEST_TIMEOUT_MS`, one shared constant) to the four live/departures calls:
- `/api/live-positions` and `/api/station-offsets` (`SyrmosLivePositionsService`)
- `/api/departures/next` (`SyrmosSchedulesService.fetchProjectedDepartures`)
- the railway.gov live-trains poll (`RailwayGovLiveTrackerService`)

Background sync keeps the 30s default. A stalled live call now fails in ~8s and the loop retries / falls back.

## Tests

`NetworkTimeoutsTest` pins the constant to the 6-10s iOS-parity band **and** below the 30s client default, so a future bump that would silently reinstate the long hang fails the build. (Real timing behaviour under a half-open socket needs on-device/network-fault injection, which the repo has no harness for; the change itself is a per-request Ktor `timeout {}` override verified by the build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)