### PR TITLE
Android: merge departure card into one TalkBack announcement + section headings (parity #18)

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/com/syrmos/core/designsystem/component/DepartureCard.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/syrmos/core/designsystem/component/DepartureCard.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.syrmos.core.common.AppLanguage
@@ -49,8 +51,21 @@ fun DepartureCard(
     disruptionSeverity: AlertSeverity? = null,
 ) {
     val vehicleResource = lineId?.let { VehicleIcons.resourceFor(it, direction, isAirport) }
+    // One compound accessibility label so TalkBack announces the row as a single
+    // sentence (line, destination, minutes, time) instead of reading each field
+    // separately. Mirrors the iOS StationDetailView `accessibilityElement(.combine)`
+    // + `accessibilityLabel`. The card is non-interactive, so clearing child
+    // semantics loses no role.
+    val a11yLabel = when (language) {
+        AppLanguage.GREEK -> "$lineName προς $direction, σε $minutesAway λεπτά, στις $departureTime"
+        AppLanguage.ALBANIAN -> "$lineName drejt $direction, për $minutesAway minuta, në $departureTime"
+        AppLanguage.ITALIAN -> "$lineName verso $direction, tra $minutesAway minuti, alle $departureTime"
+        else -> "$lineName towards $direction, in $minutesAway minutes, at $departureTime"
+    }
     Card(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .clearAndSetSemantics { contentDescription = a11yLabel },
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
         ),

--- a/core/designsystem/src/commonMain/kotlin/com/syrmos/core/designsystem/component/SectionHeader.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/syrmos/core/designsystem/component/SectionHeader.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -17,6 +19,10 @@ fun SectionHeader(
         text = title,
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.SemiBold,
-        modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        // Expose as a heading so TalkBack heading-navigation can jump between
+        // sections (iOS gets this free from SwiftUI `Section`).
+        modifier = modifier
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .semantics { heading() },
     )
 }

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeScreen.kt
@@ -49,6 +49,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -1339,6 +1341,8 @@ private fun SectionTitle(text: String) {
         text = text,
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.SemiBold,
+        // Heading semantics so TalkBack can jump between Home sections.
+        modifier = Modifier.semantics { heading() },
     )
 }
 


### PR DESCRIPTION
## What

The Android departure card rendered its fields (line, destination, source chip, minutes, time) as independent `Text` nodes, so TalkBack read ~5-6 fragments per row; section titles had no heading semantics. iOS merges the row (`accessibilityElement(.combine)` + compound label) and gets header traits free from `Section`. Closes audit **#18**.

## How

- **DepartureCard**: `clearAndSetSemantics` with one compound, localized `contentDescription` ("line towards destination, in N minutes, at HH:MM"). The row is non-interactive, so clearing child semantics loses no role. All data already passed in — no caller change.
- **SectionHeader** + Home's **SectionTitle**: `heading()` semantics so TalkBack heading-navigation can jump between sections.

## Verification

Verified on the Android emulator via the accessibility node tree: each departure row now exposes a **single** `content-desc`, e.g. `"M3 προς Dimotiko Theatro, σε 328 λεπτά, στις 06:10"`, instead of separate per-field nodes. (Runtime TalkBack traversal has no automated harness in-repo; verified via the dumped a11y tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)