### PR TITLE
feat(go): GO trip-guidance engine (web + server) + cross-client contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ The long-range product roadmap by version (1.1 through 2.0, with quarterly targe
 
 Product direction: Syrmos is a companion, not a schedule. Every feature is measured against the answer-first / proactive / reassuring / low-decision rules in [docs/PRODUCT_PRINCIPLES.md](docs/PRODUCT_PRINCIPLES.md).
 
+## Unreleased - 3.0.0 "Journeys"
+
+Direction defined in [docs/plans/3.0-JOURNEYS.md](docs/plans/3.0-JOURNEYS.md): evolve Syrmos from a
+next-departure companion into an end-to-end journey companion (plan A to B, journey confidence and
+last-train-home, and GO live trip guidance that tells you board / ride / get off next / change here without
+opening the app). Landing incrementally behind the 3.0 beta train.
+
+- **GO trip-guidance engine (core).** The pure, offline, deterministic core of GO live guidance: given a
+  planned journey (legs of ordered stops) and the rider's current stop, it returns the one instruction that
+  matters now (board, ride, get off next, transfer, arrived) and a single get-off-alert predicate. Shipped as
+  implementations kept in lockstep by one cross-client golden contract
+  (`fixtures/go-guidance/cases.json`). The web (`web-go.js`) and server (`go_guidance.py`) engines land
+  first, gated in CI (14 web `node:test`, 16 backend `pytest`); the iOS (Swift) and Android/KMP (Kotlin)
+  ports follow against the same fixtures. Not yet wired into any client UI (feature-flag-dormant).
+- **Test + release engineering.** Backend API tests (139) now run as a CI gate; a zero-dependency web JS test
+  harness gates the web client (guardrails for shipped-and-fixed bug classes + a bundled-seed contract).
+
 ## 2.0.0 - 2026-09-02
 
 The 2.0.0 general release: the culmination of the 2.0.0-beta.1 through beta.23 line (capsule vehicle markers, the three-column web redesign, anonymous Ichnos community history, the multi-airport hub, the Ariadne assistant with an async cloud provider chain, and proximity-based station interchanges), promoted to production after a full cross-platform QA and parity hardening pass.

--- a/composeApp/src/wasmJsMain/resources/web-go.js
+++ b/composeApp/src/wasmJsMain/resources/web-go.js
@@ -1,0 +1,120 @@
+'use strict';
+// Syrmos GO — the live trip-guidance engine (web reference implementation).
+//
+// GO is the 3.0 "Journeys" spine: once a rider is on a planned journey, tell them
+// the one thing that matters right now — board, ride, get off next, change here,
+// arrived — so they never have to watch for their stop. This module is the pure,
+// deterministic core: no DOM, no network, no clock. It works fully offline from a
+// journey's static stop sequence (live positions only advance `position` faster).
+//
+// It is the reference for the cross-client contract in fixtures/go-guidance/. The
+// iOS (Swift), Android/KMP (Kotlin) and web implementations must all satisfy the
+// same fixtures so GO guidance cannot drift between platforms.
+//
+// A journey is { legs: [ { lineId, towards, stops: [ {id, name}, ... ] } ] } where
+// each leg's `stops` are ordered from its board stop to its alight stop inclusive,
+// and `towards` is the direction/terminal shown to the rider. A position is
+// { legIndex, stopIndex }: the rider is currently AT legs[legIndex].stops[stopIndex].
+//
+// UMD: usable as `require('./web-go.js')` in node and as `window.SyrmosGO` in the
+// browser.
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.SyrmosGO = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  // Guidance step kinds.
+  const BOARD = 'board';       // at a leg's first stop: get on this line
+  const RIDE = 'ride';         // mid-leg: stay on, N stops to go
+  const GET_OFF_NEXT = 'getOffNext'; // one stop before this leg's alight point
+  const TRANSFER = 'transfer'; // at a leg's alight stop with another leg to come
+  const ARRIVED = 'arrived';   // at the destination
+
+  function leg(journey, i) {
+    return journey && journey.legs ? journey.legs[i] : undefined;
+  }
+
+  // The rider-facing instruction for the current position. Pure and total: an
+  // out-of-range position throws, since that is a caller bug, not a rider state.
+  function guidance(journey, position) {
+    const l = leg(journey, position.legIndex);
+    if (!l) throw new RangeError('legIndex out of range');
+    const stops = l.stops;
+    if (position.stopIndex < 0 || position.stopIndex >= stops.length) {
+      throw new RangeError('stopIndex out of range');
+    }
+    const lastLeg = position.legIndex === journey.legs.length - 1;
+    const lastStop = stops.length - 1;
+    const remaining = lastStop - position.stopIndex; // stops left on this leg
+    const here = stops[position.stopIndex];
+
+    // Destination reached.
+    if (lastLeg && remaining === 0) return { kind: ARRIVED, station: here.name };
+
+    // Alight point of a non-final leg: change to the next line.
+    if (remaining === 0) {
+      const next = journey.legs[position.legIndex + 1];
+      return { kind: TRANSFER, atStation: here.name, toLineId: next.lineId, towards: next.towards };
+    }
+
+    // First stop of a leg: board this line. (For a 2-stop leg this coincides with
+    // being one stop from the alight; the display says "board", and
+    // shouldAlertGetOff still returns true so the get-off alert is not missed.)
+    if (position.stopIndex === 0) {
+      return {
+        kind: BOARD, lineId: l.lineId, towards: l.towards,
+        stopsRemaining: remaining, nextStation: stops[1].name,
+      };
+    }
+
+    // One stop before the alight point: tell the rider to get off next.
+    if (remaining === 1) {
+      const next = lastLeg ? null : journey.legs[position.legIndex + 1];
+      return {
+        kind: GET_OFF_NEXT,
+        nextStation: stops[lastStop].name,
+        isDestination: lastLeg,
+        transferTo: next ? next.lineId : null,
+      };
+    }
+
+    // Mid-leg: stay on.
+    return {
+      kind: RIDE, lineId: l.lineId, towards: l.towards,
+      stopsRemaining: remaining, nextStation: stops[position.stopIndex + 1].name,
+    };
+  }
+
+  // Whether a get-off notification should fire now: the rider is exactly one stop
+  // from a leg's alight point (works even on a 2-stop leg, where it coincides with
+  // boarding). This is the single most-valued transit alert; keep it independent
+  // of the display `kind` so a UI can drive the notification off one predicate.
+  function shouldAlertGetOff(journey, position) {
+    const l = leg(journey, position.legIndex);
+    if (!l) return false;
+    const remaining = l.stops.length - 1 - position.stopIndex;
+    return remaining === 1;
+  }
+
+  // Advance the position by one stop, rolling from a leg's alight stop onto the
+  // next leg's board stop. Returns a new position; returns the same position when
+  // already at the destination.
+  function advance(journey, position) {
+    const l = leg(journey, position.legIndex);
+    if (!l) throw new RangeError('legIndex out of range');
+    const lastLeg = position.legIndex === journey.legs.length - 1;
+    const atLegEnd = position.stopIndex >= l.stops.length - 1;
+    if (atLegEnd) {
+      if (lastLeg) return { legIndex: position.legIndex, stopIndex: position.stopIndex };
+      return { legIndex: position.legIndex + 1, stopIndex: 0 };
+    }
+    return { legIndex: position.legIndex, stopIndex: position.stopIndex + 1 };
+  }
+
+  function isArrived(journey, position) {
+    const lastLeg = position.legIndex === journey.legs.length - 1;
+    const l = leg(journey, position.legIndex);
+    return Boolean(lastLeg && l && position.stopIndex === l.stops.length - 1);
+  }
+
+  return { guidance, shouldAlertGetOff, advance, isArrived, KIND: { BOARD, RIDE, GET_OFF_NEXT, TRANSFER, ARRIVED } };
+});

--- a/composeApp/src/wasmJsMain/resources/web-go.js
+++ b/composeApp/src/wasmJsMain/resources/web-go.js
@@ -88,6 +88,12 @@
   // from a leg's alight point (works even on a 2-stop leg, where it coincides with
   // boarding). This is the single most-valued transit alert; keep it independent
   // of the display `kind` so a UI can drive the notification off one predicate.
+  //
+  // Consumer note: on a 2-stop leg the guidance kind stays `board` while this is
+  // already true (board + alert), because after boarding the very next stop is the
+  // alight. A consumer that dedupes get-off alerts must key the dedupe on the leg's
+  // alight stop, not on the guidance `kind` becoming `getOffNext` (which never
+  // happens on a 2-stop leg) — otherwise it would drop the rider's only get-off cue.
   function shouldAlertGetOff(journey, position) {
     const l = leg(journey, position.legIndex);
     if (!l) return false;

--- a/fixtures/go-guidance/cases.json
+++ b/fixtures/go-guidance/cases.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "description": "Cross-client golden contract for Syrmos GO live trip guidance (3.0 Journeys). Every client implementation (web JS web-go.js, iOS Swift, Android/KMP Kotlin) must produce the same guidance step and get-off-alert decision for each case. A journey is { legs: [ { lineId, towards, stops: [ {id, name} ] } ] }; a position is { legIndex, stopIndex } meaning the rider is AT legs[legIndex].stops[stopIndex]. Guidance kinds: board | ride | getOffNext | transfer | arrived. `alert` is whether a get-off notification should fire now (rider one stop from a leg's alight point).",
+  "description": "Cross-client golden contract for Syrmos GO live trip guidance (3.0 Journeys). Every client engine (web/iOS/Android/server) must produce the EXACT guidance object and get-off-alert decision for each case. A journey is { legs: [ { lineId, towards, stops: [ {id, name} ] } ] }; a position is { legIndex, stopIndex } meaning the rider is AT legs[legIndex].stops[stopIndex]. Guidance kinds: board | ride | getOffNext | transfer | arrived. `alert` is whether a get-off notification should fire now (rider one stop from a leg's alight point). `expect` is the FULL guidance object; tests assert exact equality, not a subset. Note the 2-stop leg (m1_hop_2): its only alert-capable state coincides with `board` (board + alert:true) because after boarding the very next stop is the alight; a consumer must not dedupe that away, it is the rider's one and only get-off cue for that leg.",
   "journeys": {
     "m2_direct_3": {
       "legs": [
@@ -52,18 +52,18 @@
     }
   },
   "cases": [
-    { "name": "direct: at origin -> board", "journey": "m2_direct_3", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M2", "towards": "Anthoupoli" }, "alert": false },
+    { "name": "direct: at origin -> board", "journey": "m2_direct_3", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M2", "towards": "Anthoupoli", "stopsRemaining": 2, "nextStation": "Panepistimio" }, "alert": false },
     { "name": "direct: one before destination -> get off next + alert", "journey": "m2_direct_3", "position": { "legIndex": 0, "stopIndex": 1 }, "expect": { "kind": "getOffNext", "nextStation": "Omonia", "isDestination": true, "transferTo": null }, "alert": true },
     { "name": "direct: at destination -> arrived", "journey": "m2_direct_3", "position": { "legIndex": 0, "stopIndex": 2 }, "expect": { "kind": "arrived", "station": "Omonia" }, "alert": false },
 
-    { "name": "2-stop hop: board coincides with alert", "journey": "m1_hop_2", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M1", "towards": "Kifisia" }, "alert": true },
+    { "name": "2-stop hop: board coincides with alert", "journey": "m1_hop_2", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M1", "towards": "Kifisia", "stopsRemaining": 1, "nextStation": "Attiki" }, "alert": true },
     { "name": "2-stop hop: arrived", "journey": "m1_hop_2", "position": { "legIndex": 0, "stopIndex": 1 }, "expect": { "kind": "arrived", "station": "Attiki" }, "alert": false },
 
-    { "name": "transfer: at origin -> board leg 1", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M2", "towards": "Elliniko" }, "alert": false },
-    { "name": "transfer: mid leg 1 -> ride", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 1 }, "expect": { "kind": "ride", "lineId": "M2", "stopsRemaining": 2, "nextStation": "Omonia" }, "alert": false },
+    { "name": "transfer: at origin -> board leg 1", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M2", "towards": "Elliniko", "stopsRemaining": 3, "nextStation": "Metaxourgeio" }, "alert": false },
+    { "name": "transfer: mid leg 1 -> ride", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 1 }, "expect": { "kind": "ride", "lineId": "M2", "towards": "Elliniko", "stopsRemaining": 2, "nextStation": "Omonia" }, "alert": false },
     { "name": "transfer: one before interchange -> get off next, transfer to M3", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 2 }, "expect": { "kind": "getOffNext", "nextStation": "Syntagma", "isDestination": false, "transferTo": "M3" }, "alert": true },
     { "name": "transfer: at interchange -> transfer", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 3 }, "expect": { "kind": "transfer", "atStation": "Syntagma", "toLineId": "M3", "towards": "Airport" }, "alert": false },
-    { "name": "transfer: board leg 2", "journey": "m2_m3_transfer", "position": { "legIndex": 1, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M3", "towards": "Airport" }, "alert": false },
+    { "name": "transfer: board leg 2", "journey": "m2_m3_transfer", "position": { "legIndex": 1, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M3", "towards": "Airport", "stopsRemaining": 2, "nextStation": "Evangelismos" }, "alert": false },
     { "name": "transfer: one before destination on leg 2 -> get off next", "journey": "m2_m3_transfer", "position": { "legIndex": 1, "stopIndex": 1 }, "expect": { "kind": "getOffNext", "nextStation": "Megaro Moussikis", "isDestination": true, "transferTo": null }, "alert": true },
     { "name": "transfer: arrived on leg 2", "journey": "m2_m3_transfer", "position": { "legIndex": 1, "stopIndex": 2 }, "expect": { "kind": "arrived", "station": "Megaro Moussikis" }, "alert": false }
   ]

--- a/fixtures/go-guidance/cases.json
+++ b/fixtures/go-guidance/cases.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "description": "Cross-client golden contract for Syrmos GO live trip guidance (3.0 Journeys). Every client implementation (web JS web-go.js, iOS Swift, Android/KMP Kotlin) must produce the same guidance step and get-off-alert decision for each case. A journey is { legs: [ { lineId, towards, stops: [ {id, name} ] } ] }; a position is { legIndex, stopIndex } meaning the rider is AT legs[legIndex].stops[stopIndex]. Guidance kinds: board | ride | getOffNext | transfer | arrived. `alert` is whether a get-off notification should fire now (rider one stop from a leg's alight point).",
+  "journeys": {
+    "m2_direct_3": {
+      "legs": [
+        {
+          "lineId": "M2",
+          "towards": "Anthoupoli",
+          "stops": [
+            { "id": "M2_SYN", "name": "Syntagma" },
+            { "id": "M2_PAN", "name": "Panepistimio" },
+            { "id": "M2_OMO", "name": "Omonia" }
+          ]
+        }
+      ]
+    },
+    "m1_hop_2": {
+      "legs": [
+        {
+          "lineId": "M1",
+          "towards": "Kifisia",
+          "stops": [
+            { "id": "M1_VIC", "name": "Victoria" },
+            { "id": "M1_ATT", "name": "Attiki" }
+          ]
+        }
+      ]
+    },
+    "m2_m3_transfer": {
+      "legs": [
+        {
+          "lineId": "M2",
+          "towards": "Elliniko",
+          "stops": [
+            { "id": "M2_LAR", "name": "Larissa Station" },
+            { "id": "M2_MET", "name": "Metaxourgeio" },
+            { "id": "M2_OMO", "name": "Omonia" },
+            { "id": "M2_SYN", "name": "Syntagma" }
+          ]
+        },
+        {
+          "lineId": "M3",
+          "towards": "Airport",
+          "stops": [
+            { "id": "M3_SYN", "name": "Syntagma" },
+            { "id": "M3_EVA", "name": "Evangelismos" },
+            { "id": "M3_MEG", "name": "Megaro Moussikis" }
+          ]
+        }
+      ]
+    }
+  },
+  "cases": [
+    { "name": "direct: at origin -> board", "journey": "m2_direct_3", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M2", "towards": "Anthoupoli" }, "alert": false },
+    { "name": "direct: one before destination -> get off next + alert", "journey": "m2_direct_3", "position": { "legIndex": 0, "stopIndex": 1 }, "expect": { "kind": "getOffNext", "nextStation": "Omonia", "isDestination": true, "transferTo": null }, "alert": true },
+    { "name": "direct: at destination -> arrived", "journey": "m2_direct_3", "position": { "legIndex": 0, "stopIndex": 2 }, "expect": { "kind": "arrived", "station": "Omonia" }, "alert": false },
+
+    { "name": "2-stop hop: board coincides with alert", "journey": "m1_hop_2", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M1", "towards": "Kifisia" }, "alert": true },
+    { "name": "2-stop hop: arrived", "journey": "m1_hop_2", "position": { "legIndex": 0, "stopIndex": 1 }, "expect": { "kind": "arrived", "station": "Attiki" }, "alert": false },
+
+    { "name": "transfer: at origin -> board leg 1", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M2", "towards": "Elliniko" }, "alert": false },
+    { "name": "transfer: mid leg 1 -> ride", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 1 }, "expect": { "kind": "ride", "lineId": "M2", "stopsRemaining": 2, "nextStation": "Omonia" }, "alert": false },
+    { "name": "transfer: one before interchange -> get off next, transfer to M3", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 2 }, "expect": { "kind": "getOffNext", "nextStation": "Syntagma", "isDestination": false, "transferTo": "M3" }, "alert": true },
+    { "name": "transfer: at interchange -> transfer", "journey": "m2_m3_transfer", "position": { "legIndex": 0, "stopIndex": 3 }, "expect": { "kind": "transfer", "atStation": "Syntagma", "toLineId": "M3", "towards": "Airport" }, "alert": false },
+    { "name": "transfer: board leg 2", "journey": "m2_m3_transfer", "position": { "legIndex": 1, "stopIndex": 0 }, "expect": { "kind": "board", "lineId": "M3", "towards": "Airport" }, "alert": false },
+    { "name": "transfer: one before destination on leg 2 -> get off next", "journey": "m2_m3_transfer", "position": { "legIndex": 1, "stopIndex": 1 }, "expect": { "kind": "getOffNext", "nextStation": "Megaro Moussikis", "isDestination": true, "transferTo": null }, "alert": true },
+    { "name": "transfer: arrived on leg 2", "journey": "m2_m3_transfer", "position": { "legIndex": 1, "stopIndex": 2 }, "expect": { "kind": "arrived", "station": "Megaro Moussikis" }, "alert": false }
+  ]
+}

--- a/ops/syrmos-api/syrmos_admin/go_guidance.py
+++ b/ops/syrmos-api/syrmos_admin/go_guidance.py
@@ -98,6 +98,12 @@ def should_alert_get_off(journey: Dict[str, Any], position: Dict[str, int]) -> b
     """Whether a get-off notification should fire now (rider one stop from a leg's
     alight point). Independent of the display kind so a caller can drive the push
     off one predicate; true even on a 2-stop leg where it coincides with boarding.
+
+    Consumer note: on a 2-stop leg the guidance kind stays ``board`` while this is
+    already true (board + alert), because after boarding the very next stop is the
+    alight. A consumer that dedupes get-off alerts must key the dedupe on the leg's
+    alight stop, not on the guidance kind becoming ``getOffNext`` (which never
+    happens on a 2-stop leg), or it would drop the rider's only get-off cue.
     """
     leg = _leg(journey, position["legIndex"])
     if leg is None:

--- a/ops/syrmos-api/syrmos_admin/go_guidance.py
+++ b/ops/syrmos-api/syrmos_admin/go_guidance.py
@@ -1,0 +1,127 @@
+"""Syrmos GO -- live trip-guidance engine (server reference implementation).
+
+GO is the 3.0 "Journeys" spine: once a rider is on a planned journey, tell them
+the one thing that matters right now -- board, ride, get off next, change here,
+arrived -- so they never have to watch for their stop. This module is the pure,
+deterministic core: no DB, no network, no clock. It works fully offline from a
+journey's static stop sequence; live positions only advance ``position`` faster.
+
+It mirrors the web reference (``web-go.js``) and is validated against the same
+cross-client contract in ``fixtures/go-guidance/cases.json`` so GO guidance cannot
+drift between the web, iOS, Android and server implementations.
+
+Server-side GO exists so the backend can drive proactive push updates (iOS
+push-to-start / broadcast Live Activities, Android 16 ProgressStyle Live Updates):
+given a tracked journey and the vehicle's current stop, the server computes the
+next guidance step and pushes it, without the app being open.
+
+A journey is ``{"legs": [{"lineId", "towards", "stops": [{"id", "name"}]}]}`` with
+each leg's ``stops`` ordered from board to alight inclusive. A position is
+``{"legIndex", "stopIndex"}``: the rider is AT ``legs[legIndex].stops[stopIndex]``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+BOARD = "board"
+RIDE = "ride"
+GET_OFF_NEXT = "getOffNext"
+TRANSFER = "transfer"
+ARRIVED = "arrived"
+
+
+def _leg(journey: Dict[str, Any], i: int) -> Optional[Dict[str, Any]]:
+    legs = journey.get("legs") or []
+    return legs[i] if 0 <= i < len(legs) else None
+
+
+def guidance(journey: Dict[str, Any], position: Dict[str, int]) -> Dict[str, Any]:
+    """Return the rider-facing instruction for ``position``.
+
+    Pure and total: an out-of-range position raises ``IndexError`` (a caller bug,
+    not a rider state).
+    """
+    leg_index = position["legIndex"]
+    stop_index = position["stopIndex"]
+    leg = _leg(journey, leg_index)
+    if leg is None:
+        raise IndexError("legIndex out of range")
+    stops = leg["stops"]
+    if stop_index < 0 or stop_index >= len(stops):
+        raise IndexError("stopIndex out of range")
+
+    last_leg = leg_index == len(journey["legs"]) - 1
+    last_stop = len(stops) - 1
+    remaining = last_stop - stop_index
+    here = stops[stop_index]
+
+    if last_leg and remaining == 0:
+        return {"kind": ARRIVED, "station": here["name"]}
+
+    if remaining == 0:
+        nxt = journey["legs"][leg_index + 1]
+        return {
+            "kind": TRANSFER,
+            "atStation": here["name"],
+            "toLineId": nxt["lineId"],
+            "towards": nxt["towards"],
+        }
+
+    if stop_index == 0:
+        return {
+            "kind": BOARD,
+            "lineId": leg["lineId"],
+            "towards": leg["towards"],
+            "stopsRemaining": remaining,
+            "nextStation": stops[1]["name"],
+        }
+
+    if remaining == 1:
+        nxt = None if last_leg else journey["legs"][leg_index + 1]
+        return {
+            "kind": GET_OFF_NEXT,
+            "nextStation": stops[last_stop]["name"],
+            "isDestination": last_leg,
+            "transferTo": nxt["lineId"] if nxt else None,
+        }
+
+    return {
+        "kind": RIDE,
+        "lineId": leg["lineId"],
+        "towards": leg["towards"],
+        "stopsRemaining": remaining,
+        "nextStation": stops[stop_index + 1]["name"],
+    }
+
+
+def should_alert_get_off(journey: Dict[str, Any], position: Dict[str, int]) -> bool:
+    """Whether a get-off notification should fire now (rider one stop from a leg's
+    alight point). Independent of the display kind so a caller can drive the push
+    off one predicate; true even on a 2-stop leg where it coincides with boarding.
+    """
+    leg = _leg(journey, position["legIndex"])
+    if leg is None:
+        return False
+    remaining = len(leg["stops"]) - 1 - position["stopIndex"]
+    return remaining == 1
+
+
+def advance(journey: Dict[str, Any], position: Dict[str, int]) -> Dict[str, int]:
+    """Advance one stop, rolling a leg's alight stop onto the next leg's board
+    stop. Returns the same position when already at the destination."""
+    leg = _leg(journey, position["legIndex"])
+    if leg is None:
+        raise IndexError("legIndex out of range")
+    last_leg = position["legIndex"] == len(journey["legs"]) - 1
+    at_leg_end = position["stopIndex"] >= len(leg["stops"]) - 1
+    if at_leg_end:
+        if last_leg:
+            return {"legIndex": position["legIndex"], "stopIndex": position["stopIndex"]}
+        return {"legIndex": position["legIndex"] + 1, "stopIndex": 0}
+    return {"legIndex": position["legIndex"], "stopIndex": position["stopIndex"] + 1}
+
+
+def is_arrived(journey: Dict[str, Any], position: Dict[str, int]) -> bool:
+    last_leg = position["legIndex"] == len(journey["legs"]) - 1
+    leg = _leg(journey, position["legIndex"])
+    return bool(last_leg and leg and position["stopIndex"] == len(leg["stops"]) - 1)

--- a/ops/syrmos-api/tests/test_go_guidance.py
+++ b/ops/syrmos-api/tests/test_go_guidance.py
@@ -1,0 +1,54 @@
+"""Validates the server GO engine against the cross-client golden contract in
+fixtures/go-guidance/cases.json (the same fixtures the web/iOS/Android engines
+use), plus structural properties any correct implementation must hold."""
+import json
+import os
+
+import pytest
+
+from syrmos_admin import go_guidance as go
+
+_FIXTURE = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "fixtures", "go-guidance", "cases.json"
+)
+with open(_FIXTURE, encoding="utf-8") as fh:
+    FIX = json.load(fh)
+
+
+@pytest.mark.parametrize("case", FIX["cases"], ids=[c["name"] for c in FIX["cases"]])
+def test_guidance_matches_golden_fixture(case):
+    journey = FIX["journeys"][case["journey"]]
+    g = go.guidance(journey, case["position"])
+    for key, want in case["expect"].items():
+        assert g[key] == want, f"guidance.{key}: got {g.get(key)!r}, want {want!r}"
+    assert go.should_alert_get_off(journey, case["position"]) is case["alert"]
+
+
+@pytest.mark.parametrize("name", list(FIX["journeys"].keys()))
+def test_advance_walks_to_arrived_alerting_once_per_leg(name):
+    journey = FIX["journeys"][name]
+    pos = {"legIndex": 0, "stopIndex": 0}
+    alerts_per_leg = {}
+    total_stops = sum(len(l["stops"]) for l in journey["legs"])
+    steps = 0
+    while not go.is_arrived(journey, pos):
+        if go.should_alert_get_off(journey, pos):
+            alerts_per_leg[pos["legIndex"]] = alerts_per_leg.get(pos["legIndex"], 0) + 1
+        pos = go.advance(journey, pos)
+        steps += 1
+        assert steps <= total_stops + 5, f"{name}: advance did not converge"
+    for i in range(len(journey["legs"])):
+        assert alerts_per_leg.get(i, 0) == 1, f"{name}: leg {i} should alert exactly once"
+    last_leg = journey["legs"][-1]
+    assert go.guidance(journey, pos) == {
+        "kind": go.ARRIVED,
+        "station": last_leg["stops"][-1]["name"],
+    }
+
+
+def test_guidance_rejects_out_of_range():
+    j = FIX["journeys"]["m2_direct_3"]
+    with pytest.raises(IndexError):
+        go.guidance(j, {"legIndex": 9, "stopIndex": 0})
+    with pytest.raises(IndexError):
+        go.guidance(j, {"legIndex": 0, "stopIndex": 9})

--- a/ops/syrmos-api/tests/test_go_guidance.py
+++ b/ops/syrmos-api/tests/test_go_guidance.py
@@ -19,8 +19,9 @@ with open(_FIXTURE, encoding="utf-8") as fh:
 def test_guidance_matches_golden_fixture(case):
     journey = FIX["journeys"][case["journey"]]
     g = go.guidance(journey, case["position"])
-    for key, want in case["expect"].items():
-        assert g[key] == want, f"guidance.{key}: got {g.get(key)!r}, want {want!r}"
+    # Exact-equality against the full expected object (not a subset), so every
+    # rider-facing field is part of the cross-client contract.
+    assert g == case["expect"], f"guidance: got {g!r}, want {case['expect']!r}"
     assert go.should_alert_get_off(journey, case["position"]) is case["alert"]
 
 

--- a/web-tests/go-guidance.test.js
+++ b/web-tests/go-guidance.test.js
@@ -20,9 +20,10 @@ test('GO engine matches every golden fixture case', () => {
     const journey = FIX.journeys[c.journey];
     assert.ok(journey, `fixture references unknown journey ${c.journey}`);
     const g = GO.guidance(journey, c.position);
-    for (const [k, v] of Object.entries(c.expect)) {
-      assert.deepEqual(g[k], v, `[${c.name}] guidance.${k}: got ${JSON.stringify(g[k])}, want ${JSON.stringify(v)}`);
-    }
+    // Exact-equality against the full expected object (not a subset), so every
+    // rider-facing field (stopsRemaining, nextStation, towards, ...) is part of
+    // the cross-client contract.
+    assert.deepEqual(g, c.expect, `[${c.name}] guidance: got ${JSON.stringify(g)}, want ${JSON.stringify(c.expect)}`);
     assert.equal(
       GO.shouldAlertGetOff(journey, c.position),
       c.alert,

--- a/web-tests/go-guidance.test.js
+++ b/web-tests/go-guidance.test.js
@@ -1,0 +1,85 @@
+'use strict';
+// Verifies the web GO engine (web-go.js) against the cross-client golden contract
+// in fixtures/go-guidance/cases.json, plus structural properties any correct
+// implementation must hold.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const GO = require(path.join(
+  __dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources', 'web-go.js'
+));
+const FIX = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'go-guidance', 'cases.json'), 'utf8')
+);
+
+test('GO engine matches every golden fixture case', () => {
+  for (const c of FIX.cases) {
+    const journey = FIX.journeys[c.journey];
+    assert.ok(journey, `fixture references unknown journey ${c.journey}`);
+    const g = GO.guidance(journey, c.position);
+    for (const [k, v] of Object.entries(c.expect)) {
+      assert.deepEqual(g[k], v, `[${c.name}] guidance.${k}: got ${JSON.stringify(g[k])}, want ${JSON.stringify(v)}`);
+    }
+    assert.equal(
+      GO.shouldAlertGetOff(journey, c.position),
+      c.alert,
+      `[${c.name}] shouldAlertGetOff should be ${c.alert}`
+    );
+  }
+});
+
+test('advance() walks any journey from origin to arrived, alerting once per leg', () => {
+  for (const [name, journey] of Object.entries(FIX.journeys)) {
+    let pos = { legIndex: 0, stopIndex: 0 };
+    let steps = 0;
+    const alertsPerLeg = {};
+    const totalStops = journey.legs.reduce((n, l) => n + l.stops.length, 0);
+    while (!GO.isArrived(journey, pos)) {
+      if (GO.shouldAlertGetOff(journey, pos)) {
+        alertsPerLeg[pos.legIndex] = (alertsPerLeg[pos.legIndex] || 0) + 1;
+      }
+      pos = GO.advance(journey, pos);
+      if (++steps > totalStops + 5) assert.fail(`[${name}] advance() did not converge to arrived`);
+    }
+    // Exactly one get-off alert should have fired on each leg (one alight per leg).
+    for (let i = 0; i < journey.legs.length; i++) {
+      assert.equal(alertsPerLeg[i] || 0, 1, `[${name}] leg ${i} should alert exactly once`);
+    }
+    // Final state is arrived at the last leg's last stop.
+    const lastLeg = journey.legs[journey.legs.length - 1];
+    assert.deepEqual(GO.guidance(journey, pos), {
+      kind: GO.KIND.ARRIVED,
+      station: lastLeg.stops[lastLeg.stops.length - 1].name,
+    }, `[${name}] should end arrived`);
+  }
+});
+
+test('guidance() rejects out-of-range positions', () => {
+  const j = FIX.journeys.m2_direct_3;
+  assert.throws(() => GO.guidance(j, { legIndex: 9, stopIndex: 0 }), RangeError);
+  assert.throws(() => GO.guidance(j, { legIndex: 0, stopIndex: 9 }), RangeError);
+});
+
+test('GO engine works on a real seed line of realistic length', () => {
+  // Build a single-leg journey from the committed seed's M1 stops and confirm the
+  // engine boards at the origin, rides through the middle, alerts one stop before
+  // the terminus, and arrives — on a full-length line, not just the toy fixtures.
+  const seed = path.join(
+    __dirname, '..', 'core', 'data', 'src', 'commonMain', 'composeResources', 'files', 'seed'
+  );
+  const lines = JSON.parse(fs.readFileSync(path.join(seed, 'lines.json'), 'utf8'));
+  const arr = Array.isArray(lines) ? lines : lines.lines || Object.values(lines);
+  const m1 = arr.find((l) => l.id === 'M1');
+  assert.ok(m1 && Array.isArray(m1.stations) && m1.stations.length >= 5, 'seed M1 should have stops');
+  const journey = {
+    legs: [{ lineId: 'M1', towards: m1.stations[m1.stations.length - 1].name, stops: m1.stations }],
+  };
+  const n = m1.stations.length;
+  assert.equal(GO.guidance(journey, { legIndex: 0, stopIndex: 0 }).kind, GO.KIND.BOARD);
+  assert.equal(GO.guidance(journey, { legIndex: 0, stopIndex: 1 }).kind, GO.KIND.RIDE);
+  assert.equal(GO.shouldAlertGetOff(journey, { legIndex: 0, stopIndex: n - 2 }), true);
+  assert.equal(GO.guidance(journey, { legIndex: 0, stopIndex: n - 1 }).kind, GO.KIND.ARRIVED);
+});


### PR DESCRIPTION
## Why (3.0 "Journeys")
Every leading transit app (Transit GO — 2022 Apple Design Award finalist; Citymapper Go; Moovit Live Directions; Google Maps get-off alerts; DB/SBB connection companions) converges on one signature feature: once you're on a journey, the app tells you the one thing that matters — **board / ride / get off next / change here / arrived** — on a glanceable surface, so you never watch for your stop. This PR lands the pure engine behind that, the spine of 3.0. See [docs/plans/3.0-JOURNEYS.md](docs/plans/3.0-JOURNEYS.md).

## What
- **fixtures/go-guidance/cases.json** — a language-neutral **golden contract**. Every client engine (web/iOS/Android/server) must satisfy the same cases, so GO guidance cannot drift between platforms. This is the parity strategy from the thesis (iOS is native Swift, Android is KMP Kotlin, web is JS — three separate implementations kept honest by one fixture set).
- **composeApp/…/resources/web-go.js** — web reference engine. Pure, offline, deterministic: no DOM/network/clock. Works from a journey's static stop sequence; live positions only advance `position` faster.
- **ops/syrmos-api/syrmos_admin/go_guidance.py** — server engine. Enables future **push-driven** Live Activities (iOS push-to-start/broadcast) and Android 16 `ProgressStyle` Live Updates: the backend can compute the next step for a tracked journey and push it without the app open.
- **Tests** — `web-tests/go-guidance.test.js` (4) and `ops/syrmos-api/tests/test_go_guidance.py` (16) drive the **same fixtures**, plus a walk-to-arrived property (advance from origin to arrived, exactly one get-off alert per leg) and a real-seed M1 full-length walk.

## Verification (local)
- Web: `node --test` → **14/14** (10 harness + 4 GO).
- Server: `pytest tests/test_go_guidance.py` → **16/16**. Same green expected in CI (web-tests + backend-tests jobs).

## Scope / risk
- Additive only. **Not wired into any client UI yet** (feature-flag-dormant); no runtime behaviour changes for users. `web-go.js` is not yet referenced by `index.html`.
- iOS (Swift `JourneyGuidance`) and Android/KMP (Kotlin) ports follow in their own PRs against these fixtures, each build-verified/CI-gated there.
- Reversible. No release (master merge does not tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)