### PR TITLE
feat(go): iOS live GO — GPS auto-advance + get-off notification

### DIFF
--- a/iosApp/iosApp/Core/Location/LocationService.swift
+++ b/iosApp/iosApp/Core/Location/LocationService.swift
@@ -7,6 +7,9 @@ final class LocationService: NSObject, ObservableObject, CLLocationManagerDelega
     @Published var nearbyStations: [NearbyStation] = []
     @Published var hasPermission = false
     @Published var isDenied = false
+    /// The most recent fix, for features that need the raw coordinate (e.g. live
+    /// GO guidance) rather than the nearest-station list.
+    @Published var currentLocation: CLLocation?
 
     private let manager = CLLocationManager()
     private var lastLocation: CLLocation?
@@ -64,6 +67,7 @@ final class LocationService: NSObject, ObservableObject, CLLocationManagerDelega
         guard let location = locations.last else { return }
         Task { @MainActor [weak self] in
             self?.lastLocation = location
+            self?.currentLocation = location
             self?.updateNearby(from: location)
         }
     }

--- a/iosApp/iosApp/Core/Notifications/NotificationService.swift
+++ b/iosApp/iosApp/Core/Notifications/NotificationService.swift
@@ -171,6 +171,50 @@ final class NotificationService: ObservableObject {
 
     // MARK: - Seen Alert Storage
 
+    // MARK: - GO get-off alert (live guidance)
+
+    /// Fire an immediate local notification telling the rider to get off at the
+    /// next stop. `station` is the alight stop; `transferTo` is the line to change
+    /// to, or nil when it is the destination.
+    func fireGetOffAlert(station: String, isDestination: Bool, transferTo: String?, language lang: AppLanguage) {
+        guard isAuthorized else { return }
+        let content = UNMutableNotificationContent()
+        switch lang {
+        case .greek: content.title = "Αποβίβαση στην επόμενη"
+        case .albanian: content.title = "Zbrit në ndalesën tjetër"
+        case .italian: content.title = "Scendi alla prossima"
+        default: content.title = "Get off next"
+        }
+        content.body = getOffBody(station: station, isDestination: isDestination, transferTo: transferTo, language: lang)
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: "syrmos.go.getoff.\(station)",
+            content: content,
+            trigger: nil // immediate
+        )
+        center.add(request)
+    }
+
+    private func getOffBody(station: String, isDestination: Bool, transferTo: String?, language lang: AppLanguage) -> String {
+        if isDestination {
+            switch lang {
+            case .greek: return "\(station) — ο προορισμός σου."
+            case .albanian: return "\(station) — destinacioni yt."
+            case .italian: return "\(station) — la tua destinazione."
+            default: return "\(station) — your destination."
+            }
+        }
+        if let transferTo {
+            switch lang {
+            case .greek: return "\(station) → αλλαγή σε \(transferTo)."
+            case .albanian: return "\(station) → ndërro në \(transferTo)."
+            case .italian: return "\(station) → cambia in \(transferTo)."
+            default: return "\(station) → change to \(transferTo)."
+            }
+        }
+        return station
+    }
+
     private func loadSeenAlertIds() -> Set<String> {
         let array = UserDefaults.standard.stringArray(forKey: seenAlertsKey) ?? []
         return Set(array)

--- a/iosApp/iosApp/Features/Go/GoDemoEntryView.swift
+++ b/iosApp/iosApp/Features/Go/GoDemoEntryView.swift
@@ -30,9 +30,22 @@ struct GoDemoEntryView: View {
         return nil
     }
 
+    /// Stop coordinates for the journey (by id), so live GO can advance from GPS.
+    private func coords(for journey: GuidanceJourney) -> [String: GoLocationAdvancer.Coord] {
+        var out: [String: GoLocationAdvancer.Coord] = [:]
+        for leg in journey.legs {
+            for stop in leg.stops where out[stop.id] == nil {
+                if let c = StationCoordinateLookup.shared.coordinate(for: stop.id) {
+                    out[stop.id] = GoLocationAdvancer.Coord(lat: c.lat, lon: c.lon)
+                }
+            }
+        }
+        return out
+    }
+
     var body: some View {
         if let journey {
-            GoJourneyView(journey: journey, language: language)
+            GoJourneyView(journey: journey, language: language, coords: coords(for: journey))
         } else {
             ContentUnavailableView(
                 language == .greek ? "Δεν βρέθηκε διαδρομή" : language == .albanian ? "Nuk u gjet rrugë" : language == .italian ? "Nessun percorso" : "No route available",

--- a/iosApp/iosApp/Features/Go/GoJourneyView.swift
+++ b/iosApp/iosApp/Features/Go/GoJourneyView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // The GO screen: guide the rider through a planned journey one instruction at a
 // time (board / stay on / get off next / change here / arrived). The current
@@ -8,12 +9,13 @@ import SwiftUI
 // labelled "Next stop" rather than implying live tracking.
 struct GoJourneyView: View {
     @StateObject private var model: GoJourneyViewModel
+    @StateObject private var location = LocationService()
     let language: AppLanguage
     private let originName: String
     private let destinationName: String
 
-    init(journey: GuidanceJourney, language: AppLanguage) {
-        _model = StateObject(wrappedValue: GoJourneyViewModel(journey: journey))
+    init(journey: GuidanceJourney, language: AppLanguage, coords: [String: GoLocationAdvancer.Coord] = [:]) {
+        _model = StateObject(wrappedValue: GoJourneyViewModel(journey: journey, coords: coords))
         self.language = language
         self.originName = journey.legs.first?.stops.first?.name ?? ""
         self.destinationName = journey.legs.last?.stops.last?.name ?? ""
@@ -32,6 +34,7 @@ struct GoJourneyView: View {
                 .tint(tint)
                 .padding(.horizontal)
             controls
+            if model.canGoLive { liveToggle }
             Spacer()
             footnote
         }
@@ -39,6 +42,51 @@ struct GoJourneyView: View {
         .navigationTitle("GO")
         .navigationBarTitleDisplayMode(.inline)
         .animation(.easeInOut(duration: 0.2), value: model.position)
+        .onAppear {
+            model.onGetOffAlert = { guidance in fireGetOff(guidance) }
+            Task { await NotificationService.shared.requestAuthorization() }
+        }
+        .onReceive(location.$currentLocation) { loc in
+            if let loc { model.applyLocation(lat: loc.coordinate.latitude, lon: loc.coordinate.longitude) }
+        }
+    }
+
+    private var liveToggle: some View {
+        Button {
+            if model.isLive {
+                model.stopLive()
+            } else {
+                location.requestIfNeeded()
+                model.startLive()
+            }
+        } label: {
+            Label(
+                model.isLive
+                    ? t("Live guidance on", "Ζωντανή καθοδήγηση ενεργή", "Udhëzim i drejtpërdrejtë aktiv", "Guida dal vivo attiva")
+                    : t("Start live guidance", "Έναρξη ζωντανής καθοδήγησης", "Nis udhëzimin e drejtpërdrejtë", "Avvia guida dal vivo"),
+                systemImage: model.isLive ? "location.fill" : "location"
+            )
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .tint(model.isLive ? .green : .accentColor)
+    }
+
+    private func fireGetOff(_ guidance: JourneyGuidance) {
+        #if canImport(UIKit)
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        #endif
+        switch guidance {
+        case let .getOffNext(nextStation, isDestination, transferTo):
+            NotificationService.shared.fireGetOffAlert(
+                station: nextStation, isDestination: isDestination, transferTo: transferTo, language: language)
+        case let .board(_, _, _, nextStation):
+            // 2-stop leg: the get-off cue coincides with boarding.
+            NotificationService.shared.fireGetOffAlert(
+                station: nextStation, isDestination: false, transferTo: nil, language: language)
+        default:
+            break
+        }
     }
 
     private var header: some View {

--- a/iosApp/iosApp/Features/Go/GoJourneyViewModel.swift
+++ b/iosApp/iosApp/Features/Go/GoJourneyViewModel.swift
@@ -10,11 +10,24 @@ import SwiftUI
 final class GoJourneyViewModel: ObservableObject {
     let journey: GuidanceJourney
     @Published private(set) var position: GuidancePosition
+    @Published private(set) var isLive = false
 
-    init(journey: GuidanceJourney) {
+    /// Stop coordinates by id, for live GPS advance. Empty = manual-only.
+    private let coords: [String: GoLocationAdvancer.Coord]
+    /// Legs whose get-off cue has already fired, so it fires at most once per leg.
+    private var alertedLegs: Set<Int> = []
+    /// Called once per leg when the rider reaches its get-off point (the view wires
+    /// this to a local notification + haptic). Kept out of the view model so it
+    /// stays free of NotificationService and unit-testable.
+    var onGetOffAlert: ((JourneyGuidance) -> Void)?
+
+    init(journey: GuidanceJourney, coords: [String: GoLocationAdvancer.Coord] = [:]) {
         self.journey = journey
+        self.coords = coords
         self.position = GuidancePosition(legIndex: 0, stopIndex: 0)
     }
+
+    var canGoLive: Bool { !coords.isEmpty }
 
     // MARK: Derived state
 
@@ -62,5 +75,25 @@ final class GoJourneyViewModel: ObservableObject {
         }
     }
 
-    func reset() { position = GuidancePosition(legIndex: 0, stopIndex: 0) }
+    func reset() {
+        position = GuidancePosition(legIndex: 0, stopIndex: 0)
+        alertedLegs.removeAll()
+    }
+
+    // MARK: Live GO
+
+    func startLive() { guard canGoLive else { return }; isLive = true }
+    func stopLive() { isLive = false }
+
+    /// Feed a GPS fix while live: auto-advance to the reached stop and fire the
+    /// get-off cue once per leg. No-op when not live or without coordinates.
+    func applyLocation(lat: Double, lon: Double) {
+        guard isLive, !coords.isEmpty else { return }
+        let next = GoLocationAdvancer.advancedPosition(journey: journey, current: position, coords: coords, lat: lat, lon: lon)
+        if next != position { position = next }
+        if JourneyGuidance.shouldAlertGetOff(journey, position), !alertedLegs.contains(position.legIndex) {
+            alertedLegs.insert(position.legIndex)
+            if let g = try? JourneyGuidance.at(journey, position) { onGetOffAlert?(g) }
+        }
+    }
 }

--- a/iosApp/iosAppTests/GoJourneyViewModelTests.swift
+++ b/iosApp/iosAppTests/GoJourneyViewModelTests.swift
@@ -79,4 +79,47 @@ final class GoJourneyViewModelTests: XCTestCase {
         XCTAssertEqual(vm.position.legIndex, 0)
         XCTAssertEqual(vm.position.stopIndex, 0)
     }
+
+    // MARK: Live GO
+
+    // Coords for the two-leg journey: M2 (A,B,Syntagma) west->east, then M3
+    // (Syntagma, Airport). 0.012 deg lon ~ 1km at this latitude.
+    private func liveCoords() -> [String: GoLocationAdvancer.Coord] {
+        [
+            "M2_A": .init(lat: 38.0, lon: 23.700),
+            "M2_B": .init(lat: 38.0, lon: 23.712),
+            "M2_SYN": .init(lat: 38.0, lon: 23.724),
+            "M3_SYN": .init(lat: 38.0005, lon: 23.7242),
+            "M3_AER": .init(lat: 38.0, lon: 23.736),
+        ]
+    }
+
+    func test_applyLocation_noOpWhenNotLive() {
+        let vm = GoJourneyViewModel(journey: journey(), coords: liveCoords())
+        XCTAssertTrue(vm.canGoLive)
+        vm.applyLocation(lat: 38.0, lon: 23.712) // near B, but not live
+        XCTAssertEqual(vm.position, GuidancePosition(legIndex: 0, stopIndex: 0))
+    }
+
+    func test_applyLocation_advancesAndAlertsOncePerLeg() {
+        let vm = GoJourneyViewModel(journey: journey(), coords: liveCoords())
+        var alerts: [String] = []
+        vm.onGetOffAlert = { g in
+            if case let .getOffNext(next, _, _) = g { alerts.append(next) }
+            if case let .board(_, _, _, next) = g { alerts.append("board:\(next)") }
+        }
+        vm.startLive()
+
+        vm.applyLocation(lat: 38.0, lon: 23.712)   // near B -> get off next (Syntagma), alert
+        XCTAssertEqual(vm.position, GuidancePosition(legIndex: 0, stopIndex: 1))
+        XCTAssertEqual(alerts, ["Syntagma"])
+
+        vm.applyLocation(lat: 38.0005, lon: 23.7242) // at interchange -> board M3 (2-stop leg alert)
+        XCTAssertEqual(vm.position, GuidancePosition(legIndex: 1, stopIndex: 0))
+        XCTAssertEqual(alerts, ["Syntagma", "board:Airport"])
+
+        // A repeat fix on the same leg must not re-alert.
+        vm.applyLocation(lat: 38.0005, lon: 23.7242)
+        XCTAssertEqual(alerts, ["Syntagma", "board:Airport"])
+    }
 }


### PR DESCRIPTION
## Why
Makes iOS GO **live**: instead of tapping Next, GO tracks the rider's GPS and advances on its own, firing a get-off notification + haptic when they're one stop from a leg's alight point — the hands-free "your stop is next" cue that is the most-valued transit-companion feature (Transit/Citymapper/Moovit/Google GO).

## What
- **`LocationService`** — publishes `currentLocation` (raw fix) alongside the nearest-station list.
- **`NotificationService`** — `fireGetOffAlert(...)`: an immediate localized (EN/EL/SQ/IT) local notification.
- **`GoJourneyViewModel`** — `coords` + `applyLocation(lat:lon:)` advancing via the (browser- and unit-verified) `GoLocationAdvancer`, firing `onGetOffAlert` **once per leg** (dedup). The callback keeps the view model free of `NotificationService` and unit-testable.
- **`GoJourneyView`** — a live toggle, `.onReceive(location.$currentLocation) → applyLocation`, and `onGetOffAlert → NotificationService + haptic`.
- **`GoDemoEntryView`** — resolves stop coordinates via `StationCoordinateLookup`.
- Tests — `applyLocation` advances + alerts once per leg + no-op when not live + repeat-fix no re-alert.

## Verification
- Local: whole app compiles; `GoJourneyViewModelTests` pass incl. the new live tests (`** TEST SUCCEEDED **`); app launches clean on the iPhone 17 sim.
- The advance/dedup **logic is the same algorithm I verified end-to-end in the browser** for web live GO (#116): emitting fixes drove the panel ride → get-off → transfer → get-off with one alert per leg.
- **Honest gap:** the GPS-driven live path itself (fixes flowing to the notification while riding) can't be visually verified here (simulator device-access gating). Internal-beta testers exercise it.

## Scope / rollout
Still gated behind `BuildEnv.isInternalBuild` via the existing GO Settings entry — TestFlight/internal only, not a public build. Additive; the only existing-code changes are one published property (LocationService) and one method (NotificationService). Reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)