### PR TITLE
ci(release): dry-run validation mode for iOS + Android release workflows

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -19,6 +19,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build + sign the release AAB and validate it, but do NOT upload to Google Play (release-readiness check only)."
+        type: boolean
+        default: true
 
 concurrency:
   group: release-android-${{ github.ref }}
@@ -84,7 +89,29 @@ jobs:
       - name: Build signed release bundle
         run: ./gradlew :androidApp:bundleRelease
 
+      # Validate the signed artifact: prove it is production-signed by printing
+      # the signing cert's PUBLIC SHA-256 fingerprint (never the private key),
+      # and confirm the JAR/upload signature verifies. Uses only JDK tools.
+      - name: Validate signed AAB
+        run: |
+          set -euo pipefail
+          AAB=androidApp/build/outputs/bundle/release/androidApp-release.aab
+          echo "AAB size: $(du -h "$AAB" | cut -f1)"
+          echo "== signature verification =="
+          jarsigner -verify "$AAB" | head -1
+          echo "== signing certificate (public fingerprint) =="
+          keytool -printcert -jarfile "$AAB" 2>&1 | grep -iE "Owner:|SHA256:" | head -4
+
+      - name: Upload signed AAB (artifact)
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-aab
+          path: androidApp/build/outputs/bundle/release/androidApp-release.aab
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Upload to Google Play (internal track)
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -31,10 +31,21 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate the signed IPA against App Store Connect but do NOT upload to TestFlight (release-readiness check only)."
+        type: boolean
+        default: true
 
 concurrency:
   group: release-ios-${{ github.ref }}
   cancel-in-progress: false
+
+# A tag push always releases (upload to TestFlight). A manual run defaults to a
+# dry run: it signs, exports, and validates the IPA, and keeps it as an
+# artifact, but never uploads. Set dry_run=false on a manual run to also upload.
+env:
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
 
 jobs:
   ci:
@@ -186,14 +197,33 @@ jobs:
             fi
           }
 
+          # App Store Connect validation always runs (read-only pre-flight: it
+          # checks the signed IPA against the store's rules without creating a
+          # build or publishing anything).
           xcrun altool --validate-app -f "$IPA" -t ios \
             --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID" 2>&1 | tee "$RUNNER_TEMP/altool-validate.log"
           check_altool "$RUNNER_TEMP/altool-validate.log"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN: signed IPA built + App Store validation passed; skipping the TestFlight upload."
+            exit 0
+          fi
 
           xcrun altool --upload-app -f "$IPA" -t ios \
             --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID" 2>&1 | tee "$RUNNER_TEMP/altool-upload.log"
           check_altool "$RUNNER_TEMP/altool-upload.log"
           echo "Verified delivery to App Store Connect / TestFlight."
+
+      - name: Upload signed IPA + validation log (artifact)
+        if: ${{ env.IOS_DIST_CERT_P12_BASE64 != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-signed-ipa
+          path: |
+            ${{ runner.temp }}/export/*.ipa
+            ${{ runner.temp }}/altool-validate.log
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Clean up secrets from the runner
         if: always()


### PR DESCRIPTION
Adds a **`dry_run`** input (default **true** for manual `workflow_dispatch`) to both release workflows so release-readiness can be proven **without publishing**:

- **iOS**: archive → export the **production-signed IPA** → `altool --validate-app` (read-only App Store Connect pre-flight, no build created) → keep the IPA + validation log as a CI artifact. `--upload-app` to TestFlight is skipped unless `DRY_RUN=false`.
- **Android**: `bundleRelease` with the **real upload keystore** → verify the JAR/upload signature + print the signing cert's public SHA-256 → keep the AAB as a CI artifact. The Google Play upload is skipped unless `dry_run=false`.

**Tag pushes (`v*`) are unchanged** — they always publish. Only a manual dispatch defaults to the non-publishing dry run.

This is the mechanism to obtain `SIGNED IPA VERIFIED` + `APP STORE VALIDATION VERIFIED` (iOS) and `PRODUCTION-SIGNED AAB VERIFIED` (Android) as CI evidence, without an outward-facing release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)