### PR TITLE
Airport route strip: localize the M3/A1/X95/X97 station names (parity #13)

### DIFF
--- a/feature/schedule/src/commonMain/kotlin/com/syrmos/feature/schedule/AirportHubScreen.kt
+++ b/feature/schedule/src/commonMain/kotlin/com/syrmos/feature/schedule/AirportHubScreen.kt
@@ -561,14 +561,19 @@ private fun airportRouteStops(route: String, lang: AppLanguage): List<RouteStrip
     fun stop(label: String) = RouteStripStop(label, false, false)
     fun interchange(label: String) = RouteStripStop(label, false, true)
     val terminal = RouteStripStop(airport, true, false)
+    // Station names come from the bundled seed (stations.json name / name_el /
+    // name_sq); Greek/Albanian riders saw these strip stops in English before.
+    val dimotikoTheatro = airportText(lang, "Dimotiko Theatro", "Δημοτικό Θέατρο", "Dimotiko Theatro", "Dimotiko Theatro")
+    val syntagma = airportText(lang, "Syntagma", "Σύνταγμα", "Sintagma", "Syntagma")
+    val doukissis = airportText(lang, "Doukissis Plakentias", "Δουκίσσης Πλακεντίας", "Dukisës Plakendias", "Doukissis Plakentias")
     return when (route) {
         // Real termini + the major airport-route interchanges (stable stops).
-        "M3" -> listOf(stop("Dimotiko Theatro"), interchange("Syntagma"), interchange("Doukissis Plakentias"), terminal)
-        "A1" -> listOf(stop("Piraeus"), interchange("Athens"), interchange("Doukissis Plakentias"), terminal)
-        "X95" -> listOf(stop("Syntagma"), terminal)
+        "M3" -> listOf(stop(dimotikoTheatro), interchange(syntagma), interchange(doukissis), terminal)
+        "A1" -> listOf(stop(airportText(lang, "Piraeus", "Πειραιάς", "Pireu", "Pireo")), interchange(airportText(lang, "Athens", "Αθήνα", "Athinë", "Atene")), interchange(doukissis), terminal)
+        "X95" -> listOf(stop(syntagma), terminal)
         "X93" -> listOf(stop(airportText(lang, "Kifisos B Station", "ΚΤΕΛ Κηφισού", "Stacioni Kifisos", "Stazione Kifisos")), terminal)
-        "X96" -> listOf(stop(airportText(lang, "Piraeus", "Πειραιάς", "Pireus", "Pireo")), terminal)
-        "X97" -> listOf(stop("Elliniko"), terminal)
+        "X96" -> listOf(stop(airportText(lang, "Piraeus", "Πειραιάς", "Pireu", "Pireo")), terminal)
+        "X97" -> listOf(stop(airportText(lang, "Elliniko", "Ελληνικό", "Eliniko", "Elliniko")), terminal)
         else -> listOf(stop(airportText(lang, "City", "Πόλη", "Qyteti", "Città")), terminal)
     }
 }


### PR DESCRIPTION
The airport route-strip stops for M3, A1, X95 and X97 were hardcoded English literals, so Greek/Albanian riders saw them in English while the rest of the tab was translated.

(An earlier deep-QA note called this a seed data gap. That was a false alarm from checking the camelCase `nameEl` field; the seed uses `name_el` and every station has complete `name_el`/`name_sq`.)

They now use `airportText(lang, en, el, sq, it)` with the exact `stations.json` values (Σύνταγμα / Δημοτικό Θέατρο / Δουκίσσης Πλακεντίας / Πειραιάς / Ελληνικό / Αθήνα + `name_sq`).

**Verified** on the emulator in Greek: the strip renders Δημοτικό Θέατρο, Σύνταγμα, Δουκίσσης Πλακεντίας, Αθήνα, no crash. Moves #13 partial → fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)