### PR TITLE
feat(go): GPS-proximity advancer - the pure core of live GO

### DIFF
--- a/iosApp/Syrmos.xcodeproj/project.pbxproj
+++ b/iosApp/Syrmos.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		DA7A0202F00D0202F00D0202 /* JourneyGuidanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */; };
 		DA7A0206F00D0206F00D0206 /* JourneyPlannerConnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0207F00D0207F00D0207 /* JourneyPlannerConnectTests.swift */; };
 		DA7A020EF00D020EF00D020E /* GoJourneyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A020FF00D020FF00D020F /* GoJourneyViewModelTests.swift */; };
+		DA7A0222F00D0222F00D0222 /* GoLocationAdvancerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0223F00D0223F00D0223 /* GoLocationAdvancerTests.swift */; };
 		DA7A0021F00D0021F00D0021 /* DepartureTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0022F00D0022F00D0022 /* DepartureTracking.swift */; };
 		DA7A0030F00D0030F00D0030 /* MapRouteGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */; };
 		DA7A010BF00D010BF00D010B /* SyrmosWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DA7A0107F00D0107F00D0107 /* SyrmosWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -127,6 +128,7 @@
 		DA7A0208F00D0208F00D0208 /* GoJourneyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0209F00D0209F00D0209 /* GoJourneyViewModel.swift */; };
 		DA7A020AF00D020AF00D020A /* GoJourneyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A020BF00D020BF00D020B /* GoJourneyView.swift */; };
 		DA7A020CF00D020CF00D020C /* GoDemoEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A020DF00D020DF00D020D /* GoDemoEntryView.swift */; };
+		DA7A0220F00D0220F00D0220 /* GoLocationAdvancer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0221F00D0221F00D0221 /* GoLocationAdvancer.swift */; };
 		DA7A0140F00D0140F00D0140 /* WeatherStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0141F00D0141F00D0141 /* WeatherStore.swift */; };
 		DA7A0142F00D0142F00D0142 /* WeatherCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0143F00D0143F00D0143 /* WeatherCard.swift */; };
 		DA7A0150F00D0150F00D0150 /* AriadneBrain.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */; };
@@ -317,6 +319,7 @@
 		DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JourneyGuidanceTests.swift; sourceTree = "<group>"; };
 		DA7A0207F00D0207F00D0207 /* JourneyPlannerConnectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JourneyPlannerConnectTests.swift; sourceTree = "<group>"; };
 		DA7A020FF00D020FF00D020F /* GoJourneyViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GoJourneyViewModelTests.swift; sourceTree = "<group>"; };
+		DA7A0223F00D0223F00D0223 /* GoLocationAdvancerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GoLocationAdvancerTests.swift; sourceTree = "<group>"; };
 		DA7A0022F00D0022F00D0022 /* DepartureTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Schedule/DepartureTracking.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MapRouteGeometryTests.swift; sourceTree = "<group>"; };
 		DA7A0107F00D0107F00D0107 /* SyrmosWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SyrmosWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -330,6 +333,7 @@
 		DA7A0209F00D0209F00D0209 /* GoJourneyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Go/GoJourneyViewModel.swift; sourceTree = SOURCE_ROOT; };
 		DA7A020BF00D020BF00D020B /* GoJourneyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Go/GoJourneyView.swift; sourceTree = SOURCE_ROOT; };
 		DA7A020DF00D020DF00D020D /* GoDemoEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Go/GoDemoEntryView.swift; sourceTree = SOURCE_ROOT; };
+		DA7A0221F00D0221F00D0221 /* GoLocationAdvancer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Go/GoLocationAdvancer.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0141F00D0141F00D0141 /* WeatherStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Networking/WeatherStore.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0143F00D0143F00D0143 /* WeatherCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Weather/WeatherCard.swift; sourceTree = SOURCE_ROOT; };
 		DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Assistant/AriadneBrain.swift; sourceTree = SOURCE_ROOT; };
@@ -409,6 +413,7 @@
 				DA7A0203F00D0203F00D0203 /* JourneyGuidanceTests.swift */,
 				DA7A0207F00D0207F00D0207 /* JourneyPlannerConnectTests.swift */,
 				DA7A020FF00D020FF00D020F /* GoJourneyViewModelTests.swift */,
+				DA7A0223F00D0223F00D0223 /* GoLocationAdvancerTests.swift */,
 				B9C311F839BA02691F04AB93 /* NearbyStationDestinationTests.swift */,
 				BF6FDC539EEBEA3DCEA3416B /* SuburbanProjectionTests.swift */,
 			);
@@ -686,6 +691,7 @@
 				DA7A0209F00D0209F00D0209 /* GoJourneyViewModel.swift */,
 				DA7A020BF00D020BF00D020B /* GoJourneyView.swift */,
 				DA7A020DF00D020DF00D020D /* GoDemoEntryView.swift */,
+				DA7A0221F00D0221F00D0221 /* GoLocationAdvancer.swift */,
 				DA7A0141F00D0141F00D0141 /* WeatherStore.swift */,
 				DA7A0143F00D0143F00D0143 /* WeatherCard.swift */,
 				DA7A0151F00D0151F00D0151 /* AriadneBrain.swift */,
@@ -979,6 +985,7 @@
 				DA7A0208F00D0208F00D0208 /* GoJourneyViewModel.swift in Sources */,
 				DA7A020AF00D020AF00D020A /* GoJourneyView.swift in Sources */,
 				DA7A020CF00D020CF00D020C /* GoDemoEntryView.swift in Sources */,
+				DA7A0220F00D0220F00D0220 /* GoLocationAdvancer.swift in Sources */,
 				DA7A0140F00D0140F00D0140 /* WeatherStore.swift in Sources */,
 				DA7A0142F00D0142F00D0142 /* WeatherCard.swift in Sources */,
 				DA7A0150F00D0150F00D0150 /* AriadneBrain.swift in Sources */,
@@ -1054,6 +1061,7 @@
 				DA7A0202F00D0202F00D0202 /* JourneyGuidanceTests.swift in Sources */,
 				DA7A0206F00D0206F00D0206 /* JourneyPlannerConnectTests.swift in Sources */,
 				DA7A020EF00D020EF00D020E /* GoJourneyViewModelTests.swift in Sources */,
+				DA7A0222F00D0222F00D0222 /* GoLocationAdvancerTests.swift in Sources */,
 				ECAA824BE3E518277AB18AB6 /* NearbyStationDestinationTests.swift in Sources */,
 				28B86D763BF517E19CF4DB5D /* SuburbanProjectionTests.swift in Sources */,
 			);

--- a/iosApp/iosApp/Features/Go/GoLocationAdvancer.swift
+++ b/iosApp/iosApp/Features/Go/GoLocationAdvancer.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+// Pure core of LIVE GO: given the rider's GPS fix and the journey's stop
+// coordinates, decide which stop they have reached, so the guidance position can
+// advance on its own (no manual tapping). Kept free of CoreLocation so it is
+// fully unit-testable; the session layer feeds it a plain lat/lon.
+//
+// Rules:
+// - Only ever move FORWARD from the current position. GPS jitter must never rewind
+//   the rider's guidance to an earlier stop.
+// - Place the rider at the forward stop nearest their fix, but only within
+//   `thresholdMeters`; between stops (far from any) the position holds, so the
+//   guidance does not flicker.
+enum GoLocationAdvancer {
+    struct Coord: Equatable { let lat: Double; let lon: Double }
+
+    static func advancedPosition(
+        journey: GuidanceJourney,
+        current: GuidancePosition,
+        coords: [String: Coord],
+        lat: Double,
+        lon: Double,
+        thresholdMeters: Double = 350
+    ) -> GuidancePosition {
+        var best = current
+        var bestDist = Double.greatestFiniteMagnitude
+        var cursor: GuidancePosition? = current
+        while let pos = cursor {
+            if let stop = stop(journey, pos), let c = coords[stop.id] {
+                let d = haversine(c.lat, c.lon, lat, lon)
+                if d <= thresholdMeters && d < bestDist {
+                    bestDist = d
+                    best = pos
+                }
+            }
+            cursor = next(journey, pos)
+        }
+        return best
+    }
+
+    // MARK: Journey walk (forward only)
+
+    private static func stop(_ j: GuidanceJourney, _ p: GuidancePosition) -> GuidanceStop? {
+        guard j.legs.indices.contains(p.legIndex),
+              j.legs[p.legIndex].stops.indices.contains(p.stopIndex) else { return nil }
+        return j.legs[p.legIndex].stops[p.stopIndex]
+    }
+
+    private static func next(_ j: GuidanceJourney, _ p: GuidancePosition) -> GuidancePosition? {
+        guard j.legs.indices.contains(p.legIndex) else { return nil }
+        let leg = j.legs[p.legIndex]
+        if p.stopIndex < leg.stops.count - 1 {
+            return GuidancePosition(legIndex: p.legIndex, stopIndex: p.stopIndex + 1)
+        }
+        if p.legIndex < j.legs.count - 1 {
+            return GuidancePosition(legIndex: p.legIndex + 1, stopIndex: 0)
+        }
+        return nil
+    }
+
+    // MARK: Distance
+
+    /// Great-circle distance in metres.
+    static func haversine(_ lat1: Double, _ lon1: Double, _ lat2: Double, _ lon2: Double) -> Double {
+        let r = 6_371_000.0
+        let dLat = (lat2 - lat1) * .pi / 180
+        let dLon = (lon2 - lon1) * .pi / 180
+        let a = sin(dLat / 2) * sin(dLat / 2)
+            + cos(lat1 * .pi / 180) * cos(lat2 * .pi / 180) * sin(dLon / 2) * sin(dLon / 2)
+        return 2 * r * asin(min(1, sqrt(a)))
+    }
+}

--- a/iosApp/iosAppTests/GoLocationAdvancerTests.swift
+++ b/iosApp/iosAppTests/GoLocationAdvancerTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Syrmos
+
+final class GoLocationAdvancerTests: XCTestCase {
+
+    // A straight west->east line of 4 stops ~1km apart at lat 38.0.
+    // 0.009 deg lon ~ 790m at this latitude; use 0.012 for ~1km spacing.
+    private let coords: [String: GoLocationAdvancer.Coord] = [
+        "S0": .init(lat: 38.0, lon: 23.700),
+        "S1": .init(lat: 38.0, lon: 23.712),
+        "S2": .init(lat: 38.0, lon: 23.724),
+        "S3": .init(lat: 38.0, lon: 23.736),
+    ]
+
+    private func line4() -> GuidanceJourney {
+        GuidanceJourney(legs: [
+            GuidanceLeg(lineId: "L", towards: "S3", stops: [
+                GuidanceStop(id: "S0", name: "S0"),
+                GuidanceStop(id: "S1", name: "S1"),
+                GuidanceStop(id: "S2", name: "S2"),
+                GuidanceStop(id: "S3", name: "S3"),
+            ]),
+        ])
+    }
+
+    private func pos(_ l: Int, _ s: Int) -> GuidancePosition { GuidancePosition(legIndex: l, stopIndex: s) }
+
+    func test_atStopCoordinate_placesRiderThere() {
+        let j = line4()
+        let p = GoLocationAdvancer.advancedPosition(journey: j, current: pos(0, 0), coords: coords, lat: 38.0, lon: 23.724)
+        XCTAssertEqual(p, pos(0, 2)) // near S2
+    }
+
+    func test_neverMovesBackward() {
+        let j = line4()
+        // Rider is currently at S2 but a jittery fix lands near S0.
+        let p = GoLocationAdvancer.advancedPosition(journey: j, current: pos(0, 2), coords: coords, lat: 38.0, lon: 23.700)
+        XCTAssertEqual(p, pos(0, 2), "must not rewind to an earlier stop on a bad fix")
+    }
+
+    func test_betweenStops_holdsPosition() {
+        let j = line4()
+        // Midway between S1 and S2 (~lon 23.718), ~400m from each -> beyond 350m
+        // threshold, so hold at current.
+        let p = GoLocationAdvancer.advancedPosition(journey: j, current: pos(0, 1), coords: coords, lat: 38.0, lon: 23.718)
+        XCTAssertEqual(p, pos(0, 1))
+    }
+
+    func test_advancesForwardToNearestStopWithinThreshold() {
+        let j = line4()
+        let p = GoLocationAdvancer.advancedPosition(journey: j, current: pos(0, 0), coords: coords, lat: 38.0, lon: 23.735)
+        XCTAssertEqual(p, pos(0, 3)) // arrived at S3
+    }
+
+    func test_transfer_advancesOntoNextLeg() {
+        // Two legs sharing an interchange (X) with slightly offset platform coords.
+        let j = GuidanceJourney(legs: [
+            GuidanceLeg(lineId: "A", towards: "XA", stops: [
+                GuidanceStop(id: "A0", name: "A0"),
+                GuidanceStop(id: "XA", name: "X"),
+            ]),
+            GuidanceLeg(lineId: "B", towards: "B1", stops: [
+                GuidanceStop(id: "XB", name: "X"),
+                GuidanceStop(id: "B1", name: "B1"),
+            ]),
+        ])
+        let c: [String: GoLocationAdvancer.Coord] = [
+            "A0": .init(lat: 38.0, lon: 23.700),
+            "XA": .init(lat: 38.0, lon: 23.750),
+            "XB": .init(lat: 38.0005, lon: 23.7502),
+            "B1": .init(lat: 38.010, lon: 23.760),
+        ]
+        // Rider standing at the interchange, closest to leg B's board platform.
+        let p = GoLocationAdvancer.advancedPosition(journey: j, current: pos(0, 0), coords: c, lat: 38.0005, lon: 23.7502)
+        XCTAssertEqual(p, pos(1, 0), "at the interchange, advance onto the next leg's board stop")
+    }
+
+    func test_haversine_knownDistance() {
+        // ~1.1 km per 0.01 deg latitude.
+        let d = GoLocationAdvancer.haversine(38.0, 23.7, 38.01, 23.7)
+        XCTAssertEqual(d, 1113, accuracy: 30)
+    }
+}


### PR DESCRIPTION
## Why
The 3.0.0-beta.1 GO screen advances manually. The signature transit feature (Transit/Citymapper/Moovit GO) is **live** guidance: the app tracks your position and tells you to get off at the right moment, hands-free. This lands the algorithmic core of that.

## What
- **`GoLocationAdvancer.advancedPosition`** — given the rider's GPS fix and the journey's stop coordinates, returns the forward-most journey position they've plausibly reached:
  - **forward-only** — GPS jitter never rewinds guidance to an earlier stop;
  - **threshold-gated** (~350m) — holds position between stops so guidance doesn't flicker;
  - handles **transfers** — advances onto the next leg's board platform at an interchange.
  - Pure and CoreLocation-free, so fully unit-tested.
- **`GoLocationAdvancerTests`** (6) — at-stop placement, never-backward on a bad fix, hold-between-stops, forward advance, transfer onto next leg, Haversine sanity.

## Verification (local)
`xcodebuild test -only-testing:iosAppTests/GoLocationAdvancerTests` → **6/6, `** TEST SUCCEEDED **`**.

## Next / scope
This PR is the testable core only. The follow-up wires it to `CLLocationManager` + a get-off local notification (+haptic) and a "live" toggle in the GO screen; that live UI can't be visually verified in this environment (simulator device-access gating), so it ships with clear caveats. Additive, no behaviour change to existing code. Reversible. No release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)