### PR TITLE
web: privacy-link polish + drop dead hls.js CDN egress

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -530,7 +530,6 @@
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin=""
 ></script>
-<script src="https://cdn.jsdelivr.net/npm/hls.js@1/dist/hls.min.js"></script>
 <script src="/web-ariadne-rag.js"></script>
 <script src="/web-ariadne.js"></script>
 <script src="/llm/ariadne-wllama.js?v=3"></script>

--- a/composeApp/src/wasmJsMain/resources/web-map.css
+++ b/composeApp/src/wasmJsMain/resources/web-map.css
@@ -1209,6 +1209,17 @@ body.dark-mode .live-status-pill {
     text-decoration: none;
 }
 .info-link__verify:hover { text-decoration: underline; }
+.info-link__privacy {
+    display: inline-block;
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--sy-border, rgba(255,255,255,0.08));
+    width: 100%;
+    font-size: 12px; font-weight: 500;
+    color: var(--sy-accent);
+    text-decoration: none;
+}
+.info-link__privacy:hover { text-decoration: underline; }
 
 /* ===== Telemetry Grid ===== */
 .telemetry-grid {

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -99,6 +99,7 @@
             open_details: "Open details",
             reduced: "Reduced",
             verify_on: "Verify on {op} ↗",
+            privacy_policy: "Privacy Policy",
             ask_ariadne: "Ask Ariadne",
             ariadne_title: "Ariadne",
             ariadne_placeholder: "Ask Ariadne...",
@@ -193,6 +194,7 @@
             open_details: "Άνοιγμα λεπτομερειών",
             reduced: "Μειωμένο",
             verify_on: "Επιβεβαίωση στο {op} ↗",
+            privacy_policy: "Πολιτική απορρήτου",
             ask_ariadne: "Ρώτα την Αριάδνη",
             ariadne_title: "Αριάδνη",
             ariadne_placeholder: "Ρώτα την Αριάδνη...",
@@ -287,6 +289,7 @@
             open_details: "Hap detajet",
             reduced: "Me zbritje",
             verify_on: "Verifiko në {op} ↗",
+            privacy_policy: "Politika e privatësisë",
             ask_ariadne: "Pyet Ariadnen",
             ariadne_title: "Ariadne",
             ariadne_placeholder: "Pyet Ariadnen...",
@@ -381,6 +384,7 @@
             open_details: "Apri i dettagli",
             reduced: "Ridotto",
             verify_on: "Verifica su {op} ↗",
+            privacy_policy: "Informativa sulla privacy",
             ask_ariadne: "Chiedi ad Ariadne",
             ariadne_title: "Ariadne",
             ariadne_placeholder: "Chiedi ad Ariadne...",
@@ -1070,7 +1074,7 @@
         const links = (payload && payload.infoLinks) || [];
         // Always expose the privacy policy here (the footer "more" utility jumps
         // to this list), independent of the server-provided operator links.
-        const privacyLink = `<a class="info-link__privacy" href="/privacy" rel="noopener" style="display:inline-block;margin-top:8px;font-size:13px;">Privacy Policy</a>`;
+        const privacyLink = `<a class="info-link__privacy" href="/privacy" rel="noopener">${escapeHtml(t("privacy_policy"))}</a>`;
         if (!links.length) {
             infoLinksList.innerHTML = privacyLink;
             return;


### PR DESCRIPTION
Follow-up polish on the persistent Privacy Policy link added to the web map info panel.

Two defects found during the post-deploy runtime QA of the live page:
1. **Styling** — the link used class `info-link__privacy`, which had no CSS rule, so it fell back to the browser default (blue `rgb(0,0,238)`, underlined) inside the dark, light-text info panel. Every sibling operator link uses `.info-link`/`.info-link__verify` (accent color, no underline). Added a `.info-link__privacy` rule matching the verify-link accent style, with a subtle top divider since it is the panel's footer utility.
2. **Localization** — the label was hardcoded English `"Privacy Policy"` while the surrounding panel is fully localized. Routed it through `t("privacy_policy")` with a new key in all four language tables (EN/EL/SQ/IT); it re-renders on language flip via the existing `onLanguageChange` hook.

Verified: `node --check` passes, all four keys present, `t()` handles the no-vars call and falls back to EN then the key name. `/privacy` itself is already live (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)