### PR TITLE
Android: hide the dead morning-digest toggle in Settings (parity #14)

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/syrmos/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/syrmos/feature/settings/SettingsScreen.kt
@@ -329,7 +329,11 @@ fun SettingsScreen(
             val serviceAlertsOn by NotificationSettings.serviceAlerts.collectAsState()
             val weatherAlertsOn by NotificationSettings.weatherAlerts.collectAsState()
             val nearbyAlertsOn by NotificationSettings.nearbyAlerts.collectAsState()
-            val morningDigestOn by NotificationSettings.morningDigest.collectAsState()
+            // Morning digest (07:00) is implemented and wired on iOS but has no
+            // consumer on Android yet: nothing schedules a 07:00 worker that reads
+            // notif_morning_digest, so the toggle only persisted a dead flag. Hide
+            // it rather than ship a control that does nothing; restore it together
+            // with a MorningDigestWorker when the feature actually lands.
 
             SettingsSection(title = when (lang) {
                 AppLanguage.GREEK -> "Ειδοποιησεις"
@@ -368,17 +372,6 @@ fun SettingsScreen(
                     },
                     checked = nearbyAlertsOn,
                     onCheckedChange = { NotificationSettings.setNearbyAlerts(it) },
-                )
-                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
-                NotifToggleRow(
-                    title = when (lang) {
-                        AppLanguage.GREEK -> "Πρωινη ενημερωση (07:00)"
-                        AppLanguage.ALBANIAN -> "Perditesimi i mengjesit (07:00)"
-                        AppLanguage.ITALIAN -> "Riepilogo mattutino (07:00)"
-                        else -> "Morning digest (07:00)"
-                    },
-                    checked = morningDigestOn,
-                    onCheckedChange = { NotificationSettings.setMorningDigest(it) },
                 )
             }
         }


### PR DESCRIPTION
## Parity #14: no fake controls

The Notifications section shipped a **Morning digest (07:00)** toggle that only persisted `notif_morning_digest`. Nothing on Android consumes it, `AlertCheckWorker` runs service-alert + weather checks only, and no 07:00 worker is scheduled, so toggling it did nothing.

iOS implements the digest for real (a repeating 07:00 `UNCalendarNotificationTrigger` gated on the same pref). Rather than ship a dead control or rush an unverifiable scheduled-notification feature the morning of GA, this **hides** the toggle. A comment marks where to restore it with a real `MorningDigestWorker`. The shared `NotificationSettings` getter/setter stay for the future wiring; only the dead UI is removed.

This satisfies the parity ledger's own criterion for #14: *"digest toggle wired or hidden."*

## Verification
Emulator (Greek UI): the Notifications section now ends at **Nearby station alerts**, renders cleanly with no gap, no crash. `assembleDebug` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)