### PR TITLE
LinesRefresher: park overlay-added stops past seeded positions (no collision)

### DIFF
--- a/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/LinesRefresher.kt
+++ b/core/data/src/commonMain/kotlin/com/syrmos/core/data/seed/LinesRefresher.kt
@@ -104,7 +104,7 @@ class LinesRefresher(
                         database.syrmosDatabaseQueries.insertStationLine(
                             station_id = station.id,
                             line_id = line.id,
-                            position_on_line = index.toLong(),
+                            position_on_line = membershipPosition(lineIsNovel, index),
                         )
                     }
                 }
@@ -123,5 +123,26 @@ class LinesRefresher(
          */
         internal fun shouldAttachMembership(lineIsNovel: Boolean, stationIsKnown: Boolean): Boolean =
             lineIsNovel || !stationIsKnown
+
+        // Beyond the longest real Athens line (T7, ~43 stops). Seeded positions
+        // never reach this, so overlay-appended stops sort strictly after them.
+        internal const val NOVEL_STOP_BASE: Long = 100_000L
+
+        /**
+         * Position for an overlay-inserted membership row. A novel line owns its
+         * whole ordered list, so its stops keep the payload index (0..N). A novel
+         * station attaching to a SEEDED line must NOT reuse the payload index:
+         * the seed already occupies 0..N-1 and those rows are left untouched
+         * (overlay-only), so a mid-line index would collide with a seeded stop and
+         * make `getStationsOnLine`'s `ORDER BY position_on_line` nondeterministic
+         * (and shift every later stop). Park novel stops past every real seeded
+         * position ([NOVEL_STOP_BASE]) so they append deterministically, in
+         * payload order, without ever rewriting a seeded row. The trade-off - a
+         * genuinely mid-line new stop shows at the end of the stop strip rather
+         * than in place - is strictly better than a corrupted (nondeterministic)
+         * order, and departures are unaffected (they key off station_offsets).
+         */
+        internal fun membershipPosition(lineIsNovel: Boolean, index: Int): Long =
+            if (lineIsNovel) index.toLong() else NOVEL_STOP_BASE + index.toLong()
     }
 }

--- a/core/data/src/commonTest/kotlin/com/syrmos/core/data/seed/LinesRefresherTest.kt
+++ b/core/data/src/commonTest/kotlin/com/syrmos/core/data/seed/LinesRefresherTest.kt
@@ -1,6 +1,7 @@
 package com.syrmos.core.data.seed
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -36,5 +37,30 @@ class LinesRefresherTest {
     fun seededLineWithSeededStationIsLeftAlone() {
         // Both known: never rewrite the seeded membership (would reorder stops).
         assertFalse(LinesRefresher.shouldAttachMembership(lineIsNovel = false, stationIsKnown = true))
+    }
+
+    @Test
+    fun novelLineKeepsPayloadOrderPositions() {
+        // A brand-new line owns its whole ordered stop list; positions are the
+        // payload indices so the stops draw in order.
+        assertEquals(0L, LinesRefresher.membershipPosition(lineIsNovel = true, index = 0))
+        assertEquals(3L, LinesRefresher.membershipPosition(lineIsNovel = true, index = 3))
+    }
+
+    @Test
+    fun novelStopOnSeededLineParksPastEverySeededPosition() {
+        // The regression the adversarial review found: a new stop landing at a
+        // mid-line payload index (e.g. 2) must NOT be written as position 2,
+        // which collides with the seeded stop already at 2 and corrupts the
+        // ORDER BY. It parks past every real seeded position instead.
+        val pos = LinesRefresher.membershipPosition(lineIsNovel = false, index = 2)
+        assertEquals(LinesRefresher.NOVEL_STOP_BASE + 2L, pos)
+        assertTrue(pos > LinesRefresher.NOVEL_STOP_BASE)
+        // Two novel stops on the same seeded line keep their relative payload
+        // order and never collide with each other.
+        assertTrue(
+            LinesRefresher.membershipPosition(lineIsNovel = false, index = 1) <
+                LinesRefresher.membershipPosition(lineIsNovel = false, index = 4),
+        )
     }
 }


### PR DESCRIPTION
## Fixes a latent persistence-corruption bug the adversarial review found

The overlay-only `/api/lines` membership wrote a novel station on a seeded line with `position_on_line = payload index`, via `INSERT OR REPLACE`. When the remote payload inserts a stop **mid-line** the index collides:

- seed `[A,B,C,D]` at positions 0-3
- payload `[A,B,X,C,D]` with new stop X at index 2 -> X written at position **2**, colliding with the seeded C (also 2)
- `getStationsOnLine` (`ORDER BY position_on_line`) then returns C/X in nondeterministic order and every later stop is off by one, **written to SQLite and surviving relaunch**

### Fix
`membershipPosition()` parks overlay-added stops on a seeded line past every real seeded position (`NOVEL_STOP_BASE = 100000`), so they append deterministically in payload order and never collide with or rewrite a seeded row. A novel **line** still keeps its payload indices (it owns its full list). A genuinely mid-line new stop shows at the end of the strip rather than in place, strictly better than a corrupted order; departures are unaffected (they key off `station_offsets`).

Tests: 2 new `membershipPosition` cases; `core:data` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)