### PR TITLE
feat(go): Android/KMP Kotlin GO guidance engine

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/go/GoGuidance.kt
+++ b/core/domain/src/commonMain/kotlin/com/syrmos/core/domain/go/GoGuidance.kt
@@ -1,0 +1,118 @@
+package com.syrmos.core.domain.go
+
+/**
+ * Syrmos GO -- live trip-guidance engine (Android / KMP reference implementation).
+ *
+ * GO is the 3.0 "Journeys" spine: once a rider is on a planned journey, tell them
+ * the one thing that matters right now -- board, ride, get off next, change here,
+ * arrived -- so they never have to watch for their stop. This is the pure,
+ * deterministic core: no Android, no network, no clock. It works fully offline
+ * from a journey's static stop sequence; live positions only advance [GuidancePosition]
+ * faster.
+ *
+ * It mirrors the web reference (`web-go.js`), the server engine (`go_guidance.py`)
+ * and the iOS engine (`JourneyGuidance.swift`), and is validated against the same
+ * cross-client contract in `fixtures/go-guidance/cases.json`, so GO guidance
+ * cannot drift between the web, iOS, Android and server implementations.
+ *
+ * A [GuidanceLeg]'s [GuidanceLeg.stops] are ordered from its board stop to its
+ * alight stop inclusive; [GuidanceLeg.towards] is the direction shown to the
+ * rider. A [GuidancePosition] (legIndex, stopIndex) means the rider is AT
+ * `legs[legIndex].stops[stopIndex]`.
+ */
+data class GuidanceStop(val id: String, val name: String)
+
+data class GuidanceLeg(val lineId: String, val towards: String, val stops: List<GuidanceStop>)
+
+data class GuidanceJourney(val legs: List<GuidanceLeg>)
+
+data class GuidancePosition(val legIndex: Int, val stopIndex: Int)
+
+/** The rider-facing instruction for a position on a journey. */
+sealed interface JourneyGuidance {
+    data class Board(
+        val lineId: String, val towards: String, val stopsRemaining: Int, val nextStation: String,
+    ) : JourneyGuidance
+
+    data class Ride(
+        val lineId: String, val towards: String, val stopsRemaining: Int, val nextStation: String,
+    ) : JourneyGuidance
+
+    data class GetOffNext(
+        val nextStation: String, val isDestination: Boolean, val transferTo: String?,
+    ) : JourneyGuidance
+
+    data class Transfer(val atStation: String, val toLineId: String, val towards: String) : JourneyGuidance
+
+    data class Arrived(val station: String) : JourneyGuidance
+}
+
+object GoGuidance {
+
+    /**
+     * The instruction for [position]. Throws [IllegalArgumentException] for a
+     * position that does not name a real stop (a caller bug, not a rider state).
+     */
+    fun guidance(journey: GuidanceJourney, position: GuidancePosition): JourneyGuidance {
+        require(position.legIndex in journey.legs.indices) { "legIndex out of range" }
+        val leg = journey.legs[position.legIndex]
+        require(position.stopIndex in leg.stops.indices) { "stopIndex out of range" }
+
+        val lastLeg = position.legIndex == journey.legs.lastIndex
+        val lastStop = leg.stops.lastIndex
+        val remaining = lastStop - position.stopIndex
+        val here = leg.stops[position.stopIndex]
+
+        if (lastLeg && remaining == 0) return JourneyGuidance.Arrived(here.name)
+
+        if (remaining == 0) {
+            val next = journey.legs[position.legIndex + 1]
+            return JourneyGuidance.Transfer(here.name, next.lineId, next.towards)
+        }
+
+        if (position.stopIndex == 0) {
+            return JourneyGuidance.Board(leg.lineId, leg.towards, remaining, leg.stops[1].name)
+        }
+
+        if (remaining == 1) {
+            val next = if (lastLeg) null else journey.legs[position.legIndex + 1]
+            return JourneyGuidance.GetOffNext(leg.stops[lastStop].name, lastLeg, next?.lineId)
+        }
+
+        return JourneyGuidance.Ride(
+            leg.lineId, leg.towards, remaining, leg.stops[position.stopIndex + 1].name,
+        )
+    }
+
+    /**
+     * Whether a get-off notification should fire now (rider one stop from a leg's
+     * alight point). Independent of the display type so a caller can drive the
+     * notification / Live Update off one predicate; true even on a 2-stop leg.
+     */
+    fun shouldAlertGetOff(journey: GuidanceJourney, position: GuidancePosition): Boolean {
+        val leg = journey.legs.getOrNull(position.legIndex) ?: return false
+        val remaining = leg.stops.lastIndex - position.stopIndex
+        return remaining == 1
+    }
+
+    /**
+     * Advance one stop, rolling a leg's alight stop onto the next leg's board stop.
+     * Returns the same position when already at the destination.
+     */
+    fun advance(journey: GuidanceJourney, position: GuidancePosition): GuidancePosition {
+        val leg = journey.legs.getOrNull(position.legIndex) ?: return position
+        val lastLeg = position.legIndex == journey.legs.lastIndex
+        val atLegEnd = position.stopIndex >= leg.stops.lastIndex
+        return when {
+            atLegEnd && lastLeg -> position
+            atLegEnd -> GuidancePosition(position.legIndex + 1, 0)
+            else -> GuidancePosition(position.legIndex, position.stopIndex + 1)
+        }
+    }
+
+    fun isArrived(journey: GuidanceJourney, position: GuidancePosition): Boolean {
+        val leg = journey.legs.getOrNull(position.legIndex) ?: return false
+        val lastLeg = position.legIndex == journey.legs.lastIndex
+        return lastLeg && position.stopIndex == leg.stops.lastIndex
+    }
+}

--- a/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/go/GoGuidanceTest.kt
+++ b/core/domain/src/commonTest/kotlin/com/syrmos/core/domain/go/GoGuidanceTest.kt
@@ -1,0 +1,142 @@
+package com.syrmos.core.domain.go
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Mirrors the cross-client GO contract in `fixtures/go-guidance/cases.json` (the
+ * same cases the web `web-go.js`, server `go_guidance.py` and iOS
+ * `JourneyGuidance.swift` engines are tested against) so GO guidance stays
+ * identical on Android. commonTest cannot read repo files, so the fixtures are
+ * inlined here; keep them in step with cases.json.
+ */
+class GoGuidanceTest {
+
+    private fun stop(id: String, name: String) = GuidanceStop(id, name)
+
+    private val m2Direct3 = GuidanceJourney(
+        listOf(
+            GuidanceLeg(
+                "M2", "Anthoupoli",
+                listOf(stop("M2_SYN", "Syntagma"), stop("M2_PAN", "Panepistimio"), stop("M2_OMO", "Omonia")),
+            ),
+        ),
+    )
+
+    private val m1Hop2 = GuidanceJourney(
+        listOf(
+            GuidanceLeg("M1", "Kifisia", listOf(stop("M1_VIC", "Victoria"), stop("M1_ATT", "Attiki"))),
+        ),
+    )
+
+    private val m2m3Transfer = GuidanceJourney(
+        listOf(
+            GuidanceLeg(
+                "M2", "Elliniko",
+                listOf(
+                    stop("M2_LAR", "Larissa Station"), stop("M2_MET", "Metaxourgeio"),
+                    stop("M2_OMO", "Omonia"), stop("M2_SYN", "Syntagma"),
+                ),
+            ),
+            GuidanceLeg(
+                "M3", "Airport",
+                listOf(
+                    stop("M3_SYN", "Syntagma"), stop("M3_EVA", "Evangelismos"),
+                    stop("M3_MEG", "Megaro Moussikis"),
+                ),
+            ),
+        ),
+    )
+
+    private fun pos(leg: Int, stop: Int) = GuidancePosition(leg, stop)
+
+    @Test
+    fun direct_boardThenGetOffThenArrived() {
+        assertEquals(
+            JourneyGuidance.Board("M2", "Anthoupoli", 2, "Panepistimio"),
+            GoGuidance.guidance(m2Direct3, pos(0, 0)),
+        )
+        assertEquals(false, GoGuidance.shouldAlertGetOff(m2Direct3, pos(0, 0)))
+
+        assertEquals(
+            JourneyGuidance.GetOffNext("Omonia", isDestination = true, transferTo = null),
+            GoGuidance.guidance(m2Direct3, pos(0, 1)),
+        )
+        assertTrue(GoGuidance.shouldAlertGetOff(m2Direct3, pos(0, 1)))
+
+        assertEquals(JourneyGuidance.Arrived("Omonia"), GoGuidance.guidance(m2Direct3, pos(0, 2)))
+        assertEquals(false, GoGuidance.shouldAlertGetOff(m2Direct3, pos(0, 2)))
+    }
+
+    @Test
+    fun twoStopHop_boardCoincidesWithAlert() {
+        assertEquals(
+            JourneyGuidance.Board("M1", "Kifisia", 1, "Attiki"),
+            GoGuidance.guidance(m1Hop2, pos(0, 0)),
+        )
+        assertTrue(GoGuidance.shouldAlertGetOff(m1Hop2, pos(0, 0)))
+        assertEquals(JourneyGuidance.Arrived("Attiki"), GoGuidance.guidance(m1Hop2, pos(0, 1)))
+    }
+
+    @Test
+    fun transfer_stepsThroughBoardRideGetOffTransferArrived() {
+        assertEquals(
+            JourneyGuidance.Board("M2", "Elliniko", 3, "Metaxourgeio"),
+            GoGuidance.guidance(m2m3Transfer, pos(0, 0)),
+        )
+        assertEquals(
+            JourneyGuidance.Ride("M2", "Elliniko", 2, "Omonia"),
+            GoGuidance.guidance(m2m3Transfer, pos(0, 1)),
+        )
+        assertEquals(
+            JourneyGuidance.GetOffNext("Syntagma", isDestination = false, transferTo = "M3"),
+            GoGuidance.guidance(m2m3Transfer, pos(0, 2)),
+        )
+        assertTrue(GoGuidance.shouldAlertGetOff(m2m3Transfer, pos(0, 2)))
+        assertEquals(
+            JourneyGuidance.Transfer("Syntagma", "M3", "Airport"),
+            GoGuidance.guidance(m2m3Transfer, pos(0, 3)),
+        )
+        assertEquals(
+            JourneyGuidance.Board("M3", "Airport", 2, "Evangelismos"),
+            GoGuidance.guidance(m2m3Transfer, pos(1, 0)),
+        )
+        assertEquals(
+            JourneyGuidance.GetOffNext("Megaro Moussikis", isDestination = true, transferTo = null),
+            GoGuidance.guidance(m2m3Transfer, pos(1, 1)),
+        )
+        assertEquals(
+            JourneyGuidance.Arrived("Megaro Moussikis"),
+            GoGuidance.guidance(m2m3Transfer, pos(1, 2)),
+        )
+    }
+
+    @Test
+    fun advance_walksToArrivedAlertingOncePerLeg() {
+        for (journey in listOf(m2Direct3, m1Hop2, m2m3Transfer)) {
+            var p = GuidancePosition(0, 0)
+            val alertsPerLeg = HashMap<Int, Int>()
+            val totalStops = journey.legs.sumOf { it.stops.size }
+            var steps = 0
+            while (!GoGuidance.isArrived(journey, p)) {
+                if (GoGuidance.shouldAlertGetOff(journey, p)) {
+                    alertsPerLeg[p.legIndex] = (alertsPerLeg[p.legIndex] ?: 0) + 1
+                }
+                p = GoGuidance.advance(journey, p)
+                steps++
+                assertTrue(steps <= totalStops + 5, "advance did not converge")
+            }
+            journey.legs.indices.forEach { i ->
+                assertEquals(1, alertsPerLeg[i] ?: 0, "leg $i should alert exactly once")
+            }
+        }
+    }
+
+    @Test
+    fun guidance_rejectsOutOfRange() {
+        assertFailsWith<IllegalArgumentException> { GoGuidance.guidance(m2Direct3, pos(9, 0)) }
+        assertFailsWith<IllegalArgumentException> { GoGuidance.guidance(m2Direct3, pos(0, 9)) }
+    }
+}


### PR DESCRIPTION
## Why
The 4th and final language port of the 3.0 GO trip-guidance engine (after web `web-go.js`, server `go_guidance.py`, iOS `JourneyGuidance.swift`). This is how **Android** gets GO. Shared KMP Kotlin in `core/domain/go/`.

## What
- `core/domain/.../go/GoGuidance.kt` — pure, offline, deterministic engine: `Board / Ride / GetOffNext / Transfer / Arrived` + a single `shouldAlertGetOff` predicate. Sealed interface, no Android/network/clock deps.
- `core/domain/.../go/GoGuidanceTest.kt` — mirrors the cross-client contract `fixtures/go-guidance/cases.json` (inlined, per this module's commonTest convention) plus the walk-to-arrived property (advance origin→arrived, exactly one get-off alert per leg).

## Verification
Verified in CI via the existing `kmp-tests` job (`testDebugUnitTest`). No local JDK in this environment, so CI is the gate. The identical contract already passes in JS (web-tests), Python (backend-tests) and Swift (iOS XCTest, run locally: 3/3), so cross-client parity is well-established.

## Scope / risk
Additive; **not yet wired into Android UI** (feature-flag-dormant). Reversible. No release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)