### PR TITLE
Android: enable-location CTA on Home instead of a silently empty nearby section (parity #6)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/syrmos/app/tab/HomeTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/syrmos/app/tab/HomeTab.kt
@@ -2,6 +2,8 @@ package com.syrmos.app.tab
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -22,6 +24,7 @@ import com.syrmos.app.screen.LineDetailScreenRoute
 import com.syrmos.app.screen.StationDetailScreenRoute
 import com.syrmos.core.common.L
 import com.syrmos.core.common.LocalizationManager
+import com.syrmos.app.platform.requestLocationPermission
 import com.syrmos.app.platform.requestUserLocation
 import com.syrmos.feature.home.HomeScreen
 import com.syrmos.feature.home.HomeViewModel
@@ -51,6 +54,7 @@ private class HomeListScreen : cafe.adriel.voyager.core.screen.Screen {
         val navigator = LocalNavigator.currentOrThrow
         val tabNavigator = LocalTabNavigator.current
         val viewModel = koinInject<HomeViewModel>()
+        val scope = rememberCoroutineScope()
         var scrollToWeatherRequest by remember { mutableIntStateOf(0) }
 
         LaunchedEffect(Unit) {
@@ -89,6 +93,15 @@ private class HomeListScreen : cafe.adriel.voyager.core.screen.Screen {
                 navigator.push(LineDetailScreenRoute(lineId))
             },
             onMapClick = { tabNavigator.current = MapTab },
+            onEnableLocation = {
+                scope.launch {
+                    requestLocationPermission()
+                    val location = requestUserLocation()
+                    if (location != null) {
+                        viewModel.onLocationUpdate(location.latitude, location.longitude)
+                    }
+                }
+            },
             scrollToWeatherRequest = scrollToWeatherRequest,
         )
     }

--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/HomeScreen.kt
@@ -110,6 +110,7 @@ fun HomeScreen(
     onLineClick: (String) -> Unit = {},
     onOpenUrl: (String) -> Unit = {},
     onMapClick: () -> Unit = {},
+    onEnableLocation: () -> Unit = {},
     scrollToWeatherRequest: Int = 0,
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -376,6 +377,11 @@ fun HomeScreen(
                     onStationClick = onStationClick,
                 )
             }
+        } else {
+            // Nearby needs a location. Instead of collapsing the section
+            // silently, offer an actionable CTA that (re)requests permission,
+            // mirroring the iOS HomeView "Near me" enable-location card.
+            item { NearbyLocationCta(lang = lang, onEnableLocation = onEnableLocation) }
         }
 
         val realTrains = uiState.liveTrains.filter { !it.origin.isNullOrEmpty() && !it.destination.isNullOrEmpty() }
@@ -1344,6 +1350,40 @@ private fun SectionTitle(text: String) {
         // Heading semantics so TalkBack can jump between Home sections.
         modifier = Modifier.semantics { heading() },
     )
+}
+
+/**
+ * Shown in place of the nearby-stations section when there is no location, so
+ * the user can actually enable it instead of the section silently collapsing.
+ * Mirrors the iOS HomeView "Near me" enable-location card.
+ */
+@Composable
+private fun NearbyLocationCta(lang: AppLanguage, onEnableLocation: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .clickable { onEnableLocation() },
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = L.ENABLE_LOCATION_FOR_NEXT.text(lang),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = L.ONBOARD_LOCATION_CTA.text(lang),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## What

iOS `HomeView` shows an actionable enable-location card when location is unavailable. On Android the nearby-stations section simply **collapsed to nothing** (`if (nearestStations.isNotEmpty())` with no else); the only no-location affordance was passive hero text, so a user who denied the startup permission had **no way to enable location from Home**. Closes audit **#6**.

## How

Add `NearbyLocationCta` in the empty branch — a tappable card ("Enable location…" + an "Allow location" action) wired through a new `onEnableLocation` callback to the **existing** `requestLocationPermission()` then a location re-fetch. **No new `expect/actual`** — reuses the platform functions `ExploreTab` already uses, so it compiles on Android, web, and iOS targets unchanged (verified: `assembleDebug` + `compileKotlinWasmJs`).

## Verification

Verified on the Android emulator: with no GPS fix the Home nearby section now renders the enable-location CTA (localized to Greek in the test) instead of collapsing, and tapping it re-requests permission without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)