### PR TITLE
Android: refresh on reconnect via a connectivity observer (parity #7)

### DIFF
--- a/androidApp/src/androidMain/AndroidManifest.xml
+++ b/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Read-only network-state access so the app can refresh the moment
+         connectivity returns (ConnectivityObserver), mirroring iOS NWPathMonitor. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/androidApp/src/androidMain/kotlin/com/syrmos/android/ConnectivityObserver.kt
+++ b/androidApp/src/androidMain/kotlin/com/syrmos/android/ConnectivityObserver.kt
@@ -1,0 +1,45 @@
+package com.syrmos.android
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import com.syrmos.core.common.LiveDataFreshness
+
+/**
+ * Fires [LiveDataFreshness.requestRetry] the instant the device regains
+ * connectivity, so the home surface refreshes immediately on reconnect instead
+ * of waiting up to 60s for the next poll. This is the Android counterpart to
+ * the iOS NWPathMonitor in DataFreshness.swift, which already does exactly this
+ * (parity #7). The shared retry channel already exists: HomeViewModel collects
+ * [LiveDataFreshness.retryRequested] and probes on every bump.
+ *
+ * Registered once from [SyrmosApplication.onCreate] for the whole process
+ * lifetime, so there is no unregister/leak concern (the callback is meant to
+ * live as long as the app). requestRetry() only bumps a StateFlow, so it is
+ * cheap, thread-safe from the binder callback thread, and idempotent.
+ */
+class ConnectivityObserver(context: Context) {
+
+    private val connectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+            as? ConnectivityManager
+
+    private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            // A usable default network appeared (cold start while online, or an
+            // offline -> online transition). Ask the home surface to re-probe.
+            LiveDataFreshness.requestRetry()
+        }
+    }
+
+    /**
+     * Begins observing the system default network. registerDefaultNetworkCallback
+     * requires API 24; minSdk is 26, so it is always available. Wrapped in
+     * runCatching because a few OEM/emulator builds throw on registration; a
+     * failure just means we fall back to the existing 60s poll, never a crash.
+     */
+    fun start() {
+        val cm = connectivityManager ?: return
+        runCatching { cm.registerDefaultNetworkCallback(callback) }
+    }
+}

--- a/androidApp/src/androidMain/kotlin/com/syrmos/android/SyrmosApplication.kt
+++ b/androidApp/src/androidMain/kotlin/com/syrmos/android/SyrmosApplication.kt
@@ -29,5 +29,9 @@ class SyrmosApplication : Application() {
         // Periodic alert and weather checks, posts local notifications
         // when new service alerts appear or severe weather is detected.
         com.syrmos.android.notification.AlertCheckWorker.enqueuePeriodic(this)
+
+        // Refresh the moment the device is back online instead of waiting for
+        // the next 60s freshness poll. Mirrors the iOS NWPathMonitor (parity #7).
+        ConnectivityObserver(this).start()
     }
 }


### PR DESCRIPTION
## Parity #7: instant reconnect refresh

Home recovers from offline -> online today, but only when the **60s** freshness poll next fires or the user pulls to refresh. iOS refreshes the instant the network returns (`NWPathMonitor` in `DataFreshness.swift`). Android already had the retry channel (`LiveDataFreshness.requestRetry` / `retryRequested`, collected by `HomeViewModel`) but nothing invoked it on reconnect.

**`ConnectivityObserver`** registers a default-network callback and calls `requestRetry()` on `onAvailable`, closing the gap:
- Registered once from `Application.onCreate` for the process lifetime (no unregister, no leak).
- `runCatching` around registration so an OEM/emulator failure degrades to the existing 60s poll, never a crash.
- Adds the read-only `ACCESS_NETWORK_STATE` permission.

## Verification (emulator)
With a temporary log (removed before commit), `onAvailable -> requestRetry` fired at launch **and again after an airplane-mode OFF toggle**, no crash. So a reconnect immediately drives the home probe. `assembleDebug` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)