### PR TITLE
feat(go): iOS Swift GO guidance engine + XCTest

### DIFF
--- a/iosApp/Syrmos.xcodeproj/project.pbxproj
+++ b/iosApp/Syrmos.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		DA7A0013F00D0013F00D0013 /* AriadneModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0014F00D0014F00D0014 /* AriadneModel.swift */; };
 		DA7A0015F00D0015F00D0015 /* AriadneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0016F00D0016F00D0016 /* AriadneView.swift */; };
 		DA7A0018F00D0018F00D0018 /* AriadneParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0019F00D0019F00D0019 /* AriadneParserTests.swift */; };
+		DA7A0202F00D0202F00D0202 /* JourneyGuidanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */; };
 		DA7A0021F00D0021F00D0021 /* DepartureTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0022F00D0022F00D0022 /* DepartureTracking.swift */; };
 		DA7A0030F00D0030F00D0030 /* MapRouteGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */; };
 		DA7A010BF00D010BF00D010B /* SyrmosWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DA7A0107F00D0107F00D0107 /* SyrmosWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -119,6 +120,7 @@
 		DA7A0122F00D0122F00D0122 /* SyrmosLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0111F00D0111F00D0111 /* SyrmosLiveActivity.swift */; };
 		DA7A0123F00D0123F00D0123 /* SyrmosWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0112F00D0112F00D0112 /* SyrmosWidgetBundle.swift */; };
 		DA7A0130F00D0130F00D0130 /* JourneyPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0131F00D0131F00D0131 /* JourneyPlanner.swift */; };
+		DA7A0200F00D0200F00D0200 /* JourneyGuidance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0201F00D0201F00D0201 /* JourneyGuidance.swift */; };
 		DA7A0140F00D0140F00D0140 /* WeatherStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0141F00D0141F00D0141 /* WeatherStore.swift */; };
 		DA7A0142F00D0142F00D0142 /* WeatherCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0143F00D0143F00D0143 /* WeatherCard.swift */; };
 		DA7A0150F00D0150F00D0150 /* AriadneBrain.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */; };
@@ -306,6 +308,7 @@
 		DA7A0014F00D0014F00D0014 /* AriadneModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneModel.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0016F00D0016F00D0016 /* AriadneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneView.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0019F00D0019F00D0019 /* AriadneParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AriadneParserTests.swift; sourceTree = "<group>"; };
+		DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JourneyGuidanceTests.swift; sourceTree = "<group>"; };
 		DA7A0022F00D0022F00D0022 /* DepartureTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Schedule/DepartureTracking.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MapRouteGeometryTests.swift; sourceTree = "<group>"; };
 		DA7A0107F00D0107F00D0107 /* SyrmosWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SyrmosWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -314,6 +317,7 @@
 		DA7A0112F00D0112F00D0112 /* SyrmosWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyrmosWidget/SyrmosWidgetBundle.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0113F00D0113F00D0113 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = SyrmosWidget/Info.plist; sourceTree = SOURCE_ROOT; };
 		DA7A0131F00D0131F00D0131 /* JourneyPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/JourneyPlanner.swift; sourceTree = SOURCE_ROOT; };
+		DA7A0201F00D0201F00D0201 /* JourneyGuidance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/JourneyGuidance.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0141F00D0141F00D0141 /* WeatherStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Networking/WeatherStore.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0143F00D0143F00D0143 /* WeatherCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Weather/WeatherCard.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneBrain.swift; sourceTree = SOURCE_ROOT; };
@@ -390,6 +394,7 @@
 				DA7A0004F00D0004F00D0004 /* HomeFeaturesTests.swift */,
 				DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */,
 				DA7A0019F00D0019F00D0019 /* AriadneParserTests.swift */,
+				DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */,
 				B9C311F839BA02691F04AB93 /* NearbyStationDestinationTests.swift */,
 				BF6FDC539EEBEA3DCEA3416B /* SuburbanProjectionTests.swift */,
 			);
@@ -662,6 +667,7 @@
 				DA7A0014F00D0014F00D0014 /* AriadneModel.swift */,
 				DA7A0016F00D0016F00D0016 /* AriadneView.swift */,
 				DA7A0131F00D0131F00D0131 /* JourneyPlanner.swift */,
+				DA7A0201F00D0201F00D0201 /* JourneyGuidance.swift */,
 				DA7A0141F00D0141F00D0141 /* WeatherStore.swift */,
 				DA7A0143F00D0143F00D0143 /* WeatherCard.swift */,
 				DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */,
@@ -950,6 +956,7 @@
 				DA7A0013F00D0013F00D0013 /* AriadneModel.swift in Sources */,
 				DA7A0015F00D0015F00D0015 /* AriadneView.swift in Sources */,
 				DA7A0130F00D0130F00D0130 /* JourneyPlanner.swift in Sources */,
+				DA7A0200F00D0200F00D0200 /* JourneyGuidance.swift in Sources */,
 				DA7A0140F00D0140F00D0140 /* WeatherStore.swift in Sources */,
 				DA7A0142F00D0142F00D0142 /* WeatherCard.swift in Sources */,
 				DA7A0150F00D0150F00D0150 /* AriadneBrain.swift in Sources */,
@@ -1022,6 +1029,7 @@
 				DA7A0003F00D0003F00D0003 /* HomeFeaturesTests.swift in Sources */,
 				DA7A0030F00D0030F00D0030 /* MapRouteGeometryTests.swift in Sources */,
 				DA7A0018F00D0018F00D0018 /* AriadneParserTests.swift in Sources */,
+				DA7A0202F00D0202F00D0202 /* JourneyGuidanceTests.swift in Sources */,
 				ECAA824BE3E518277AB18AB6 /* NearbyStationDestinationTests.swift in Sources */,
 				28B86D763BF517E19CF4DB5D /* SuburbanProjectionTests.swift in Sources */,
 			);

--- a/iosApp/iosApp/Features/Assistant/JourneyGuidance.swift
+++ b/iosApp/iosApp/Features/Assistant/JourneyGuidance.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+// Syrmos GO -- live trip-guidance engine (iOS reference implementation).
+//
+// GO is the 3.0 "Journeys" spine: once a rider is on a planned journey, tell them
+// the one thing that matters right now -- board, ride, get off next, change here,
+// arrived -- so they never have to watch for their stop. This is the pure,
+// deterministic core: no UIKit, no network, no clock. It works fully offline from
+// a journey's static stop sequence; live positions only advance `position` faster.
+//
+// It mirrors the web reference (`web-go.js`) and the server engine
+// (`go_guidance.py`) and is validated against the same cross-client contract in
+// `fixtures/go-guidance/cases.json`, so GO guidance cannot drift between the web,
+// iOS, Android and server implementations.
+//
+// A `GuidanceLeg`'s `stops` are ordered from its board stop to its alight stop
+// inclusive; `towards` is the direction shown to the rider. A `GuidancePosition`
+// { legIndex, stopIndex } means the rider is AT `legs[legIndex].stops[stopIndex]`.
+
+struct GuidanceStop: Equatable, Sendable {
+    let id: String
+    let name: String
+}
+
+struct GuidanceLeg: Equatable, Sendable {
+    let lineId: String
+    let towards: String
+    let stops: [GuidanceStop]
+}
+
+struct GuidanceJourney: Equatable, Sendable {
+    let legs: [GuidanceLeg]
+}
+
+struct GuidancePosition: Equatable, Sendable {
+    let legIndex: Int
+    let stopIndex: Int
+}
+
+/// The rider-facing instruction for a position on a journey.
+enum JourneyGuidance: Equatable, Sendable {
+    case board(lineId: String, towards: String, stopsRemaining: Int, nextStation: String)
+    case ride(lineId: String, towards: String, stopsRemaining: Int, nextStation: String)
+    case getOffNext(nextStation: String, isDestination: Bool, transferTo: String?)
+    case transfer(atStation: String, toLineId: String, towards: String)
+    case arrived(station: String)
+
+    enum GuidanceError: Error, Equatable { case positionOutOfRange }
+
+    /// The instruction for `position`. Throws `positionOutOfRange` for a position
+    /// that does not name a real stop (a caller bug, not a rider state).
+    static func at(_ journey: GuidanceJourney, _ position: GuidancePosition) throws -> JourneyGuidance {
+        guard journey.legs.indices.contains(position.legIndex) else { throw GuidanceError.positionOutOfRange }
+        let leg = journey.legs[position.legIndex]
+        guard leg.stops.indices.contains(position.stopIndex) else { throw GuidanceError.positionOutOfRange }
+
+        let lastLeg = position.legIndex == journey.legs.count - 1
+        let lastStop = leg.stops.count - 1
+        let remaining = lastStop - position.stopIndex
+        let here = leg.stops[position.stopIndex]
+
+        if lastLeg && remaining == 0 { return .arrived(station: here.name) }
+
+        if remaining == 0 {
+            let next = journey.legs[position.legIndex + 1]
+            return .transfer(atStation: here.name, toLineId: next.lineId, towards: next.towards)
+        }
+
+        if position.stopIndex == 0 {
+            return .board(lineId: leg.lineId, towards: leg.towards,
+                          stopsRemaining: remaining, nextStation: leg.stops[1].name)
+        }
+
+        if remaining == 1 {
+            let next = lastLeg ? nil : journey.legs[position.legIndex + 1]
+            return .getOffNext(nextStation: leg.stops[lastStop].name,
+                               isDestination: lastLeg, transferTo: next?.lineId)
+        }
+
+        return .ride(lineId: leg.lineId, towards: leg.towards,
+                     stopsRemaining: remaining, nextStation: leg.stops[position.stopIndex + 1].name)
+    }
+
+    /// Whether a get-off notification should fire now (rider one stop from a leg's
+    /// alight point). Independent of the display case so a caller drives the local
+    /// notification / Live Activity off one predicate; true even on a 2-stop leg.
+    static func shouldAlertGetOff(_ journey: GuidanceJourney, _ position: GuidancePosition) -> Bool {
+        guard journey.legs.indices.contains(position.legIndex) else { return false }
+        let leg = journey.legs[position.legIndex]
+        let remaining = leg.stops.count - 1 - position.stopIndex
+        return remaining == 1
+    }
+
+    /// Advance one stop, rolling a leg's alight stop onto the next leg's board
+    /// stop. Returns the same position when already at the destination.
+    static func advance(_ journey: GuidanceJourney, _ position: GuidancePosition) -> GuidancePosition {
+        guard journey.legs.indices.contains(position.legIndex) else { return position }
+        let leg = journey.legs[position.legIndex]
+        let lastLeg = position.legIndex == journey.legs.count - 1
+        let atLegEnd = position.stopIndex >= leg.stops.count - 1
+        if atLegEnd {
+            if lastLeg { return position }
+            return GuidancePosition(legIndex: position.legIndex + 1, stopIndex: 0)
+        }
+        return GuidancePosition(legIndex: position.legIndex, stopIndex: position.stopIndex + 1)
+    }
+
+    static func isArrived(_ journey: GuidanceJourney, _ position: GuidancePosition) -> Bool {
+        let lastLeg = position.legIndex == journey.legs.count - 1
+        guard journey.legs.indices.contains(position.legIndex) else { return false }
+        let leg = journey.legs[position.legIndex]
+        return lastLeg && position.stopIndex == leg.stops.count - 1
+    }
+}

--- a/iosApp/iosAppTests/JourneyGuidanceTests.swift
+++ b/iosApp/iosAppTests/JourneyGuidanceTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import Syrmos
+
+/// Validates the iOS GO engine (`JourneyGuidance`) against the cross-client golden
+/// contract in `fixtures/go-guidance/cases.json` -- the same fixtures the web
+/// (`web-go.js`) and server (`go_guidance.py`) engines use -- plus the walk-to-
+/// arrived property. Keeping all engines on one fixture set prevents GO guidance
+/// from drifting between platforms.
+final class JourneyGuidanceTests: XCTestCase {
+
+    // MARK: Fixture loading
+
+    private struct Fixtures {
+        let journeys: [String: GuidanceJourney]
+        let cases: [[String: Any]]
+    }
+
+    private func loadFixtures() throws -> Fixtures {
+        // fixtures/go-guidance/cases.json lives at the repo root; this test file is
+        // at iosApp/iosAppTests/, so climb two directories from its folder.
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("fixtures/go-guidance/cases.json")
+        let data = try Data(contentsOf: url)
+        let root = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let journeysRaw = try XCTUnwrap(root["journeys"] as? [String: Any])
+        var journeys: [String: GuidanceJourney] = [:]
+        for (name, value) in journeysRaw {
+            let legsRaw = try XCTUnwrap((value as? [String: Any])?["legs"] as? [[String: Any]])
+            let legs: [GuidanceLeg] = try legsRaw.map { legDict in
+                let stopsRaw = try XCTUnwrap(legDict["stops"] as? [[String: Any]])
+                let stops = try stopsRaw.map { GuidanceStop(id: try XCTUnwrap($0["id"] as? String),
+                                                            name: try XCTUnwrap($0["name"] as? String)) }
+                return GuidanceLeg(lineId: try XCTUnwrap(legDict["lineId"] as? String),
+                                   towards: try XCTUnwrap(legDict["towards"] as? String),
+                                   stops: stops)
+            }
+            journeys[name] = GuidanceJourney(legs: legs)
+        }
+        let cases = try XCTUnwrap(root["cases"] as? [[String: Any]])
+        return Fixtures(journeys: journeys, cases: cases)
+    }
+
+    /// Flatten a guidance value into the same field shape the fixtures assert on.
+    private func fields(_ g: JourneyGuidance) -> [String: Any?] {
+        switch g {
+        case let .board(lineId, towards, stopsRemaining, nextStation):
+            return ["kind": "board", "lineId": lineId, "towards": towards,
+                    "stopsRemaining": stopsRemaining, "nextStation": nextStation]
+        case let .ride(lineId, towards, stopsRemaining, nextStation):
+            return ["kind": "ride", "lineId": lineId, "towards": towards,
+                    "stopsRemaining": stopsRemaining, "nextStation": nextStation]
+        case let .getOffNext(nextStation, isDestination, transferTo):
+            return ["kind": "getOffNext", "nextStation": nextStation,
+                    "isDestination": isDestination, "transferTo": transferTo]
+        case let .transfer(atStation, toLineId, towards):
+            return ["kind": "transfer", "atStation": atStation, "toLineId": toLineId, "towards": towards]
+        case let .arrived(station):
+            return ["kind": "arrived", "station": station]
+        }
+    }
+
+    private func assertField(_ got: Any?, _ want: Any, _ label: String) {
+        if want is NSNull { XCTAssertNil(got ?? nil, label); return }
+        if let w = want as? String { XCTAssertEqual(got as? String, w, label) }
+        else if let w = want as? Bool, got is Bool { XCTAssertEqual(got as? Bool, w, label) }
+        else if let w = want as? Int { XCTAssertEqual(got as? Int, w, label) }
+        else { XCTFail("\(label): unhandled expected type \(type(of: want))") }
+    }
+
+    // MARK: Tests
+
+    func test_matchesEveryGoldenFixtureCase() throws {
+        let fx = try loadFixtures()
+        for c in fx.cases {
+            let name = c["name"] as? String ?? "?"
+            let journey = try XCTUnwrap(fx.journeys[try XCTUnwrap(c["journey"] as? String)])
+            let posDict = try XCTUnwrap(c["position"] as? [String: Any])
+            let pos = GuidancePosition(legIndex: try XCTUnwrap(posDict["legIndex"] as? Int),
+                                       stopIndex: try XCTUnwrap(posDict["stopIndex"] as? Int))
+            let got = fields(try JourneyGuidance.at(journey, pos))
+            let expect = try XCTUnwrap(c["expect"] as? [String: Any])
+            for (key, want) in expect {
+                // Bool vs Int disambiguation: JSONSerialization yields NSNumber; a
+                // JSON bool is __NSCFBoolean. Our fields() returns native Bool/Int,
+                // so compare through assertField which branches on the expected type.
+                assertField(got[key] ?? nil, want, "[\(name)] \(key)")
+            }
+            let alert = try XCTUnwrap(c["alert"] as? Bool)
+            XCTAssertEqual(JourneyGuidance.shouldAlertGetOff(journey, pos), alert, "[\(name)] alert")
+        }
+    }
+
+    func test_advanceWalksToArrivedAlertingOncePerLeg() throws {
+        let fx = try loadFixtures()
+        for (name, journey) in fx.journeys {
+            var pos = GuidancePosition(legIndex: 0, stopIndex: 0)
+            var alertsPerLeg: [Int: Int] = [:]
+            let totalStops = journey.legs.reduce(0) { $0 + $1.stops.count }
+            var steps = 0
+            while !JourneyGuidance.isArrived(journey, pos) {
+                if JourneyGuidance.shouldAlertGetOff(journey, pos) {
+                    alertsPerLeg[pos.legIndex, default: 0] += 1
+                }
+                pos = JourneyGuidance.advance(journey, pos)
+                steps += 1
+                XCTAssertLessThanOrEqual(steps, totalStops + 5, "[\(name)] did not converge")
+            }
+            for i in journey.legs.indices {
+                XCTAssertEqual(alertsPerLeg[i] ?? 0, 1, "[\(name)] leg \(i) should alert once")
+            }
+        }
+    }
+
+    func test_rejectsOutOfRangePositions() throws {
+        let fx = try loadFixtures()
+        let j = try XCTUnwrap(fx.journeys["m2_direct_3"])
+        XCTAssertThrowsError(try JourneyGuidance.at(j, GuidancePosition(legIndex: 9, stopIndex: 0)))
+        XCTAssertThrowsError(try JourneyGuidance.at(j, GuidancePosition(legIndex: 0, stopIndex: 9)))
+    }
+}


### PR DESCRIPTION
## Why
The iOS (native Swift) port of the 3.0 GO trip-guidance engine, completing the set alongside web `web-go.js`, server `go_guidance.py`, and Android/KMP `GoGuidance.kt` — all four now implement the **same** cross-client contract `fixtures/go-guidance/cases.json`.

## What
- `iosApp/…/Features/Assistant/JourneyGuidance.swift` — pure, offline, deterministic engine: `board / ride / getOffNext / transfer / arrived` + a single `shouldAlertGetOff` predicate. Sealed enum with associated values; no UIKit/network/clock. Wired into the app + test targets (pbxproj).
- `iosApp/iosAppTests/JourneyGuidanceTests.swift` — loads the shared fixtures and asserts guidance + alert per case, plus the walk-to-arrived property (advance origin→arrived, exactly one get-off alert per leg) and out-of-range rejection.

## Verification (local)
`xcodebuild test -only-testing:iosAppTests/JourneyGuidanceTests` on iPhone 17 Pro (Xcode 26.6) → **`** TEST SUCCEEDED **`, 3/3**, against the strengthened exact-object fixtures now on master. The identical contract passes in JS (web-tests), Python (backend-tests), and Kotlin (kmp-tests) in CI, and was Codex-reviewed on #106 (no divergence across 1,290 states).

## Scope / risk
Additive; **not yet wired into any UI** (feature-flag-dormant). Does not touch the Ariadne-critical `JourneyPlanner`. Reversible. No release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)