### PR TITLE
Add in-app Privacy Policy links (iOS/Android/web)

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -1068,8 +1068,11 @@
     function renderInfoLinksPanel(payload) {
         if (!infoLinksList) return;
         const links = (payload && payload.infoLinks) || [];
+        // Always expose the privacy policy here (the footer "more" utility jumps
+        // to this list), independent of the server-provided operator links.
+        const privacyLink = `<a class="info-link__privacy" href="/privacy" rel="noopener" style="display:inline-block;margin-top:8px;font-size:13px;">Privacy Policy</a>`;
         if (!links.length) {
-            infoLinksList.innerHTML = "";
+            infoLinksList.innerHTML = privacyLink;
             return;
         }
         infoLinksList.innerHTML = links.map((link) => {
@@ -1091,7 +1094,7 @@
                     <a class="info-link__verify" href="${escapeAttr(localisedUrl)}" target="_blank" rel="noopener">${escapeHtml(t("verify_on", { op }))}</a>
                 </article>
             `;
-        }).join("");
+        }).join("") + privacyLink;
     }
 
     // Re-render fares + info links when the language flips, using the

--- a/feature/settings/src/commonMain/kotlin/com/syrmos/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/syrmos/feature/settings/SettingsScreen.kt
@@ -520,6 +520,18 @@ fun SettingsScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(16.dp),
                 )
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
+                SettingsRow(
+                    title = when (lang) {
+                        AppLanguage.GREEK -> "Πολιτικη απορρητου"
+                        AppLanguage.ALBANIAN -> "Politika e privatesise"
+                        AppLanguage.ITALIAN -> "Informativa sulla privacy"
+                        else -> "Privacy Policy"
+                    },
+                    value = "",
+                    onClick = { uriHandler.openUri("https://syrmos.peterdsp.dev/privacy") },
+                    interactive = true,
+                )
             }
         }
 

--- a/iosApp/iosApp/Views/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Views/Settings/SettingsView.swift
@@ -380,6 +380,17 @@ struct SyrmosSettingsView: View {
             Text(loc[.aboutText])
                 .font(.footnote)
                 .foregroundStyle(.secondary)
+            if let url = URL(string: "https://syrmos.peterdsp.dev/privacy") {
+                Link(destination: url) {
+                    Label(
+                        loc.language == .greek ? "Πολιτικη απορρητου"
+                            : loc.language == .albanian ? "Politika e privatesise"
+                            : loc.language == .italian ? "Informativa sulla privacy"
+                            : "Privacy Policy",
+                        systemImage: "hand.raised.fill"
+                    )
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Both stores expect an accessible **in-app** privacy-policy link. Adds a "Privacy Policy" entry opening `https://syrmos.peterdsp.dev/privacy`:
- **Android**: Settings › About row (localized EN/EL/SQ/IT).
- **iOS**: Settings › About Link (localized).
- **Web**: persistent link in the footer info-links list (the "more" utility target).

Points at the /privacy page (PR #92). Android `assembleDebug` green. Merge after #92 so the link is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)