### PR TITLE
feat(go): web live GO — geolocation auto-advance + get-off alerts

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-go-panel.js
+++ b/composeApp/src/wasmJsMain/resources/web-go-panel.js
@@ -62,7 +62,12 @@
     opts = opts || {};
     const lang = opts.language || 'en';
     const color = (id) => (opts.lineColor ? opts.lineColor(id) || '#0072CE' : '#0072CE');
+    const coords = opts.coords || {}; // { [stopId]: {lat, lon} } for live advance
+    const hasCoords = Object.keys(coords).length > 0;
     let pos = { legIndex: 0, stopIndex: 0 };
+    let live = false;
+    let watchId = null;
+    const alertedLegs = new Set();
 
     const origin = journey.legs[0] && journey.legs[0].stops[0] ? journey.legs[0].stops[0].name : '';
     const destLeg = journey.legs[journey.legs.length - 1];
@@ -103,12 +108,18 @@
             <button class="go-back" ${canBack ? '' : 'disabled'} style="flex:1;padding:12px;border-radius:12px;border:1px solid #ccc;background:#fff;font-weight:600;">${esc(t(lang, 'Back', 'Πίσω', 'Prapa', 'Indietro'))}</button>
             <button class="go-next" style="flex:1;padding:12px;border-radius:12px;border:0;background:${tint};color:#fff;font-weight:700;">${arrived ? esc(t(lang, 'Restart', 'Επανεκκίνηση', 'Rifillo', 'Ricomincia')) : esc(t(lang, 'Next stop', 'Επόμενη στάση', 'Ndalesa tjetër', 'Fermata succ.'))}</button>
           </div>
+          ${(hasCoords && typeof navigator !== 'undefined' && navigator.geolocation) ? `
+          <button class="go-live" style="width:100%;box-sizing:border-box;margin-top:10px;padding:10px;border-radius:12px;border:1px solid ${live ? '#2E7D32' : '#ccc'};background:${live ? 'rgba(46,125,50,.08)' : '#fff'};font-weight:600;color:${live ? '#2E7D32' : '#333'};">
+            ${live ? '● ' + esc(t(lang, 'Live guidance on', 'Ζωντανή καθοδήγηση ενεργή', 'Udhëzim i drejtpërdrejtë aktiv', 'Guida dal vivo attiva')) : esc(t(lang, 'Start live guidance', 'Έναρξη ζωντανής καθοδήγησης', 'Nis udhëzimin e drejtpërdrejtë', 'Avvia guida dal vivo'))}
+          </button>` : ''}
         </div>`;
 
       const back = container.querySelector('.go-back');
       const next = container.querySelector('.go-next');
+      const liveBtn = container.querySelector('.go-live');
       if (back) back.onclick = () => { api.back(); };
       if (next) next.onclick = () => { arrived ? api.reset() : api.advance(); };
+      if (liveBtn) liveBtn.onclick = () => { live ? api.stopLive() : api.startLive(); };
     }
 
     const api = {
@@ -118,8 +129,35 @@
         else if (pos.legIndex > 0) { const p = pos.legIndex - 1; pos = { legIndex: p, stopIndex: journey.legs[p].stops.length - 1 }; }
         render();
       },
-      reset() { pos = { legIndex: 0, stopIndex: 0 }; render(); },
+      reset() { pos = { legIndex: 0, stopIndex: 0 }; alertedLegs.clear(); render(); },
       position() { return pos; },
+      // Live GO: feed a GPS fix; auto-advance the position and fire onGetOff once
+      // per leg when the rider is one stop from a leg's alight point.
+      applyLocation(lat, lon) {
+        if (!hasCoords) return;
+        const np = GO.advancedPosition(journey, pos, coords, lat, lon);
+        if (np.legIndex !== pos.legIndex || np.stopIndex !== pos.stopIndex) { pos = np; render(); }
+        if (GO.shouldAlertGetOff(journey, pos) && !alertedLegs.has(pos.legIndex)) {
+          alertedLegs.add(pos.legIndex);
+          if (opts.onGetOff) { try { opts.onGetOff(GO.guidance(journey, pos)); } catch (_) {} }
+        }
+      },
+      startLive() {
+        if (live || typeof navigator === 'undefined' || !navigator.geolocation || !hasCoords) return;
+        live = true; render();
+        watchId = navigator.geolocation.watchPosition(
+          (fx) => api.applyLocation(fx.coords.latitude, fx.coords.longitude),
+          () => {},
+          { enableHighAccuracy: true, maximumAge: 5000 }
+        );
+      },
+      stopLive() {
+        live = false;
+        if (watchId != null && typeof navigator !== 'undefined' && navigator.geolocation) navigator.geolocation.clearWatch(watchId);
+        watchId = null;
+        render();
+      },
+      isLive() { return live; },
     };
     render();
     return api;

--- a/composeApp/src/wasmJsMain/resources/web-go.js
+++ b/composeApp/src/wasmJsMain/resources/web-go.js
@@ -122,5 +122,52 @@
     return Boolean(lastLeg && l && position.stopIndex === l.stops.length - 1);
   }
 
-  return { guidance, shouldAlertGetOff, advance, isArrived, KIND: { BOARD, RIDE, GET_OFF_NEXT, TRANSFER, ARRIVED } };
+  // Live GO: given the rider's GPS fix and the journey's stop coordinates
+  // ({ [stopId]: {lat, lon} }), return the forward-most position they've reached,
+  // so the guidance advances on its own. Forward-only (jitter never rewinds),
+  // threshold-gated (holds between stops so guidance doesn't flicker). Mirrors iOS
+  // GoLocationAdvancer.
+  function advancedPosition(journey, current, coords, lat, lon, thresholdMeters) {
+    const threshold = thresholdMeters == null ? 350 : thresholdMeters;
+    let best = current;
+    let bestDist = Infinity;
+    let cursor = current;
+    while (cursor) {
+      const st = stopAt(journey, cursor);
+      if (st && coords[st.id]) {
+        const d = haversine(coords[st.id].lat, coords[st.id].lon, lat, lon);
+        if (d <= threshold && d < bestDist) { bestDist = d; best = cursor; }
+      }
+      cursor = nextPos(journey, cursor);
+    }
+    return best;
+  }
+
+  function stopAt(journey, p) {
+    const l = leg(journey, p.legIndex);
+    if (!l || p.stopIndex < 0 || p.stopIndex >= l.stops.length) return null;
+    return l.stops[p.stopIndex];
+  }
+
+  function nextPos(journey, p) {
+    const l = leg(journey, p.legIndex);
+    if (!l) return null;
+    if (p.stopIndex < l.stops.length - 1) return { legIndex: p.legIndex, stopIndex: p.stopIndex + 1 };
+    if (p.legIndex < journey.legs.length - 1) return { legIndex: p.legIndex + 1, stopIndex: 0 };
+    return null;
+  }
+
+  function haversine(lat1, lon1, lat2, lon2) {
+    const R = 6371000;
+    const dLat = (lat2 - lat1) * Math.PI / 180;
+    const dLon = (lon2 - lon1) * Math.PI / 180;
+    const a = Math.sin(dLat / 2) ** 2
+      + Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * Math.sin(dLon / 2) ** 2;
+    return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
+  }
+
+  return {
+    guidance, shouldAlertGetOff, advance, isArrived, advancedPosition, haversine,
+    KIND: { BOARD, RIDE, GET_OFF_NEXT, TRANSFER, ARRIVED },
+  };
 });

--- a/web-tests/go-advance.test.js
+++ b/web-tests/go-advance.test.js
@@ -1,0 +1,60 @@
+'use strict';
+// Mirrors iOS GoLocationAdvancerTests so the web live-GO advancer behaves
+// identically: forward-only, threshold-gated, transfer-aware.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const GO = require(path.join(
+  __dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources', 'web-go.js'
+));
+
+// West->east line of 4 stops ~1km apart at lat 38.0 (0.012 deg lon ~ 1053m here).
+const coords = {
+  S0: { lat: 38.0, lon: 23.700 },
+  S1: { lat: 38.0, lon: 23.712 },
+  S2: { lat: 38.0, lon: 23.724 },
+  S3: { lat: 38.0, lon: 23.736 },
+};
+const line4 = () => ({
+  legs: [{ lineId: 'L', towards: 'S3', stops: [
+    { id: 'S0', name: 'S0' }, { id: 'S1', name: 'S1' }, { id: 'S2', name: 'S2' }, { id: 'S3', name: 'S3' },
+  ] }],
+});
+const p = (l, s) => ({ legIndex: l, stopIndex: s });
+
+test('at a stop coordinate places the rider there', () => {
+  assert.deepEqual(GO.advancedPosition(line4(), p(0, 0), coords, 38.0, 23.724), p(0, 2));
+});
+
+test('never moves backward on a jittery fix', () => {
+  assert.deepEqual(GO.advancedPosition(line4(), p(0, 2), coords, 38.0, 23.700), p(0, 2));
+});
+
+test('between stops holds position', () => {
+  assert.deepEqual(GO.advancedPosition(line4(), p(0, 1), coords, 38.0, 23.718), p(0, 1));
+});
+
+test('advances forward to nearest stop within threshold', () => {
+  assert.deepEqual(GO.advancedPosition(line4(), p(0, 0), coords, 38.0, 23.735), p(0, 3));
+});
+
+test('transfer advances onto the next leg board platform', () => {
+  const j = {
+    legs: [
+      { lineId: 'A', towards: 'X', stops: [{ id: 'A0', name: 'A0' }, { id: 'XA', name: 'X' }] },
+      { lineId: 'B', towards: 'B1', stops: [{ id: 'XB', name: 'X' }, { id: 'B1', name: 'B1' }] },
+    ],
+  };
+  const c = {
+    A0: { lat: 38.0, lon: 23.700 },
+    XA: { lat: 38.0, lon: 23.750 },
+    XB: { lat: 38.0005, lon: 23.7502 },
+    B1: { lat: 38.010, lon: 23.760 },
+  };
+  assert.deepEqual(GO.advancedPosition(j, p(0, 0), c, 38.0005, 23.7502), p(1, 0));
+});
+
+test('haversine known distance (~1.1km per 0.01 deg lat)', () => {
+  const d = GO.haversine(38.0, 23.7, 38.01, 23.7);
+  assert.ok(Math.abs(d - 1113) < 30, `got ${d}`);
+});

--- a/web-tests/go-live-harness.html
+++ b/web-tests/go-live-harness.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Syrmos GO live harness</title>
+  <style>body{margin:0;padding:24px;background:#fafafa;font-family:system-ui;} #go{max-width:420px;} #log{margin-top:16px;font-size:13px;color:#333;white-space:pre-wrap;}</style>
+</head>
+<body>
+  <!-- Manual harness (not shipped): drives the GO panel's LIVE mode with a fake
+       geolocation so the GPS-proximity auto-advance can be verified in a browser.
+       window.__emit(lat,lon) feeds a fix; window.__alerts records get-off cues. -->
+  <div id="go"></div>
+  <div id="log">alerts: none</div>
+  <script src="../composeApp/src/wasmJsMain/resources/web-go.js"></script>
+  <script src="../composeApp/src/wasmJsMain/resources/web-go-panel.js"></script>
+  <script>
+    // Fake geolocation: navigator.geolocation is read-only, but its methods are
+    // writable, so patch watchPosition/clearWatch to capture the callback and let
+    // __emit drive scripted fixes.
+    let __cb = null;
+    navigator.geolocation.watchPosition = (cb) => { __cb = cb; return 1; };
+    navigator.geolocation.clearWatch = () => { __cb = null; };
+    window.__emit = (lat, lon) => { if (__cb) __cb({ coords: { latitude: lat, longitude: lon } }); };
+
+    // M2 -> M3 transfer journey with synthetic coords along a west->east line.
+    const journey = {
+      legs: [
+        { lineId: 'M2', towards: 'Syntagma', stops: [
+          { id: 'M2_LAR', name: 'Larissa Station' }, { id: 'M2_MET', name: 'Metaxourgeio' },
+          { id: 'M2_OMO', name: 'Omonia' }, { id: 'M2_SYN', name: 'Syntagma' } ] },
+        { lineId: 'M3', towards: 'Airport', stops: [
+          { id: 'M3_SYN', name: 'Syntagma' }, { id: 'M3_EVA', name: 'Evangelismos' },
+          { id: 'M3_MEG', name: 'Megaro Moussikis' } ] },
+      ],
+    };
+    const coords = {
+      M2_LAR: { lat: 38.0, lon: 23.700 }, M2_MET: { lat: 38.0, lon: 23.712 },
+      M2_OMO: { lat: 38.0, lon: 23.724 }, M2_SYN: { lat: 38.0, lon: 23.736 },
+      M3_SYN: { lat: 38.0005, lon: 23.7362 }, M3_EVA: { lat: 38.0, lon: 23.748 },
+      M3_MEG: { lat: 38.0, lon: 23.760 },
+    };
+    const colors = { M2: '#e30613', M3: '#0072CE' };
+    window.__alerts = [];
+    window.__go = SyrmosGoPanel.mount(document.getElementById('go'), journey, {
+      language: 'en', coords, lineColor: (id) => colors[id] || '#0072CE',
+      onGetOff: (g) => { window.__alerts.push(g.nextStation); document.getElementById('log').textContent = 'alerts: ' + window.__alerts.join(', '); },
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Why
Makes web GO **live**: instead of tapping Next, the panel tracks the rider via the browser's geolocation and advances on its own, firing a get-off cue at the right moment — the web analog of the iOS live-GO core (#114) and the signature transit-companion feature.

## What
- **`web-go.js`** — `advancedPosition` + `haversine`: given a GPS fix and the journey's stop coordinates, return the forward-most position reached. Forward-only (jitter never rewinds), threshold-gated (~350m). Mirrors iOS `GoLocationAdvancer`.
- **`web-go-panel.js`** — a "Start live guidance" toggle: `startLive()`/`stopLive()` over `navigator.geolocation.watchPosition`, `applyLocation(lat,lon)` (advance + per-leg get-off dedupe + `onGetOff` callback), a live indicator. Manual Next/Back stay available.
- Tests + harness: `web-tests/go-advance.test.js` (6, mirrors the iOS advancer scenarios exactly), `go-live-harness.html` (manual, not shipped).

## Verification
- Node: **26/26** web tests (incl. the advancer parity with iOS).
- **Browser (visual, end-to-end):** emitting GPS fixes down an M2→M3 journey, the panel auto-advanced *ride → get off at Syntagma → transfer onto M3 (tint flips red→blue) → get off at destination*, firing **exactly one get-off alert per leg** (`["Syntagma","Megaro Moussikis"]`). Screenshots captured.

## Scope
The modules ship in the resources bundle; wiring them into the app's Plan workspace (which needs a local Compose/Wasm build to verify — no JDK here) is a follow-up verified on deploy. Additive, reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)