### PR TITLE
feat(go): GO journey screen (iOS) - the first visible GO feature

### DIFF
--- a/iosApp/Syrmos.xcodeproj/project.pbxproj
+++ b/iosApp/Syrmos.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		DA7A0018F00D0018F00D0018 /* AriadneParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0019F00D0019F00D0019 /* AriadneParserTests.swift */; };
 		DA7A0202F00D0202F00D0202 /* JourneyGuidanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */; };
 		DA7A0206F00D0206F00D0206 /* JourneyPlannerConnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0207F00D0207F00D0207 /* JourneyPlannerConnectTests.swift */; };
+		DA7A020EF00D020EF00D020E /* GoJourneyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A020FF00D020FF00D020F /* GoJourneyViewModelTests.swift */; };
 		DA7A0021F00D0021F00D0021 /* DepartureTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0022F00D0022F00D0022 /* DepartureTracking.swift */; };
 		DA7A0030F00D0030F00D0030 /* MapRouteGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */; };
 		DA7A010BF00D010BF00D010B /* SyrmosWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DA7A0107F00D0107F00D0107 /* SyrmosWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -123,6 +124,9 @@
 		DA7A0130F00D0130F00D0130 /* JourneyPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0131F00D0131F00D0131 /* JourneyPlanner.swift */; };
 		DA7A0200F00D0200F00D0200 /* JourneyGuidance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0201F00D0201F00D0201 /* JourneyGuidance.swift */; };
 		DA7A0204F00D0204F00D0204 /* JourneyGuidance+Planner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0205F00D0205F00D0205 /* JourneyGuidance+Planner.swift */; };
+		DA7A0208F00D0208F00D0208 /* GoJourneyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0209F00D0209F00D0209 /* GoJourneyViewModel.swift */; };
+		DA7A020AF00D020AF00D020A /* GoJourneyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A020BF00D020BF00D020B /* GoJourneyView.swift */; };
+		DA7A020CF00D020CF00D020C /* GoDemoEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A020DF00D020DF00D020D /* GoDemoEntryView.swift */; };
 		DA7A0140F00D0140F00D0140 /* WeatherStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0141F00D0141F00D0141 /* WeatherStore.swift */; };
 		DA7A0142F00D0142F00D0142 /* WeatherCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0143F00D0143F00D0143 /* WeatherCard.swift */; };
 		DA7A0150F00D0150F00D0150 /* AriadneBrain.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */; };
@@ -312,6 +316,7 @@
 		DA7A0019F00D0019F00D0019 /* AriadneParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AriadneParserTests.swift; sourceTree = "<group>"; };
 		DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JourneyGuidanceTests.swift; sourceTree = "<group>"; };
 		DA7A0207F00D0207F00D0207 /* JourneyPlannerConnectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JourneyPlannerConnectTests.swift; sourceTree = "<group>"; };
+		DA7A020FF00D020FF00D020F /* GoJourneyViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GoJourneyViewModelTests.swift; sourceTree = "<group>"; };
 		DA7A0022F00D0022F00D0022 /* DepartureTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Schedule/DepartureTracking.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MapRouteGeometryTests.swift; sourceTree = "<group>"; };
 		DA7A0107F00D0107F00D0107 /* SyrmosWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SyrmosWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -322,6 +327,9 @@
 		DA7A0131F00D0131F00D0131 /* JourneyPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/JourneyPlanner.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0201F00D0201F00D0201 /* JourneyGuidance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/JourneyGuidance.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0205F00D0205F00D0205 /* JourneyGuidance+Planner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "iosApp/Features/Assistant/JourneyGuidance+Planner.swift"; sourceTree = SOURCE_ROOT; };
+		DA7A0209F00D0209F00D0209 /* GoJourneyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Go/GoJourneyViewModel.swift; sourceTree = SOURCE_ROOT; };
+		DA7A020BF00D020BF00D020B /* GoJourneyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Go/GoJourneyView.swift; sourceTree = SOURCE_ROOT; };
+		DA7A020DF00D020DF00D020D /* GoDemoEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Go/GoDemoEntryView.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0141F00D0141F00D0141 /* WeatherStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Networking/WeatherStore.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0143F00D0143F00D0143 /* WeatherCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Weather/WeatherCard.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneBrain.swift; sourceTree = SOURCE_ROOT; };
@@ -400,6 +408,7 @@
 				DA7A0019F00D0019F00D0019 /* AriadneParserTests.swift */,
 				DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */,
 				DA7A0207F00D0207F00D0207 /* JourneyPlannerConnectTests.swift */,
+				DA7A020FF00D020FF00D020F /* GoJourneyViewModelTests.swift */,
 				B9C311F839BA02691F04AB93 /* NearbyStationDestinationTests.swift */,
 				BF6FDC539EEBEA3DCEA3416B /* SuburbanProjectionTests.swift */,
 			);
@@ -674,6 +683,9 @@
 				DA7A0131F00D0131F00D0131 /* JourneyPlanner.swift */,
 				DA7A0201F00D0201F00D0201 /* JourneyGuidance.swift */,
 				DA7A0205F00D0205F00D0205 /* JourneyGuidance+Planner.swift */,
+				DA7A0209F00D0209F00D0209 /* GoJourneyViewModel.swift */,
+				DA7A020BF00D020BF00D020B /* GoJourneyView.swift */,
+				DA7A020DF00D020DF00D020D /* GoDemoEntryView.swift */,
 				DA7A0141F00D0141F00D0141 /* WeatherStore.swift */,
 				DA7A0143F00D0143F00D0143 /* WeatherCard.swift */,
 				DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */,
@@ -964,6 +976,9 @@
 				DA7A0130F00D0130F00D0130 /* JourneyPlanner.swift in Sources */,
 				DA7A0200F00D0200F00D0200 /* JourneyGuidance.swift in Sources */,
 				DA7A0204F00D0204F00D0204 /* JourneyGuidance+Planner.swift in Sources */,
+				DA7A0208F00D0208F00D0208 /* GoJourneyViewModel.swift in Sources */,
+				DA7A020AF00D020AF00D020A /* GoJourneyView.swift in Sources */,
+				DA7A020CF00D020CF00D020C /* GoDemoEntryView.swift in Sources */,
 				DA7A0140F00D0140F00D0140 /* WeatherStore.swift in Sources */,
 				DA7A0142F00D0142F00D0142 /* WeatherCard.swift in Sources */,
 				DA7A0150F00D0150F00D0150 /* AriadneBrain.swift in Sources */,
@@ -1038,6 +1053,7 @@
 				DA7A0018F00D0018F00D0018 /* AriadneParserTests.swift in Sources */,
 				DA7A0202F00D0202F00D0202 /* JourneyGuidanceTests.swift in Sources */,
 				DA7A0206F00D0206F00D0206 /* JourneyPlannerConnectTests.swift in Sources */,
+				DA7A020EF00D020EF00D020E /* GoJourneyViewModelTests.swift in Sources */,
 				ECAA824BE3E518277AB18AB6 /* NearbyStationDestinationTests.swift in Sources */,
 				28B86D763BF517E19CF4DB5D /* SuburbanProjectionTests.swift in Sources */,
 			);

--- a/iosApp/iosApp/Features/Go/GoDemoEntryView.swift
+++ b/iosApp/iosApp/Features/Go/GoDemoEntryView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+// Entry point that builds a real planned journey from the bundled network and
+// hands it to the GO screen. Prefers a cross-line route (so the preview shows a
+// transfer) and falls back to a long single-line route, so it works whatever the
+// seed contains.
+struct GoDemoEntryView: View {
+    let language: AppLanguage
+
+    private var journey: GuidanceJourney? {
+        let ops = SyrmosData.operationalLines
+
+        // Prefer M1 origin -> M2 destination (usually a transfer through the core).
+        if let m1 = ops.first(where: { $0.id == "M1" }),
+           let m2 = ops.first(where: { $0.id == "M2" }),
+           let a = SyrmosData.stations(for: m1.id).first?.id,
+           let b = SyrmosData.stations(for: m2.id).last?.id,
+           let detailed = JourneyPlanner.planDetailed(from: a, to: b, language: language) {
+            return GuidanceJourney.from(detailed, language: language)
+        }
+
+        // Fallback: first operational line with >=4 stops, first -> last.
+        for line in ops {
+            let stops = SyrmosData.stations(for: line.id)
+            if stops.count >= 4,
+               let detailed = JourneyPlanner.planDetailed(from: stops[0].id, to: stops[stops.count - 1].id, language: language) {
+                return GuidanceJourney.from(detailed, language: language)
+            }
+        }
+        return nil
+    }
+
+    var body: some View {
+        if let journey {
+            GoJourneyView(journey: journey, language: language)
+        } else {
+            ContentUnavailableView(
+                language == .greek ? "Δεν βρέθηκε διαδρομή" : language == .albanian ? "Nuk u gjet rrugë" : language == .italian ? "Nessun percorso" : "No route available",
+                systemImage: "figure.walk.motion",
+                description: Text(
+                    language == .greek ? "Δεν ήταν δυνατή η δημιουργία διαδρομής από τα δεδομένα." :
+                    language == .albanian ? "Nuk u krijua dot një rrugë nga të dhënat." :
+                    language == .italian ? "Impossibile creare un percorso dai dati." :
+                    "Could not build a route from the bundled data."
+                )
+            )
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Go/GoJourneyView.swift
+++ b/iosApp/iosApp/Features/Go/GoJourneyView.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+
+// The GO screen: guide the rider through a planned journey one instruction at a
+// time (board / stay on / get off next / change here / arrived). The current
+// instruction is the hero; the get-off cue is emphasised because it is the one
+// moment that matters most. Advancing is manual for now (step through your
+// journey); GPS / live-position auto-advance is a later phase, so the control is
+// labelled "Next stop" rather than implying live tracking.
+struct GoJourneyView: View {
+    @StateObject private var model: GoJourneyViewModel
+    let language: AppLanguage
+    private let originName: String
+    private let destinationName: String
+
+    init(journey: GuidanceJourney, language: AppLanguage) {
+        _model = StateObject(wrappedValue: GoJourneyViewModel(journey: journey))
+        self.language = language
+        self.originName = journey.legs.first?.stops.first?.name ?? ""
+        self.destinationName = journey.legs.last?.stops.last?.name ?? ""
+    }
+
+    private var tint: Color {
+        guard let id = model.currentLineId else { return .accentColor }
+        return SyrmosData.line(for: id)?.color ?? .accentColor
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            header
+            heroCard
+            ProgressView(value: model.progress)
+                .tint(tint)
+                .padding(.horizontal)
+            controls
+            Spacer()
+            footnote
+        }
+        .padding()
+        .navigationTitle("GO")
+        .navigationBarTitleDisplayMode(.inline)
+        .animation(.easeInOut(duration: 0.2), value: model.position)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text(originName).fontWeight(.semibold)
+            Image(systemName: "arrow.right").font(.caption).foregroundStyle(.secondary)
+            Text(destinationName).fontWeight(.semibold)
+        }
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var heroCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label {
+                Text(headline).font(.title2.bold())
+            } icon: {
+                Image(systemName: icon).font(.title2)
+            }
+            .foregroundStyle(model.shouldAlert ? Color.white : tint)
+
+            if !detail.isEmpty {
+                Text(detail)
+                    .font(.headline)
+                    .foregroundStyle(model.shouldAlert ? Color.white.opacity(0.9) : .primary)
+            }
+            if !subdetail.isEmpty {
+                Text(subdetail)
+                    .font(.subheadline)
+                    .foregroundStyle(model.shouldAlert ? Color.white.opacity(0.8) : .secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(model.shouldAlert ? tint : tint.opacity(0.12))
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(headline). \(detail). \(subdetail)")
+    }
+
+    private var controls: some View {
+        HStack(spacing: 12) {
+            Button {
+                model.back()
+            } label: {
+                Label(t("Back", "Πίσω", "Prapa", "Indietro"), systemImage: "chevron.left")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .disabled(!model.canGoBack)
+
+            if model.isArrived {
+                Button {
+                    model.reset()
+                } label: {
+                    Label(t("Restart", "Επανεκκίνηση", "Rifillo", "Ricomincia"), systemImage: "arrow.counterclockwise")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(tint)
+            } else {
+                Button {
+                    model.advance()
+                } label: {
+                    Label(t("Next stop", "Επόμενη στάση", "Ndalesa tjetër", "Fermata succ."), systemImage: "chevron.right")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(tint)
+            }
+        }
+    }
+
+    private var footnote: some View {
+        Text(t(
+            "Step through your journey. Live get-off alerts as you ride are coming next.",
+            "Δες το ταξίδι σου βήμα-βήμα. Οι ζωντανές ειδοποιήσεις αποβίβασης έρχονται σύντομα.",
+            "Shiko udhëtimin hap pas hapi. Njoftimet e zbritjes në kohë reale vijnë së shpejti.",
+            "Percorri il tuo viaggio passo passo. Gli avvisi di discesa in tempo reale arrivano presto."
+        ))
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+    }
+
+    // MARK: Instruction rendering
+
+    private var icon: String {
+        switch model.current {
+        case .board: return "figure.walk"
+        case .ride: return "tram.fill"
+        case .getOffNext: return "figure.walk.departure"
+        case .transfer: return "arrow.triangle.swap"
+        case .arrived: return "checkmark.circle.fill"
+        }
+    }
+
+    private var headline: String {
+        switch model.current {
+        case .board(let line, _, _, _):
+            return t("Board \(line)", "Επιβίβαση \(line)", "Hip në \(line)", "Sali su \(line)")
+        case .ride(let line, _, _, _):
+            return t("Stay on \(line)", "Μείνε στη \(line)", "Qëndro në \(line)", "Resta su \(line)")
+        case .getOffNext:
+            return t("Get off next", "Αποβίβαση στην επόμενη", "Zbrit në tjetrën", "Scendi alla prossima")
+        case .transfer:
+            return t("Change here", "Αλλαγή εδώ", "Ndërro këtu", "Cambia qui")
+        case .arrived:
+            return t("Arrived", "Έφτασες", "Mbërritët", "Arrivato")
+        }
+    }
+
+    private var detail: String {
+        switch model.current {
+        case .board(_, let towards, _, _), .ride(_, let towards, _, _):
+            return t("toward \(towards)", "προς \(towards)", "drejt \(towards)", "verso \(towards)")
+        case .getOffNext(let next, let isDestination, let transferTo):
+            if isDestination { return next }
+            if let x = transferTo { return t("\(next) → change to \(x)", "\(next) → αλλαγή σε \(x)", "\(next) → ndërro në \(x)", "\(next) → cambia in \(x)") }
+            return next
+        case .transfer(let at, let to, let towards):
+            return t("\(at) → \(to) toward \(towards)", "\(at) → \(to) προς \(towards)", "\(at) → \(to) drejt \(towards)", "\(at) → \(to) verso \(towards)")
+        case .arrived(let station):
+            return station
+        }
+    }
+
+    private var subdetail: String {
+        switch model.current {
+        case .board(_, _, let remaining, let next), .ride(_, _, let remaining, let next):
+            let stops = t("\(remaining) stops", "\(remaining) στάσεις", "\(remaining) ndalesa", "\(remaining) fermate")
+            return t("\(stops) · next \(next)", "\(stops) · επόμενη \(next)", "\(stops) · tjetra \(next)", "\(stops) · prossima \(next)")
+        case .getOffNext(let next, let isDestination, _):
+            return isDestination
+                ? t("Your destination is next", "Ο προορισμός σου είναι η επόμενη", "Destinacioni yt është tjetra", "La tua destinazione è la prossima")
+                : t("Next stop: \(next)", "Επόμενη στάση: \(next)", "Ndalesa tjetër: \(next)", "Prossima fermata: \(next)")
+        default:
+            return ""
+        }
+    }
+
+    private func t(_ en: String, _ el: String, _ sq: String, _ it: String) -> String {
+        switch language {
+        case .greek: return el
+        case .albanian: return sq
+        case .italian: return it
+        default: return en
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Go/GoJourneyViewModel.swift
+++ b/iosApp/iosApp/Features/Go/GoJourneyViewModel.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftUI
+
+// Drives the GO live-guidance screen over a planned journey. Holds the rider's
+// position and derives the current instruction from the pure `JourneyGuidance`
+// engine. Advancing is manual here (step through your journey); a later phase
+// advances `position` from GPS proximity / live train position. Pure UI state on
+// top of the engine — no network, no clock.
+@MainActor
+final class GoJourneyViewModel: ObservableObject {
+    let journey: GuidanceJourney
+    @Published private(set) var position: GuidancePosition
+
+    init(journey: GuidanceJourney) {
+        self.journey = journey
+        self.position = GuidancePosition(legIndex: 0, stopIndex: 0)
+    }
+
+    // MARK: Derived state
+
+    var current: JourneyGuidance {
+        (try? JourneyGuidance.at(journey, position)) ?? .arrived(station: journey.legs.last?.stops.last?.name ?? "")
+    }
+
+    var isArrived: Bool { JourneyGuidance.isArrived(journey, position) }
+
+    /// True when the rider is one stop from a leg's alight point (fire the get-off
+    /// cue). Keyed independently of the display case, per the GO contract.
+    var shouldAlert: Bool { JourneyGuidance.shouldAlertGetOff(journey, position) }
+
+    var canAdvance: Bool { !isArrived }
+    var canGoBack: Bool { position.legIndex > 0 || position.stopIndex > 0 }
+
+    /// 0...1 progress across the whole journey by stops visited.
+    var progress: Double {
+        let total = max(1, journey.legs.reduce(0) { $0 + max(0, $1.stops.count - 1) })
+        var done = 0
+        for i in 0..<position.legIndex { done += max(0, journey.legs[i].stops.count - 1) }
+        done += position.stopIndex
+        return min(1, Double(done) / Double(total))
+    }
+
+    /// The line id for the current leg (for tint), nil once arrived at the end.
+    var currentLineId: String? {
+        guard journey.legs.indices.contains(position.legIndex) else { return nil }
+        return journey.legs[position.legIndex].lineId
+    }
+
+    // MARK: Actions
+
+    func advance() {
+        guard canAdvance else { return }
+        position = JourneyGuidance.advance(journey, position)
+    }
+
+    func back() {
+        if position.stopIndex > 0 {
+            position = GuidancePosition(legIndex: position.legIndex, stopIndex: position.stopIndex - 1)
+        } else if position.legIndex > 0 {
+            let prev = position.legIndex - 1
+            position = GuidancePosition(legIndex: prev, stopIndex: journey.legs[prev].stops.count - 1)
+        }
+    }
+
+    func reset() { position = GuidancePosition(legIndex: 0, stopIndex: 0) }
+}

--- a/iosApp/iosApp/Views/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Views/Settings/SettingsView.swift
@@ -39,6 +39,25 @@ struct SyrmosSettingsView: View {
 
                 contactSection
 
+                // GO is a 3.0 preview (manual step-through; live get-off alerts
+                // come later), so it rides the internal-build flag: visible in
+                // TestFlight / internal betas, hidden in a public App Store build
+                // until live GO ships.
+                if BuildEnv.isInternalBuild {
+                    Section {
+                        NavigationLink {
+                            GoDemoEntryView(language: loc.language)
+                        } label: {
+                            Label(
+                                loc.language == .greek ? "Οδηγός ταξιδιού (GO)" : loc.language == .albanian ? "Udhëzues udhëtimi (GO)" : loc.language == .italian ? "Guida al viaggio (GO)" : "Journey guide (GO)",
+                                systemImage: "figure.walk.motion"
+                            )
+                        }
+                    } footer: {
+                        Text(loc.language == .greek ? "Δες μια διαδρομή βήμα-βήμα με το GO." : loc.language == .albanian ? "Shiko një rrugë hap pas hapi me GO." : loc.language == .italian ? "Vedi un percorso passo passo con GO." : "Preview a route step by step with GO.")
+                    }
+                }
+
                 #if DEBUG
                 Section {
                     NavigationLink {

--- a/iosApp/iosAppTests/GoJourneyViewModelTests.swift
+++ b/iosApp/iosAppTests/GoJourneyViewModelTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import Syrmos
+
+@MainActor
+final class GoJourneyViewModelTests: XCTestCase {
+
+    // Two-leg journey: M2 (3 stops) -> transfer -> M3 (2 stops).
+    private func journey() -> GuidanceJourney {
+        GuidanceJourney(legs: [
+            GuidanceLeg(lineId: "M2", towards: "Syntagma", stops: [
+                GuidanceStop(id: "M2_A", name: "A"),
+                GuidanceStop(id: "M2_B", name: "B"),
+                GuidanceStop(id: "M2_SYN", name: "Syntagma"),
+            ]),
+            GuidanceLeg(lineId: "M3", towards: "Airport", stops: [
+                GuidanceStop(id: "M3_SYN", name: "Syntagma"),
+                GuidanceStop(id: "M3_AER", name: "Airport"),
+            ]),
+        ])
+    }
+
+    func test_walkThrough_currentStepsAndAlerts() {
+        let vm = GoJourneyViewModel(journey: journey())
+
+        // Start: board M2, not yet alerting, can advance, cannot go back.
+        guard case .board(let line, _, _, _) = vm.current else { return XCTFail("expected board") }
+        XCTAssertEqual(line, "M2")
+        XCTAssertFalse(vm.shouldAlert)
+        XCTAssertTrue(vm.canAdvance)
+        XCTAssertFalse(vm.canGoBack)
+        XCTAssertEqual(vm.currentLineId, "M2")
+
+        vm.advance() // at B: ride, one stop before Syntagma -> alert
+        guard case .getOffNext(let s, let dest, let xfer) = vm.current else { return XCTFail("expected getOffNext") }
+        XCTAssertEqual(s, "Syntagma"); XCTAssertFalse(dest); XCTAssertEqual(xfer, "M3")
+        XCTAssertTrue(vm.shouldAlert)
+
+        vm.advance() // at Syntagma (M2 alight): transfer to M3
+        guard case .transfer(_, let to, _) = vm.current else { return XCTFail("expected transfer") }
+        XCTAssertEqual(to, "M3")
+        XCTAssertFalse(vm.shouldAlert)
+
+        vm.advance() // board M3 (2-stop leg -> board coincides with alert)
+        guard case .board(let l2, _, _, _) = vm.current else { return XCTFail("expected board M3") }
+        XCTAssertEqual(l2, "M3")
+        XCTAssertTrue(vm.shouldAlert, "2-stop leg: get-off cue coincides with board")
+
+        vm.advance() // arrived at Airport
+        XCTAssertTrue(vm.isArrived)
+        guard case .arrived(let station) = vm.current else { return XCTFail("expected arrived") }
+        XCTAssertEqual(station, "Airport")
+        XCTAssertFalse(vm.canAdvance)
+    }
+
+    func test_back_reversesPositionAcrossLegs() {
+        let vm = GoJourneyViewModel(journey: journey())
+        vm.advance(); vm.advance(); vm.advance() // now on M3 leg, stop 0
+        XCTAssertEqual(vm.currentLineId, "M3")
+        vm.back() // back to M2 alight (Syntagma)
+        XCTAssertEqual(vm.currentLineId, "M2")
+        if case .transfer = vm.current {} else { XCTFail("expected transfer after back") }
+    }
+
+    func test_progress_isMonotonicToOne() {
+        let vm = GoJourneyViewModel(journey: journey())
+        var last = -1.0
+        while vm.canAdvance {
+            XCTAssertGreaterThanOrEqual(vm.progress, last)
+            last = vm.progress
+            vm.advance()
+        }
+        XCTAssertEqual(vm.progress, 1.0, accuracy: 0.0001)
+    }
+
+    func test_reset_returnsToOrigin() {
+        let vm = GoJourneyViewModel(journey: journey())
+        vm.advance(); vm.advance()
+        vm.reset()
+        XCTAssertEqual(vm.position.legIndex, 0)
+        XCTAssertEqual(vm.position.stopIndex, 0)
+    }
+}


### PR DESCRIPTION
## Why
The first **user-visible** slice of 3.0 GO: a screen that guides a rider through a planned journey one instruction at a time — **board / stay on / get off next / change here / arrived** — with the get-off cue emphasised (the one moment that matters most). Turns the merged GO engine + planner connection into something a rider can see.

## What
- **`GoJourneyViewModel`** — pure UI state over the `JourneyGuidance` engine (current step, get-off predicate, progress, advance/back/reset). Unit-tested.
- **`GoJourneyView`** — SwiftUI hero-instruction card, line-tinted, get-off state emphasised, progress bar, controls, localized EN/EL/SQ/IT. Advancing is manual for now (`Next stop`); a footnote states live get-off alerts are coming, so it doesn't imply live tracking it doesn't yet do.
- **`GoDemoEntryView`** — builds a real journey via `JourneyPlanner.planDetailed` (prefers a cross-line route to show a transfer; falls back to a long single-line route) and hands it to the screen.
- **`SettingsView`** — a "Journey guide (GO)" row, **gated behind `BuildEnv.isInternalBuild`** so GO appears in TestFlight / internal betas but **not** a public App Store build until live GO ships (rollout control, matching `developerSection`).
- **`GoJourneyViewModelTests`** — step/alert transitions across a transfer journey, back across legs, monotonic progress to 1, reset.

## Verification (local)
`GoJourneyViewModelTests` pass; the whole app + all SwiftUI views compile (`** TEST SUCCEEDED **`), including after gating; the app launches cleanly on the iPhone 17 sim with these changes. Visual navigation to the screen is blocked by simulator device-access gating in this environment (honest boundary); CI's `ios-ui-inspection` job captures launch inspection.

## Scope / risk
Additive; the only change to existing code is one gated Settings row. Feature-flagged off for public builds. Reversible. No release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)