### PR TITLE
Server projector: fix Peania-Kantza/Koropi phantom rows + unify rounding (parity #9)

### DIFF
--- a/ops/syrmos-api/syrmos_admin/projector.py
+++ b/ops/syrmos-api/syrmos_admin/projector.py
@@ -29,10 +29,25 @@ mirror the change OR be deleted in favour of always calling the API.
 """
 from __future__ import annotations
 
+import math
 import sqlite3
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 from typing import Iterable
+
+
+def _round_half_up(x: float) -> int:
+    """Round a slot minute to the nearest whole minute, half up.
+
+    Python's built-in round() is banker's rounding (half to even), but all three
+    clients round half up: iOS Int(x.rounded()), Kotlin roundToInt() and JS
+    Math.round() are all floor(x + 0.5). Athens metro headways include exact
+    half-integers (7.5, 8.5, 9.5, 12.5 ...), so every odd slot lands on x.5;
+    banker's rounding on the server therefore disagreed with the clients by one
+    minute on ~half of those slots. Match the clients so a rider sees the same
+    time on every platform.
+    """
+    return math.floor(x + 0.5)
 
 # Athens timezone, fixed UTC+2/+3 with DST. Use zoneinfo from stdlib.
 try:
@@ -41,7 +56,14 @@ try:
 except ImportError:  # very old Python; should never happen on the Pi
     ATHENS = timezone(timedelta(hours=2))
 
-LINE3_AIRPORT_ONLY_STATIONS = {"M3_PAL", "M3_PEK", "M3_KRP", "M3_AER"}
+# Peania-Kantza (M3_PEA) and Koropi (M3_KO2) are on the airport branch only, so
+# a city-bound (Doukissis Plakentias) train never reaches them. The ids must
+# match the seed/clients exactly; the earlier M3_PEK/M3_KRP were typos that do
+# not exist in the data, so the guard silently failed and the server emitted
+# phantom "towards Doukissis Plakentias" rows at those two stations that iOS
+# (which uses the correct ids) never showed. See ScheduleProjector.swift /
+# ComputeDeparturesFromBandsUseCase.kt / web-map.js for the canonical set.
+LINE3_AIRPORT_ONLY_STATIONS = {"M3_PAL", "M3_PEA", "M3_KO2", "M3_AER"}
 NEXT_DAY_EXTENSION_CUTOFF_MIN = 5 * 60   # bands < 05:00 count as next-day extension
 AIRPORT_LOOKAHEAD_DAYS = 7
 
@@ -610,7 +632,7 @@ def _project_band(
 
     added = 0
     while slot <= end and added < limit:
-        slot_min = int(round(slot)) + offset
+        slot_min = _round_half_up(slot) + offset
         display_min = ((slot_min % (24 * 60)) + 24 * 60) % (24 * 60)
         time_str = f"{display_min // 60:02d}:{display_min % 60:02d}"
         minutes_away = max(0, slot_min - now_minutes)
@@ -1089,7 +1111,7 @@ def _next_airport_lookahead(
                 while slot + offset < now_minutes:
                     slot += headway
             if slot <= end:
-                total_minutes = int(round(slot)) + offset + day_offset * 24 * 60
+                total_minutes = _round_half_up(slot) + offset + day_offset * 24 * 60
                 display_min = ((total_minutes % (24 * 60)) + 24 * 60) % (24 * 60)
                 time_str = f"{display_min // 60:02d}:{display_min % 60:02d}"
                 minutes_away = max(0, total_minutes - now_minutes)

--- a/ops/syrmos-api/tests/test_projector.py
+++ b/ops/syrmos-api/tests/test_projector.py
@@ -2,7 +2,50 @@ import sqlite3
 import unittest
 from datetime import datetime
 
-from syrmos_admin.projector import ATHENS, active_trains, project_next_departures
+from syrmos_admin.projector import (
+    ATHENS,
+    active_trains,
+    project_next_departures,
+    _expand_line_ids,
+    _round_half_up,
+)
+
+
+class Line3AirportOnlyStationsTest(unittest.TestCase):
+    """Parity #9: Peania-Kantza (M3_PEA) and Koropi (M3_KO2) are on the airport
+    branch only, so a query there must NOT project city M3 service (which would
+    show phantom 'towards Doukissis Plakentias' rows the clients never show)."""
+
+    def test_airport_only_station_gets_airport_service_only(self):
+        for sid in ("M3_PEA", "M3_KO2", "M3_PAL", "M3_AER"):
+            self.assertEqual(_expand_line_ids(sid, ["M3"]), ["M3_AIR"], sid)
+
+    def test_city_station_gets_both_city_and_airport(self):
+        self.assertEqual(_expand_line_ids("M3_SYN", ["M3"]), ["M3", "M3_AIR"])
+
+    def test_typoed_ids_are_gone(self):
+        # The old typos (M3_PEK / M3_KRP) do not exist in the data; if they crept
+        # back, the real station ids would wrongly get city service again.
+        from syrmos_admin.projector import LINE3_AIRPORT_ONLY_STATIONS as S
+        self.assertNotIn("M3_PEK", S)
+        self.assertNotIn("M3_KRP", S)
+        self.assertEqual(S, {"M3_PAL", "M3_PEA", "M3_KO2", "M3_AER"})
+
+
+class RoundHalfUpTest(unittest.TestCase):
+    """Parity #9: the server must round slots half up to match all three clients
+    (iOS Int(rounded()), Kotlin roundToInt(), JS Math.round()), not banker's."""
+
+    def test_half_rounds_up_not_to_even(self):
+        # 382.5 -> 383 (half up), NOT 382 (banker's would pick the even 382).
+        self.assertEqual(_round_half_up(382.5), 383)
+        self.assertEqual(_round_half_up(383.5), 384)  # banker's would also give 384 here
+        self.assertEqual(_round_half_up(0.5), 1)
+
+    def test_non_half_values_round_to_nearest(self):
+        self.assertEqual(_round_half_up(382.4), 382)
+        self.assertEqual(_round_half_up(382.6), 383)
+        self.assertEqual(_round_half_up(382.0), 382)
 
 
 def make_conn() -> sqlite3.Connection:


### PR DESCRIPTION
The deep user-visible-parity analysis of #9 found two ways a rider sees **different departures** on Android/Web (server-first) than on iOS (local-first):

1. **HARD, rider-facing — phantom rows.** `LINE3_AIRPORT_ONLY_STATIONS` used ids `M3_PEK`/`M3_KRP` that **do not exist**; the real airport-branch stations are `M3_PEA` (Peania-Kantza) and `M3_KO2` (Koropi), which all three clients already use. So the server's airport-only guard silently failed there, `_expand_line_ids` kept regular M3 city service, and the endpoint emitted phantom ~5-min *"towards Doukissis Plakentias"* rows for trains that never reach those stations. Android/Web showed them; iOS didn't. Fixed the ids to match the seed/clients.
2. **SOFT — rounding.** The server used Python's banker's `round()`; all three clients round **half up** (`floor(x+0.5)`). Athens metro headways are half-integers (7.5, 8.5, 9.5, 12.5 …), so the server disagreed with the clients by 1 minute on ~half of those slots. Added `_round_half_up` and used it at the two departure-display sites.

## Tests
5 new cases (airport-only expansion for M3_PEA/M3_KO2, city station gets both, typos gone, half-up rounding). Projector suite **23/23**; server suite green.

**Deploy note**: server-side, takes effect on the next Pi deploy (same path as #12). Verified locally that production currently exhibits the pre-fix behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)