### PR TITLE
ops: deploy.sh must not --delete Pi-generated OSM line-geometry

### DIFF
--- a/ops/syrmos-api/deploy.sh
+++ b/ops/syrmos-api/deploy.sh
@@ -26,9 +26,15 @@ ssh "$PI" "mkdir -p $REMOTE_HOME/assets/icons"
 rsync -avz --delete \
   "$REPO_ROOT/assets/athens-transit-package/icons"/ "$PI:$REMOTE_HOME/assets/icons"/
 
-echo ">>> syncing OSM line-geometry to $PI"
+echo ">>> syncing OSM line-geometry to $PI (no --delete: preserve scraper output)"
+# NOTE: no --delete here. The Pi's weekly OSM refresh (refresh_osm_shapes.py)
+# generates geometry for lines that are NOT committed to the repo (the non-Athens
+# lines TM1/TM2/AL1/PS1/DK1). A mirroring --delete would wipe those on every
+# deploy, 404-ing them until the next weekly refresh (and a deploy landing during
+# an Overpass outage would leave them missing for a while). We only push/refresh
+# the committed geometry and leave the scraper's extra files in place.
 ssh "$PI" "mkdir -p $REMOTE_HOME/assets/line-geometry"
-rsync -avz --delete \
+rsync -avz \
   "$REPO_ROOT/assets/line-geometry"/ "$PI:$REMOTE_HOME/assets/line-geometry"/
 
 echo ">>> installing venv + deps"


### PR DESCRIPTION
The `assets/line-geometry` rsync in `deploy.sh` used `--delete`, which mirrors the repo's committed geometry onto the Pi. But the Pi's weekly OSM refresh (`refresh_osm_shapes.py`) generates geometry for lines that are **not** committed to the repo (TM1, TM2, AL1, PS1, DK1). `--delete` wiped those on every deploy, 404-ing `/line-geometry/{line}.geojson` until the next weekly refresh.

Observed live during the 2.0.0 backend deploy: all five files were deleted, and the immediate OSM re-run hit an Overpass `504 Gateway Timeout`; a retry regenerated them. This change drops `--delete` for the line-geometry sync so a deploy never removes scraper-owned geometry. The code rsync keeps `--delete`; only this scraper-owned asset dir changes.

Deploy tooling only; no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)