### PR TITLE
Fix adversarial-review findings from the deep-QA phase

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
@@ -54,7 +54,12 @@ val featureModule = module {
         )
     }
     single { LinesViewModel(getLinesUseCase = get()) }
-    factory {
+    // single, not factory: LineDetailViewModel owns an uncancelled CoroutineScope
+    // running an unbounded live-poll loop (and now a departures collector). As a
+    // factory, each navigation to a line detail spun up a fresh VM and leaked the
+    // previous one's loops forever - the same reason its siblings above are single.
+    // loadLine() re-inits per lineId (LineDetailScreenRoute keys it on lineId).
+    single {
         LineDetailViewModel(
             getLineDetailUseCase = get(),
             liveTrackerService = get(),

--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/LinesRefresher.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/LinesRefresher.kt
@@ -15,14 +15,17 @@ import kotlinx.coroutines.flow.firstOrNull
  * continues to work fully offline; this just lets us ship station fixes
  * (new tram stops, renamed stations) without an app release.
  *
- * Behaviour:
- * - Line rows are upserted (safe — API has the same columns as the seed).
- * - Station rows for stations the DB already knows about are LEFT ALONE
- *   so we don't clobber the interchange/accessibility/zone flags from the
- *   bundled seed.
+ * Behaviour (overlay-only, matching the iOS reference): the seed is
+ * authoritative; /api/lines may only ADD what the seed lacks, never mutate it.
+ * - A seeded line row is LEFT ALONE (its status/region/terminals are never
+ *   overwritten); only a genuinely new line id is inserted.
+ * - A seeded station row is LEFT ALONE (interchange/accessibility/zone flags
+ *   preserved); only a genuinely new station id is inserted.
+ * - Membership rows are added for a new line's full ordered stop list and for
+ *   a new station attaching to a seeded line; a seeded line's existing
+ *   membership order is never rewritten.
  * - New stations from the API (e.g. the 2022 Piraeus tram extension) are
  *   inserted with sensible defaults.
- * - Station-to-line relations are upserted so the order matches the API.
  * Schedules, frequencies and transfers are not touched — they remain
  * managed by the bundled seed since they're domain-specific.
  */
@@ -57,7 +60,8 @@ class LinesRefresher(
             remoteLines.forEach { line ->
                 // Only insert a genuinely NEW line; never overwrite a seeded line's
                 // status/region/terminals.
-                if (line.id !in knownLineIds) {
+                val lineIsNovel = line.id !in knownLineIds
+                if (lineIsNovel) {
                     database.syrmosDatabaseQueries.insertLine(
                         id = line.id,
                         name = line.name,
@@ -72,10 +76,10 @@ class LinesRefresher(
                     )
                 }
 
-                // Only add NOVEL stations and their membership. A known station's
-                // membership/order is left exactly as seeded (no reorder). This
-                // also never truncates a line: it only ever adds rows.
                 line.stations.forEachIndexed { index, station ->
+                    // Add the station row itself only when it is novel, so a seeded
+                    // station's interchange/accessibility/zone flags are never
+                    // clobbered.
                     if (station.id !in knownStationIds) {
                         database.syrmosDatabaseQueries.insertStation(
                             id = station.id,
@@ -90,6 +94,13 @@ class LinesRefresher(
                             region = line.region,
                             source_confidence = "scheduled",
                         )
+                    }
+                    // Insert the membership when the LINE is new (so a new line gets
+                    // its full ordered stop list, including stops that are already
+                    // seeded interchanges) OR the STATION is new (attach a new stop
+                    // to a seeded line). Skip only when both are already known -
+                    // that is the seeded-membership reorder we must avoid.
+                    if (shouldAttachMembership(lineIsNovel, station.id in knownStationIds)) {
                         database.syrmosDatabaseQueries.insertStationLine(
                             station_id = station.id,
                             line_id = line.id,
@@ -99,5 +110,18 @@ class LinesRefresher(
                 }
             }
         }
+    }
+
+    companion object {
+        /**
+         * Overlay-only membership rule: a station-to-line row is (re)written only
+         * when the line is genuinely new (it needs its full ordered stop list,
+         * including stops that are already-seeded interchanges) or the station is
+         * genuinely new (attach it to a seeded line). When both are already known
+         * the seeded membership is left untouched - writing it would reorder a
+         * seeded line's stops, the exact divergence overlay-only removes.
+         */
+        internal fun shouldAttachMembership(lineIsNovel: Boolean, stationIsKnown: Boolean): Boolean =
+            lineIsNovel || !stationIsKnown
     }
 }

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/seed/LinesRefresherTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/seed/LinesRefresherTest.kt
@@ -1,0 +1,40 @@
+package com.syrmos.core.data.seed
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Guards the overlay-only membership rule. The adversarial review of the
+ * overlay-only change (parity #16) caught a regression: nesting the membership
+ * insert under the station-novelty check alone meant a genuinely-new line whose
+ * stops include already-seeded interchange stations got an incomplete (or empty)
+ * membership and drew nothing. The rule must attach a membership when the LINE
+ * is new OR the STATION is new, and skip only when both are already known (that
+ * is the seeded-membership reorder overlay-only must avoid).
+ */
+class LinesRefresherTest {
+
+    @Test
+    fun newLineWithAlreadySeededStationStillGetsMembership() {
+        // The regression case: novel line, station already seeded (e.g. a new M4
+        // whose stops include Syntagma). Must still attach so the line draws.
+        assertTrue(LinesRefresher.shouldAttachMembership(lineIsNovel = true, stationIsKnown = true))
+    }
+
+    @Test
+    fun newLineWithNewStationGetsMembership() {
+        assertTrue(LinesRefresher.shouldAttachMembership(lineIsNovel = true, stationIsKnown = false))
+    }
+
+    @Test
+    fun seededLineGainingANewStationAttachesIt() {
+        assertTrue(LinesRefresher.shouldAttachMembership(lineIsNovel = false, stationIsKnown = false))
+    }
+
+    @Test
+    fun seededLineWithSeededStationIsLeftAlone() {
+        // Both known: never rewrite the seeded membership (would reorder stops).
+        assertFalse(LinesRefresher.shouldAttachMembership(lineIsNovel = false, stationIsKnown = true))
+    }
+}

--- a/core/designsystem/src/commonMain/kotlin/com/syrmos/core/designsystem/component/DepartureCard.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/syrmos/core/designsystem/component/DepartureCard.kt
@@ -52,15 +52,35 @@ fun DepartureCard(
 ) {
     val vehicleResource = lineId?.let { VehicleIcons.resourceFor(it, direction, isAirport) }
     // One compound accessibility label so TalkBack announces the row as a single
-    // sentence (line, destination, minutes, time) instead of reading each field
-    // separately. Mirrors the iOS StationDetailView `accessibilityElement(.combine)`
-    // + `accessibilityLabel`. The card is non-interactive, so clearing child
-    // semantics loses no role.
-    val a11yLabel = when (language) {
-        AppLanguage.GREEK -> "$lineName προς $direction, σε $minutesAway λεπτά, στις $departureTime"
-        AppLanguage.ALBANIAN -> "$lineName drejt $direction, për $minutesAway minuta, në $departureTime"
-        AppLanguage.ITALIAN -> "$lineName verso $direction, tra $minutesAway minuti, alle $departureTime"
-        else -> "$lineName towards $direction, in $minutesAway minutes, at $departureTime"
+    // sentence instead of reading each field separately. Mirrors the iOS
+    // StationDetailView `accessibilityElement(.combine)` + `accessibilityLabel`.
+    // The card is non-interactive, so clearing child semantics loses no role -
+    // but the label must carry every on-screen field (airport badge, train
+    // number, source confidence) or a screen-reader user loses them; and it uses
+    // the same human countdown the row shows (formatMinutesAway) rather than the
+    // raw minute count.
+    val a11yLabel = buildString {
+        append(lineName)
+        if (isAirport && airportLabel != null) append(", $airportLabel")
+        append(
+            when (language) {
+                AppLanguage.GREEK -> ", προς $direction"
+                AppLanguage.ALBANIAN -> ", drejt $direction"
+                AppLanguage.ITALIAN -> ", verso $direction"
+                else -> ", towards $direction"
+            },
+        )
+        if (trainNo != null) append(", #$trainNo")
+        append(", ${formatMinutesAway(minutesAway, language)}")
+        append(
+            when (language) {
+                AppLanguage.GREEK -> ", στις $departureTime"
+                AppLanguage.ALBANIAN -> ", në $departureTime"
+                AppLanguage.ITALIAN -> ", alle $departureTime"
+                else -> ", at $departureTime"
+            },
+        )
+        sourceConfidence?.let { append(", ${sourceLabel ?: it.defaultLabel(language)}") }
     }
     Card(
         modifier = modifier

--- a/core/designsystem/src/commonMain/kotlin/com/syrmos/core/designsystem/component/SourceConfidenceChip.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/syrmos/core/designsystem/component/SourceConfidenceChip.kt
@@ -40,7 +40,7 @@ private fun SourceConfidence.color(): Color = when (this) {
 }
 
 /** English default label; callers pass a localised [label] for EL / SQ. */
-private fun SourceConfidence.defaultLabel(language: AppLanguage): String = when (this) {
+internal fun SourceConfidence.defaultLabel(language: AppLanguage): String = when (this) {
     SourceConfidence.LIVE -> localized(language, "Live", "Ζωντανά", "Drejtpërdrejt", "In tempo reale")
     SourceConfidence.SCHEDULED -> localized(language, "Scheduled", "Προγραμματισμένο", "I planifikuar", "Programmato")
     SourceConfidence.OFFLINE -> localized(language, "Offline snapshot", "Στιγμιότυπο εκτός σύνδεσης", "Pamje pa internet", "Istantanea offline")


### PR DESCRIPTION
A fresh-perspective review of the deep-QA-phase PRs (#74/#75/#76) caught three real issues; all fixed here.

- **FINDING 1 (HIGH, correctness regression in #16):** nesting the membership insert under the station-novelty check alone meant a genuinely-new line whose stops include already-seeded interchanges got incomplete/empty membership and drew nothing. Now attaches a membership when the **line** is new OR the **station** is new; skips only when both are known. Extracted a pure `shouldAttachMembership()` with a **regression test**; refreshed the stale KDoc.
- **FINDING 3 (MEDIUM, a11y regression in #18):** the merged `DepartureCard` label dropped the airport badge, train number, and source-confidence chip and read the raw minute count. Rebuilt to include them + `formatMinutesAway`. Verified on emulator: *"M3, Airport, towards Dimotiko Theatro, 4h 50min, at 06:10, Scheduled"*.
- **FINDING 2 (MEDIUM, pre-existing leak aggravated by #74):** `LineDetailViewModel` was a `factory` with an uncancelled scope + unbounded poll loop → leaked per navigation. Made it `single` (matching its sibling VMs + the `loadLine()`-per-lineId lifecycle).
- **FINDING 4 (LOW):** CTA flash during the ~5s location resolve — accepted for GA (self-corrects). **FINDING 5:** CI change confirmed solid.

Build (Android + wasmJs) + KMP tests green locally; FINDING 1/3 verified on the emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)