### PR TITLE
feat(go): web GO — JS planner + panel (browser-verified)

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-go-panel.js
+++ b/composeApp/src/wasmJsMain/resources/web-go-panel.js
@@ -1,0 +1,129 @@
+'use strict';
+// Renders the GO live-guidance panel for the web: given a planned GuidanceJourney,
+// show the one instruction that matters now (board / stay on / get off next /
+// change here / arrived) with the get-off cue emphasised, and Next/Back controls
+// to step through. Pure view over web-go.js; advancing is manual for now (live
+// position advance is a later phase), matching the iOS GO screen.
+//
+// UMD: `require('./web-go-panel.js')` in node (logic testable), `window.SyrmosGoPanel`
+// in the browser.
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory(root);
+  else root.SyrmosGoPanel = factory(root);
+})(typeof self !== 'undefined' ? self : this, function (root) {
+  const GO = (typeof require === 'function') ? require('./web-go.js') : root.SyrmosGO;
+
+  function t(lang, en, el, sq, it) {
+    return lang === 'el' ? el : lang === 'sq' ? sq : lang === 'it' ? it : en;
+  }
+
+  // The rider-facing text for a guidance object (headline + detail + sub).
+  function describe(g, lang) {
+    switch (g.kind) {
+      case 'board':
+        return {
+          icon: '🚶', headline: t(lang, `Board ${g.lineId}`, `Επιβίβαση ${g.lineId}`, `Hip në ${g.lineId}`, `Sali su ${g.lineId}`),
+          detail: t(lang, `toward ${g.towards}`, `προς ${g.towards}`, `drejt ${g.towards}`, `verso ${g.towards}`),
+          sub: t(lang, `${g.stopsRemaining} stops · next ${g.nextStation}`, `${g.stopsRemaining} στάσεις · επόμενη ${g.nextStation}`, `${g.stopsRemaining} ndalesa · tjetra ${g.nextStation}`, `${g.stopsRemaining} fermate · prossima ${g.nextStation}`),
+        };
+      case 'ride':
+        return {
+          icon: '🚈', headline: t(lang, `Stay on ${g.lineId}`, `Μείνε στη ${g.lineId}`, `Qëndro në ${g.lineId}`, `Resta su ${g.lineId}`),
+          detail: t(lang, `toward ${g.towards}`, `προς ${g.towards}`, `drejt ${g.towards}`, `verso ${g.towards}`),
+          sub: t(lang, `${g.stopsRemaining} stops · next ${g.nextStation}`, `${g.stopsRemaining} στάσεις · επόμενη ${g.nextStation}`, `${g.stopsRemaining} ndalesa · tjetra ${g.nextStation}`, `${g.stopsRemaining} fermate · prossima ${g.nextStation}`),
+        };
+      case 'getOffNext':
+        return {
+          icon: '🚪', headline: t(lang, 'Get off next', 'Αποβίβαση στην επόμενη', 'Zbrit në tjetrën', 'Scendi alla prossima'),
+          detail: g.isDestination ? g.nextStation : (g.transferTo ? t(lang, `${g.nextStation} → change to ${g.transferTo}`, `${g.nextStation} → αλλαγή σε ${g.transferTo}`, `${g.nextStation} → ndërro në ${g.transferTo}`, `${g.nextStation} → cambia in ${g.transferTo}`) : g.nextStation),
+          sub: g.isDestination ? t(lang, 'Your destination is next', 'Ο προορισμός σου είναι η επόμενη', 'Destinacioni yt është tjetra', 'La tua destinazione è la prossima') : t(lang, `Next stop: ${g.nextStation}`, `Επόμενη στάση: ${g.nextStation}`, `Ndalesa tjetër: ${g.nextStation}`, `Prossima fermata: ${g.nextStation}`),
+        };
+      case 'transfer':
+        return {
+          icon: '🔄', headline: t(lang, 'Change here', 'Αλλαγή εδώ', 'Ndërro këtu', 'Cambia qui'),
+          detail: t(lang, `${g.atStation} → ${g.toLineId} toward ${g.towards}`, `${g.atStation} → ${g.toLineId} προς ${g.towards}`, `${g.atStation} → ${g.toLineId} drejt ${g.towards}`, `${g.atStation} → ${g.toLineId} verso ${g.towards}`),
+          sub: '',
+        };
+      case 'arrived':
+        return {
+          icon: '✓', headline: t(lang, 'Arrived', 'Έφτασες', 'Mbërritët', 'Arrivato'), detail: g.station, sub: '',
+        };
+      default:
+        return { icon: '', headline: '', detail: '', sub: '' };
+    }
+  }
+
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+  }
+
+  // Mount the panel into `container`. `opts`: { language, lineColor(lineId)->css }.
+  function mount(container, journey, opts) {
+    opts = opts || {};
+    const lang = opts.language || 'en';
+    const color = (id) => (opts.lineColor ? opts.lineColor(id) || '#0072CE' : '#0072CE');
+    let pos = { legIndex: 0, stopIndex: 0 };
+
+    const origin = journey.legs[0] && journey.legs[0].stops[0] ? journey.legs[0].stops[0].name : '';
+    const destLeg = journey.legs[journey.legs.length - 1];
+    const dest = destLeg ? destLeg.stops[destLeg.stops.length - 1].name : '';
+
+    function progress() {
+      const total = Math.max(1, journey.legs.reduce((n, l) => n + Math.max(0, l.stops.length - 1), 0));
+      let done = 0;
+      for (let i = 0; i < pos.legIndex; i++) done += Math.max(0, journey.legs[i].stops.length - 1);
+      done += pos.stopIndex;
+      return Math.min(1, done / total);
+    }
+
+    function render() {
+      const g = GO.guidance(journey, pos);
+      const alert = GO.shouldAlertGetOff(journey, pos);
+      const arrived = GO.isArrived(journey, pos);
+      const d = describe(g, lang);
+      const tint = g.kind === 'arrived' ? '#2E7D32' : color(g.lineId || (journey.legs[pos.legIndex] && journey.legs[pos.legIndex].lineId));
+      const canBack = pos.legIndex > 0 || pos.stopIndex > 0;
+
+      container.innerHTML = `
+        <div class="go-panel" role="group" aria-label="GO journey guidance" style="max-width:420px;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;">
+          <div class="go-head" style="display:flex;gap:8px;align-items:center;color:#666;font-size:14px;font-weight:600;margin-bottom:12px;">
+            <span>${esc(origin)}</span><span aria-hidden="true">→</span><span>${esc(dest)}</span>
+          </div>
+          <div class="go-card" style="border-radius:18px;padding:20px;background:${alert ? tint : tint + '1f'};color:${alert ? '#fff' : '#111'};">
+            <div style="font-size:22px;font-weight:800;display:flex;gap:10px;align-items:center;">
+              <span aria-hidden="true">${d.icon}</span><span>${esc(d.headline)}</span>
+            </div>
+            ${d.detail ? `<div style="font-size:17px;font-weight:700;margin-top:8px;">${esc(d.detail)}</div>` : ''}
+            ${d.sub ? `<div style="font-size:14px;opacity:.85;margin-top:4px;">${esc(d.sub)}</div>` : ''}
+          </div>
+          <div class="go-progress" style="height:6px;border-radius:3px;background:#e5e5e5;margin:14px 0;overflow:hidden;">
+            <div style="height:100%;width:${Math.round(progress() * 100)}%;background:${tint};"></div>
+          </div>
+          <div class="go-controls" style="display:flex;gap:10px;">
+            <button class="go-back" ${canBack ? '' : 'disabled'} style="flex:1;padding:12px;border-radius:12px;border:1px solid #ccc;background:#fff;font-weight:600;">${esc(t(lang, 'Back', 'Πίσω', 'Prapa', 'Indietro'))}</button>
+            <button class="go-next" style="flex:1;padding:12px;border-radius:12px;border:0;background:${tint};color:#fff;font-weight:700;">${arrived ? esc(t(lang, 'Restart', 'Επανεκκίνηση', 'Rifillo', 'Ricomincia')) : esc(t(lang, 'Next stop', 'Επόμενη στάση', 'Ndalesa tjetër', 'Fermata succ.'))}</button>
+          </div>
+        </div>`;
+
+      const back = container.querySelector('.go-back');
+      const next = container.querySelector('.go-next');
+      if (back) back.onclick = () => { api.back(); };
+      if (next) next.onclick = () => { arrived ? api.reset() : api.advance(); };
+    }
+
+    const api = {
+      advance() { if (!GO.isArrived(journey, pos)) { pos = GO.advance(journey, pos); render(); } },
+      back() {
+        if (pos.stopIndex > 0) pos = { legIndex: pos.legIndex, stopIndex: pos.stopIndex - 1 };
+        else if (pos.legIndex > 0) { const p = pos.legIndex - 1; pos = { legIndex: p, stopIndex: journey.legs[p].stops.length - 1 }; }
+        render();
+      },
+      reset() { pos = { legIndex: 0, stopIndex: 0 }; render(); },
+      position() { return pos; },
+    };
+    render();
+    return api;
+  }
+
+  return { mount, describe };
+});

--- a/composeApp/src/wasmJsMain/resources/web-planner.js
+++ b/composeApp/src/wasmJsMain/resources/web-planner.js
@@ -1,0 +1,179 @@
+'use strict';
+// Web point-to-point planner: Dijkstra over the bundled Athens rail graph,
+// producing a GuidanceJourney (legs of ordered {id, name} stops) that the GO
+// engine (web-go.js) can guide the rider through. It is the web peer of iOS
+// `JourneyPlanner.planDetailed`, so GO works on the web the same way it does on
+// iOS: plan A -> B, then GO.
+//
+// Interchange stations carry a different id per line (M2_SYN vs M3_SYN at
+// Syntagma), so the graph adds transfer edges between co-located stations (same
+// accent-folded name), letting Dijkstra change lines at a physical interchange.
+//
+// Pure: no DOM, no network. Callers pass the bundled `stations` (registry, for
+// names + interchange grouping) and `lines` (each with an ordered `stations`
+// array and a `type`).
+//
+// UMD: `require('./web-planner.js')` in node, `window.SyrmosPlanner` in browser.
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.SyrmosPlanner = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  const TRANSFER_MINUTES = 3;
+
+  function travelTime(type) {
+    switch (type) {
+      case 'metro': return 2;
+      case 'tram': return 3;
+      case 'suburban': return 4;
+      case 'bus': return 4;
+      default: return 5;
+    }
+  }
+
+  // Accent-folded, alphanumerics-only key for grouping co-located interchange
+  // stations by name (mirrors iOS AthensTransitParser.fold + filter).
+  function nameKey(s) {
+    return String(s || '')
+      .normalize('NFD')
+      .replace(/[̀-ͯ]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '');
+  }
+
+  function displayName(st) {
+    if (!st) return '';
+    return st.name || st.name_el || st.nameEl || st.id;
+  }
+
+  // Build { id -> station } from the registry, falling back to line.stations.
+  function indexStations(stations, lines) {
+    const byId = new Map();
+    for (const s of stations || []) byId.set(s.id, s);
+    for (const l of lines || []) {
+      for (const s of l.stations || []) if (!byId.has(s.id)) byId.set(s.id, s);
+    }
+    return byId;
+  }
+
+  function buildGraph(lines, byId) {
+    const graph = new Map();
+    const add = (a, b, lineId, weight) => {
+      if (!graph.has(a)) graph.set(a, []);
+      graph.get(a).push({ to: b, lineId, weight });
+    };
+
+    // Same-line edges between consecutive stops.
+    for (const line of lines || []) {
+      const w = travelTime(line.type);
+      const ordered = line.stations || [];
+      for (let i = 0; i < ordered.length - 1; i++) {
+        const a = ordered[i].id, b = ordered[i + 1].id;
+        add(a, b, line.id, w);
+        add(b, a, line.id, w);
+      }
+    }
+
+    // Transfer edges between co-located stations (same folded name).
+    const groups = new Map();
+    for (const id of byId.keys()) {
+      const key = nameKey(displayName(byId.get(id)));
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(id);
+    }
+    for (const ids of groups.values()) {
+      if (ids.length < 2) continue;
+      for (let i = 0; i < ids.length; i++) {
+        for (let j = i + 1; j < ids.length; j++) {
+          add(ids[i], ids[j], null, TRANSFER_MINUTES);
+          add(ids[j], ids[i], null, TRANSFER_MINUTES);
+        }
+      }
+    }
+    return graph;
+  }
+
+  // Dijkstra returning the ordered [{stationId, edge}] path and total weight.
+  function shortestPath(graph, fromId, toId) {
+    const dist = new Map([[fromId, 0]]);
+    const prev = new Map();
+    const visited = new Set();
+    const frontier = [[fromId, 0]];
+    while (frontier.length) {
+      frontier.sort((a, b) => a[1] - b[1]);
+      const [cur, d] = frontier.shift();
+      if (visited.has(cur)) continue;
+      visited.add(cur);
+      if (cur === toId) break;
+      for (const e of graph.get(cur) || []) {
+        const nd = d + e.weight;
+        if (nd < (dist.has(e.to) ? dist.get(e.to) : Infinity)) {
+          dist.set(e.to, nd);
+          prev.set(e.to, [cur, e]);
+          frontier.push([e.to, nd]);
+        }
+      }
+    }
+    if (!prev.has(toId)) return null;
+    const path = [];
+    let node = toId;
+    while (node !== fromId) {
+      const [p, e] = prev.get(node);
+      path.unshift({ stationId: node, edge: e });
+      node = p;
+    }
+    return { path, total: dist.get(toId) };
+  }
+
+  // Plan the fastest route as a GuidanceJourney { legs: [ { lineId, towards,
+  // stops: [ {id, name} ] } ] }, or null when there is no route.
+  function planDetailed(stations, lines, fromId, toId, language) {
+    if (!fromId || !toId || fromId === toId) return null;
+    const byId = indexStations(stations, lines);
+    if (!byId.has(fromId) || !byId.has(toId)) return null;
+    const graph = buildGraph(lines, byId);
+    const result = shortestPath(graph, fromId, toId);
+    if (!result) return null;
+
+    const name = (id) => {
+      const st = byId.get(id);
+      if (!st) return id;
+      if (language === 'el' && (st.name_el || st.nameEl)) return st.name_el || st.nameEl;
+      return displayName(st);
+    };
+
+    const legs = [];
+    let curLine = null;
+    let curStops = [fromId];
+    const flush = () => {
+      if (curLine && curStops.length >= 2) {
+        legs.push({
+          lineId: curLine,
+          towards: name(curStops[curStops.length - 1]),
+          stops: curStops.map((id) => ({ id, name: name(id) })),
+        });
+      }
+    };
+    for (const { stationId, edge } of result.path) {
+      if (edge.lineId === null) {
+        flush();
+        curLine = null;
+        curStops = [stationId];
+      } else if (edge.lineId !== curLine) {
+        if (curLine !== null) {
+          flush();
+          curStops = [curStops[curStops.length - 1]];
+        }
+        curLine = edge.lineId;
+        curStops.push(stationId);
+      } else {
+        curStops.push(stationId);
+      }
+    }
+    flush();
+
+    if (!legs.length) return null;
+    return { legs };
+  }
+
+  return { planDetailed, _nameKey: nameKey, _travelTime: travelTime };
+});

--- a/web-tests/go-panel-harness.html
+++ b/web-tests/go-panel-harness.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Syrmos GO panel harness</title>
+  <style>body{margin:0;padding:24px;background:#fafafa;} #go{margin:0 auto;}</style>
+</head>
+<body>
+  <!-- Manual browser harness (not part of the app or the deployed bundle): mounts
+       the GO panel over a planned journey so the rendered UI can be eyeballed.
+       Load order matters (web-go defines SyrmosGO, then planner, then panel). -->
+  <div id="go"></div>
+  <script src="../composeApp/src/wasmJsMain/resources/web-go.js"></script>
+  <script src="../composeApp/src/wasmJsMain/resources/web-planner.js"></script>
+  <script src="../composeApp/src/wasmJsMain/resources/web-go-panel.js"></script>
+  <script>
+    // A representative M2 -> M3 transfer journey (Larissa Station -> Airport).
+    const journey = {
+      legs: [
+        { lineId: 'M2', towards: 'Syntagma', stops: [
+          { id: 'M2_LAR', name: 'Larissa Station' }, { id: 'M2_MET', name: 'Metaxourgeio' },
+          { id: 'M2_OMO', name: 'Omonia' }, { id: 'M2_SYN', name: 'Syntagma' } ] },
+        { lineId: 'M3', towards: 'Airport', stops: [
+          { id: 'M3_SYN', name: 'Syntagma' }, { id: 'M3_EVA', name: 'Evangelismos' },
+          { id: 'M3_MEG', name: 'Megaro Moussikis' } ] },
+      ],
+    };
+    const colors = { M1: '#009640', M2: '#e30613', M3: '#0072CE' };
+    window.__go = SyrmosGoPanel.mount(document.getElementById('go'), journey, {
+      language: 'en',
+      lineColor: (id) => colors[id] || '#0072CE',
+    });
+  </script>
+</body>
+</html>

--- a/web-tests/go-panel.test.js
+++ b/web-tests/go-panel.test.js
@@ -1,0 +1,25 @@
+'use strict';
+// Unit-tests the pure text logic of the web GO panel (describe()); DOM rendering
+// is verified separately in a browser.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Panel = require(path.join(
+  __dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources', 'web-go-panel.js'
+));
+
+test('describe() renders each guidance kind (en)', () => {
+  assert.match(Panel.describe({ kind: 'board', lineId: 'M2', towards: 'Omonia', stopsRemaining: 2, nextStation: 'Panepistimio' }, 'en').headline, /Board M2/);
+  assert.match(Panel.describe({ kind: 'ride', lineId: 'M2', towards: 'Omonia', stopsRemaining: 1, nextStation: 'Omonia' }, 'en').headline, /Stay on M2/);
+  const off = Panel.describe({ kind: 'getOffNext', nextStation: 'Syntagma', isDestination: false, transferTo: 'M3' }, 'en');
+  assert.match(off.headline, /Get off next/);
+  assert.match(off.detail, /change to M3/);
+  assert.match(Panel.describe({ kind: 'transfer', atStation: 'Syntagma', toLineId: 'M3', towards: 'Airport' }, 'en').headline, /Change here/);
+  assert.match(Panel.describe({ kind: 'arrived', station: 'Airport' }, 'en').detail, /Airport/);
+});
+
+test('describe() localizes (el/sq/it)', () => {
+  assert.match(Panel.describe({ kind: 'getOffNext', nextStation: 'X', isDestination: true }, 'el').headline, /Αποβίβαση/);
+  assert.match(Panel.describe({ kind: 'arrived', station: 'X' }, 'sq').headline, /Mbërritët/);
+  assert.match(Panel.describe({ kind: 'transfer', atStation: 'X', toLineId: 'M3', towards: 'Y' }, 'it').headline, /Cambia qui/);
+});

--- a/web-tests/web-planner.test.js
+++ b/web-tests/web-planner.test.js
@@ -1,0 +1,86 @@
+'use strict';
+// End-to-end web GO: plan a real route with web-planner.js over the bundled seed,
+// then guide it through web-go.js to arrival. Proves the web can produce a
+// GuidanceJourney the GO engine drives, the web peer of the iOS planner->GO test.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const SEED = path.join(
+  __dirname, '..', 'core', 'data', 'src', 'commonMain', 'composeResources', 'files', 'seed'
+);
+const Planner = require(path.join(RES, 'web-planner.js'));
+const GO = require(path.join(RES, 'web-go.js'));
+
+const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+const stations = readJson(path.join(SEED, 'stations.json'));
+const linesRaw = readJson(path.join(SEED, 'lines.json'));
+const lines = Array.isArray(linesRaw) ? linesRaw : linesRaw.lines;
+
+const lineById = (id) => lines.find((l) => l.id === id);
+
+test('plans a cross-line route (M1 -> M2) with a transfer and guides to arrived', () => {
+  const m1 = lineById('M1'), m2 = lineById('M2');
+  assert.ok(m1 && m2, 'seed should have M1 and M2');
+  const from = m1.stations[0].id;
+  const to = m2.stations[m2.stations.length - 1].id;
+
+  const journey = Planner.planDetailed(stations, lines, from, to);
+  assert.ok(journey && journey.legs.length >= 2, 'M1->M2 should need at least one transfer');
+  // Every leg is a real line, board == prior alight's interchange, >=2 stops.
+  for (const leg of journey.legs) {
+    assert.ok(lineById(leg.lineId), `leg on unknown line ${leg.lineId}`);
+    assert.ok(leg.stops.length >= 2, 'leg should have >=2 stops');
+  }
+  assert.equal(journey.legs[0].stops[0].id, from, 'first leg boards at origin');
+  assert.equal(journey.legs[journey.legs.length - 1].stops.slice(-1)[0].id, to, 'last leg alights at destination');
+
+  // Walk it with GO: origin -> arrived, exactly one get-off alert per leg.
+  let pos = { legIndex: 0, stopIndex: 0 };
+  const alertsPerLeg = {};
+  const totalStops = journey.legs.reduce((n, l) => n + l.stops.length, 0);
+  let steps = 0;
+  while (!GO.isArrived(journey, pos)) {
+    if (GO.shouldAlertGetOff(journey, pos)) alertsPerLeg[pos.legIndex] = (alertsPerLeg[pos.legIndex] || 0) + 1;
+    pos = GO.advance(journey, pos);
+    assert.ok(++steps <= totalStops + 5, 'GO walk should converge');
+  }
+  for (let i = 0; i < journey.legs.length; i++) {
+    assert.equal(alertsPerLeg[i] || 0, 1, `leg ${i} should alert exactly once`);
+  }
+  assert.equal(GO.guidance(journey, pos).kind, 'arrived');
+});
+
+test('same-line route is a single contiguous leg', () => {
+  const m1 = lineById('M1');
+  const from = m1.stations[0].id;
+  const to = m1.stations[3].id;
+  const journey = Planner.planDetailed(stations, lines, from, to);
+  assert.ok(journey);
+  assert.equal(journey.legs.length, 1);
+  assert.equal(journey.legs[0].lineId, 'M1');
+  // Board..alight ids are consecutive M1 stops.
+  const m1ids = m1.stations.map((s) => s.id);
+  const legIds = journey.legs[0].stops.map((s) => s.id);
+  const start = m1ids.indexOf(from);
+  assert.deepEqual(legIds, m1ids.slice(start, start + legIds.length));
+  assert.equal(legIds[legIds.length - 1], to);
+});
+
+test('degenerate inputs return null', () => {
+  const id = lineById('M1').stations[0].id;
+  assert.equal(Planner.planDetailed(stations, lines, id, id), null, 'from === to');
+  assert.equal(Planner.planDetailed(stations, lines, 'NOPE', id), null, 'unknown from');
+  assert.equal(Planner.planDetailed(stations, lines, id, 'NOPE'), null, 'unknown to');
+});
+
+test('every planned stop id resolves to a real station', () => {
+  const ids = new Set(stations.map((s) => s.id));
+  for (const l of lines) for (const s of l.stations || []) ids.add(s.id);
+  const j = Planner.planDetailed(stations, lines, lineById('M1').stations[0].id, lineById('M3').stations.slice(-1)[0].id);
+  assert.ok(j);
+  for (const leg of j.legs) for (const s of leg.stops) assert.ok(ids.has(s.id), `unknown stop ${s.id}`);
+});


### PR DESCRIPTION
## Why
Brings GO to a second visible platform — the web — the peer of the iOS GO screen shipped in 3.0.0-beta.1.

## What
- **`web-planner.js`** — pure Dijkstra planner over the bundled Athens graph (same-line edges + name-folded interchange transfer edges), producing a `GuidanceJourney` the GO engine (`web-go.js`) drives. Mirrors iOS `JourneyPlanner.planDetailed`.
- **`web-go-panel.js`** — renders the current GO instruction (board / stay on / get off next / change here / arrived), line-tinted, get-off cue emphasised, localized EN/EL/SQ/IT, Next/Back controls.
- **Tests** — `web-planner.test.js` plans a real **M1→M2 transfer** over the seed and walks it through GO to arrived; `go-panel.test.js` covers the panel text logic. **20/20 web tests pass.**
- **`go-panel-harness.html`** — a manual browser harness (not shipped/deployed).

## Verification
- Node: 20/20 web tests.
- **Browser (visual):** served the harness over HTTP and confirmed the panel renders `Board M2 → toward Syntagma → 3 stops · next Metaxourgeio`, and on advancing flips to the emphasised red **"Get off next → change to M3"** card with the progress bar advancing. Screenshots captured.

## Scope
The modules are **not yet wired into the app's Plan workspace** — I can't build the Compose/Wasm web app locally (no JDK), so that integration verifies on the Pages deploy and lands in a careful follow-up. The modules ship in the resources bundle but are unreferenced by `index.html` until then (no behaviour change). Additive, reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)