### PR TITLE
Server projector: short-turn last-train destination override (parity #12)

### DIFF
--- a/ops/syrmos-api/syrmos_admin/projector.py
+++ b/ops/syrmos-api/syrmos_admin/projector.py
@@ -387,6 +387,56 @@ def _service_type(line_id: str, band_label: str) -> str:
     return "regular"
 
 
+def _last_train_overrides(
+    conn: sqlite3.Connection, line_id: str, day_type: str, station_id: str
+) -> dict[str, list[tuple[int, str]]]:
+    """Short-turn destination overrides for the last trains of the night.
+
+    STASY runs short-turn services that terminate at an intermediate station
+    (M1 00:30 from Piraeus goes only to Omonia, not Kifissia). Those rows live
+    in last_train_endpoints (migration 0017), scraped per (line, direction,
+    from_station, time). When a projected slot at this station matches such a
+    row by time (+/-1 min), the displayed destination must become the short-turn
+    terminal instead of the band's line terminal - otherwise a passenger is told
+    "towards Kifissia" for a train that never reaches it. iOS already does this
+    from its synced bundle (ScheduleProjector.lastTrainOverride); Android and
+    Web render whatever this endpoint returns, so applying it here is what brings
+    them to parity without a client change.
+
+    Returns {direction_key: [(time_minutes, destination_name)]}. Empty when the
+    table is absent (older Pi without migration 0017) or the line ships no
+    short-turn rows - the projector then keeps the band terminal, matching the
+    client fallback projectors and the bundled seed (both ship none). Only
+    genuine short-turns (label='short') override; regular last trains
+    (label='last') keep the line terminal, so a spelling difference between the
+    stations table and lines.terminal_* can never flip a normal destination.
+    """
+    if not station_id:
+        return {}
+    try:
+        rows = conn.execute(
+            "SELECT lte.direction AS direction, lte.time AS time,"
+            " lte.end_station_id AS end_station_id, s.name AS end_name"
+            " FROM last_train_endpoints lte"
+            " LEFT JOIN stations s ON s.id = lte.end_station_id"
+            " WHERE lte.line_id=? AND lte.day_type=? AND lte.from_station_id=?"
+            " AND lte.label='short'",
+            (line_id, day_type, station_id),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        # Pi hasn't applied migration 0017 (or has no stations table): no
+        # override, keep the line terminal. Mirrors generator.py's guard.
+        return {}
+    result: dict[str, list[tuple[int, str]]] = {}
+    for r in rows:
+        minute = _minutes_of_day(r["time"])
+        if minute is None:
+            continue
+        end_name = r["end_name"] if ("end_name" in r.keys() and r["end_name"]) else r["end_station_id"]
+        result.setdefault((r["direction"] or "").lower(), []).append((minute, end_name))
+    return result
+
+
 def _project_line(
     *,
     bundle: dict,
@@ -491,6 +541,11 @@ def _project_line(
             bands.append(b)
         bands.sort(key=lambda b: _minutes_of_day(b["timeStart"]) or 0)
 
+        # Short-turn last-train destinations for this day-type at this station
+        # (empty for lines/days with no scraped short-turns). Keyed by direction
+        # so an outbound override never leaks onto an inbound slot.
+        overrides = _last_train_overrides(conn, line_id, dt, station_id)
+
         for band in bands:
             band_dir = (band.get("direction") or "both").lower()
             for direction_key, direction_label in streams:
@@ -507,6 +562,7 @@ def _project_line(
                     limit=limit,
                     out=line_out,
                     conn=conn,
+                    overrides=overrides.get(direction_key, ()),
                 )
 
     line_out = _dedupe(line_out)
@@ -526,6 +582,7 @@ def _project_band(
     limit: int,
     out: list[Departure],
     conn: sqlite3.Connection,
+    overrides: "Iterable[tuple[int, str]]" = (),
 ):
     raw_start = _minutes_of_day(band["timeStart"])
     raw_end = _minutes_of_day(band["timeEnd"])
@@ -554,11 +611,20 @@ def _project_band(
         time_str = f"{display_min // 60:02d}:{display_min % 60:02d}"
         minutes_away = max(0, slot_min - now_minutes)
         display_line_id = _display_line_id(line_id)
+        # Override the destination when this exact slot is a scraped short-turn
+        # last train (e.g. the 00:30 that stops at Omonia, not Kifissia). +/-1
+        # min absorbs the rounding between the band's headway grid and STASY's
+        # published clock time; matches iOS ScheduleProjector.lastTrainOverride.
+        dest = direction_label
+        for ov_min, ov_name in overrides:
+            if abs(ov_min - display_min) <= 1:
+                dest = ov_name
+                break
         out.append(Departure(
             lineId=display_line_id,
             line=display_line_id,
             directionKey=direction_key,
-            direction=direction_label,
+            direction=dest,
             time=time_str,
             minutesAway=minutes_away,
             serviceType=_service_type(line_id, band["label"]),

--- a/ops/syrmos-api/tests/test_projector.py
+++ b/ops/syrmos-api/tests/test_projector.py
@@ -278,5 +278,95 @@ class ActiveTrainsOvernightTest(unittest.TestCase):
         self.assertIsInstance(trains, list)
 
 
+def make_m1_shortturn_conn(*, with_endpoints: bool = True, label: str = "short") -> sqlite3.Connection:
+    """M1 with a late-night band and (optionally) a scraped short-turn row.
+
+    STASY's real case: the 00:30 outbound from Piraeus terminates at Omonia,
+    not the line terminal Kifissia. The band grid only knows the terminal, so
+    the destination has to come from last_train_endpoints (migration 0017).
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE lines (id TEXT PRIMARY KEY, terminal_a TEXT NOT NULL, terminal_b TEXT NOT NULL);
+        CREATE TABLE schedule_rules (line_id TEXT, day_type TEXT, open_time TEXT, close_time TEXT, is_24_7 INTEGER DEFAULT 0);
+        CREATE TABLE frequency_bands (line_id TEXT, day_type TEXT, time_start TEXT, time_end TEXT, headway_minutes REAL, label TEXT, direction TEXT DEFAULT 'both');
+        CREATE TABLE station_offsets (line_id TEXT, direction TEXT, station_id TEXT, minutes_from_origin INTEGER);
+        CREATE TABLE stations (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+        CREATE TABLE last_train_endpoints (
+            line_id TEXT, day_type TEXT, direction TEXT, from_station_id TEXT,
+            time TEXT, end_station_id TEXT, label TEXT, source TEXT, fetched_at TEXT
+        );
+        """
+    )
+    conn.execute("INSERT INTO lines VALUES ('M1', 'Piraeus', 'Kifissia')")
+    conn.execute("INSERT INTO schedule_rules VALUES ('M1', 'mon_thu', '05:30', '00:30', 0)")
+    # A plain 10:00 -> 11:00 band (slots 10:00, 10:15, 10:30, 10:45, 11:00).
+    # The real short-turn is at the end of the night, but the override matches
+    # purely on slot time, so a daytime band exercises the same code without
+    # fighting the projector's overnight next-day-extension descriptors.
+    conn.execute("INSERT INTO frequency_bands(line_id, day_type, time_start, time_end, headway_minutes, label) VALUES ('M1','mon_thu','10:00','11:00',15.0,'regular')")
+    conn.executemany(
+        "INSERT INTO stations(id, name) VALUES (?, ?)",
+        [("M1_OMO", "Omonia"), ("M1_KIF", "Kifissia")],
+    )
+    if with_endpoints:
+        conn.execute(
+            "INSERT INTO last_train_endpoints(line_id, day_type, direction, from_station_id, time, end_station_id, label)"
+            " VALUES ('M1', 'mon_thu', 'outbound', 'M1_PIR', '10:30', 'M1_OMO', ?)",
+            (label,),
+        )
+    return conn
+
+
+class LastTrainShortTurnTest(unittest.TestCase):
+    """Parity #12: the last short-turn train shows its real terminus."""
+
+    def _outbound(self, conn):
+        return project_next_departures(
+            conn, "M1_PIR", ["M1"], direction="outbound",
+            now=datetime(2026, 6, 15, 10, 0, tzinfo=ATHENS),  # Monday 10:00
+            limit=5,
+        )
+
+    def test_shortturn_slot_shows_intermediate_terminus(self):
+        rows = self._outbound(make_m1_shortturn_conn())
+        by_time = {r["time"]: r["direction"] for r in rows}
+        # The 10:30 short-turn goes to Omonia, not the line terminal.
+        self.assertEqual(by_time.get("10:30"), "Omonia")
+
+    def test_normal_slots_keep_line_terminal(self):
+        rows = self._outbound(make_m1_shortturn_conn())
+        by_time = {r["time"]: r["direction"] for r in rows}
+        # Trains that are not the short-turn still run to Kifissia.
+        self.assertEqual(by_time.get("10:15"), "Kifissia")
+        self.assertEqual(by_time.get("10:45"), "Kifissia")
+
+    def test_no_endpoints_table_data_keeps_terminal(self):
+        # Regression / offline parity: with no short-turn rows every slot is
+        # the line terminal, exactly as the bundled seed (which ships none).
+        rows = self._outbound(make_m1_shortturn_conn(with_endpoints=False))
+        self.assertTrue(rows)
+        for r in rows:
+            self.assertEqual(r["direction"], "Kifissia")
+
+    def test_regular_last_train_does_not_override(self):
+        # label='last' rows pin the clock time but keep the line terminal;
+        # only label='short' rewrites the destination.
+        rows = self._outbound(make_m1_shortturn_conn(label="last"))
+        by_time = {r["time"]: r["direction"] for r in rows}
+        self.assertEqual(by_time.get("10:30"), "Kifissia")
+
+    def test_missing_migration_is_graceful(self):
+        # A Pi without migration 0017 has no last_train_endpoints table; the
+        # projector must still return the normal terminal, never raise.
+        conn = make_m1_shortturn_conn(with_endpoints=False)
+        conn.execute("DROP TABLE last_train_endpoints")
+        rows = self._outbound(conn)
+        self.assertTrue(rows)
+        self.assertTrue(all(r["direction"] == "Kifissia" for r in rows))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Parity #12: last short-turn train shows its real terminus

**The gap.** STASY runs short-turn last trains that stop at an intermediate station: the M1 00:30 from Piraeus terminates at **Omonia**, not the line terminal **Kifissia**. The frequency-band grid only knows the line terminal, so the real terminus lives in the scraped `last_train_endpoints` table (migration 0017).

- **iOS** already applies this override locally (`ScheduleProjector.lastTrainOverride`) from its synced bundle.
- **Android + Web are server-first**: they render `/api/departures/next` verbatim, and the server projector never applied the override. So the last train of the night showed *"towards Kifissia"* for a train that never reaches it, a materially wrong journey instruction on two of three platforms.

**The fix.** `project_next_departures` now resolves the short-turn terminus per matching slot (±1 min, direction-scoped) and swaps the destination, at the single source of truth. No client change; Android and Web inherit the correct destination. Only genuine short-turns (`label='short'`) override; regular last trains keep the terminal. Guarded so a Pi without migration 0017 keeps the terminal, matching the bundled seed (which ships no short-turn rows). Offline, every platform still shows the terminal, so there is no divergence.

## Tests
5 new cases in `test_projector.py`: short-turn override, normal slots keep terminal, no-data parity, `label='last'` no-op, missing-migration graceful. Full projector suite **18/18**; server suite **83/83** (only the pre-existing `httpx`-import module is skipped in this env).

## Deploy note
Takes effect once the Pi applies migration `0017_last_train_endpoints` and the STASY last-train scraper populates the table. Until then it is a verified no-op. iOS is unaffected (already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)