### PR TITLE
ci: stop the flaky watchOS-runtime download from failing iOS workflows

### DIFF
--- a/.github/workflows/ios-ui-inspection.yml
+++ b/.github/workflows/ios-ui-inspection.yml
@@ -47,7 +47,12 @@ jobs:
           xcodebuild -version
 
       # The app scheme embeds the watch app, so the watchOS runtime is required.
+      # The download occasionally fails with "Unable to connect to simulator"
+      # (exit 70) on a transient network/infra hiccup; don't let that flake fail
+      # the job. A genuinely missing runtime surfaces as a real error in the
+      # later build step. Matches ci.yml's handling of the same step.
       - name: Install watchOS simulator runtime
+        continue-on-error: true
         run: xcodebuild -downloadPlatform watchOS
 
       - name: Install Apple AI tools (Loupe + agent-device)

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -42,7 +42,12 @@ jobs:
           xcodebuild -version
 
       # The iOS scheme embeds the watch app, so the watchOS runtime is required.
+      # The download occasionally fails with "Unable to connect to simulator"
+      # (exit 70) on a transient network/infra hiccup; don't let that flake fail
+      # the whole build. If the runtime is genuinely missing the later build step
+      # fails with a real error. Matches ci.yml's handling of the same step.
       - name: Install watchOS simulator runtime
+        continue-on-error: true
         run: xcodebuild -downloadPlatform watchOS
 
       - name: Build watch scheme (SDK only, fast sanity check)


### PR DESCRIPTION
`xcodebuild -downloadPlatform watchOS` intermittently fails with "Unable to connect to simulator" (exit 70) on transient infra, red-flagging iOS PRs even when the app + tests build fine — observed on #109, where the same `ios.yml` job **failed (36s) and passed (2m22s) on two runs of the same commit**, and the real gate (ci.yml `iOS build + tests`) passed. This marks the download step `continue-on-error` in `ios.yml` and `ios-ui-inspection.yml`, matching how `ci.yml` already handles it. A genuinely missing runtime still fails the later build step with a real error. CI-only, reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)