### PR TITLE
Server short-turn override: query name_en, not name (parity #12 fix)

### DIFF
--- a/ops/syrmos-api/syrmos_admin/projector.py
+++ b/ops/syrmos-api/syrmos_admin/projector.py
@@ -416,7 +416,7 @@ def _last_train_overrides(
     try:
         rows = conn.execute(
             "SELECT lte.direction AS direction, lte.time AS time,"
-            " lte.end_station_id AS end_station_id, s.name AS end_name"
+            " lte.end_station_id AS end_station_id, s.name_en AS end_name"
             " FROM last_train_endpoints lte"
             " LEFT JOIN stations s ON s.id = lte.end_station_id"
             " WHERE lte.line_id=? AND lte.day_type=? AND lte.from_station_id=?"
@@ -424,8 +424,12 @@ def _last_train_overrides(
             (line_id, day_type, station_id),
         ).fetchall()
     except sqlite3.OperationalError:
-        # Pi hasn't applied migration 0017 (or has no stations table): no
-        # override, keep the line terminal. Mirrors generator.py's guard.
+        # Only the last_train_endpoints table is optional (Pi without migration
+        # 0017): keep the line terminal, mirroring generator.py's guard. The
+        # stations columns (name_en/name_el, migration 0001) always exist, so a
+        # column error here would be a real bug, not a graceful-degrade case -
+        # the projector test fixture mirrors the production schema so a wrong
+        # column name fails the tests instead of silently returning {}.
         return {}
     result: dict[str, list[tuple[int, str]]] = {}
     for r in rows:

--- a/ops/syrmos-api/tests/test_projector.py
+++ b/ops/syrmos-api/tests/test_projector.py
@@ -293,7 +293,11 @@ def make_m1_shortturn_conn(*, with_endpoints: bool = True, label: str = "short")
         CREATE TABLE schedule_rules (line_id TEXT, day_type TEXT, open_time TEXT, close_time TEXT, is_24_7 INTEGER DEFAULT 0);
         CREATE TABLE frequency_bands (line_id TEXT, day_type TEXT, time_start TEXT, time_end TEXT, headway_minutes REAL, label TEXT, direction TEXT DEFAULT 'both');
         CREATE TABLE station_offsets (line_id TEXT, direction TEXT, station_id TEXT, minutes_from_origin INTEGER);
-        CREATE TABLE stations (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+        -- Mirror the production stations schema (migration 0001): name_en/name_el,
+        -- NOT a single `name` column. The projector resolves the short-turn
+        -- terminus via s.name_en, so a fixture with the wrong column would let a
+        -- column-name bug pass silently (it did once); keep this in sync with prod.
+        CREATE TABLE stations (id TEXT PRIMARY KEY, name_en TEXT NOT NULL, name_el TEXT NOT NULL, lat REAL, lng REAL);
         CREATE TABLE last_train_endpoints (
             line_id TEXT, day_type TEXT, direction TEXT, from_station_id TEXT,
             time TEXT, end_station_id TEXT, label TEXT, source TEXT, fetched_at TEXT
@@ -308,8 +312,8 @@ def make_m1_shortturn_conn(*, with_endpoints: bool = True, label: str = "short")
     # fighting the projector's overnight next-day-extension descriptors.
     conn.execute("INSERT INTO frequency_bands(line_id, day_type, time_start, time_end, headway_minutes, label) VALUES ('M1','mon_thu','10:00','11:00',15.0,'regular')")
     conn.executemany(
-        "INSERT INTO stations(id, name) VALUES (?, ?)",
-        [("M1_OMO", "Omonia"), ("M1_KIF", "Kifissia")],
+        "INSERT INTO stations(id, name_en, name_el, lat, lng) VALUES (?, ?, ?, 0, 0)",
+        [("M1_OMO", "Omonia", "Ομόνοια"), ("M1_KIF", "Kifissia", "Κηφισιά")],
     )
     if with_endpoints:
         conn.execute(


### PR DESCRIPTION
## Fixes a HIGH bug the adversarial review caught in #80

The #12 short-turn override query selected `s.name`, but the production `stations` table (migration 0001) has **`name_en` / `name_el`** and no `name` column. Against the real Pi DB the query raised `sqlite3.OperationalError`, which the *table-absent* guard swallowed, so `_last_train_overrides` returned `{}` on every call. **The whole #12 feature was a silent no-op in production** — `/api/departures/next` still showed the line terminal for short-turn last trains.

It passed CI because the test fixture created `stations(id, name)` — a schema that does not match production. Classic "compiles + passes happy-path, wrong in prod."

### Fix
- `projector.py`: `s.name` → `s.name_en` (English, matching `lines.terminal_a/b`; `generator.py` already uses `name_en`/`name_el` everywhere).
- `test_projector.py`: the fixture now mirrors the production schema (`name_en`/`name_el`), so a wrong column fails the tests instead of degrading silently. **Verified**: reverting to `s.name` now FAILS the short-turn test.

Full projector suite 18/18; server suite green (only the pre-existing `httpx`-import module is skipped in this env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)