### PR TITLE
feat(go): announce GO instructions to screen readers (a11y)

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-go-panel.js
+++ b/composeApp/src/wasmJsMain/resources/web-go-panel.js
@@ -73,6 +73,20 @@
     const destLeg = journey.legs[journey.legs.length - 1];
     const dest = destLeg ? destLeg.stops[destLeg.stops.length - 1].name : '';
 
+    // Persistent structure so screen readers hear every instruction change: a
+    // visually-hidden aria-live region whose text is updated on each render (a
+    // re-created live region would not reliably announce), plus a content div the
+    // card re-renders into.
+    container.innerHTML = '';
+    const srEl = document.createElement('div');
+    srEl.className = 'go-sr';
+    srEl.setAttribute('aria-live', 'assertive');
+    srEl.setAttribute('role', 'status');
+    srEl.style.cssText = 'position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;';
+    const contentEl = document.createElement('div');
+    container.appendChild(srEl);
+    container.appendChild(contentEl);
+
     function progress() {
       const total = Math.max(1, journey.legs.reduce((n, l) => n + Math.max(0, l.stops.length - 1), 0));
       let done = 0;
@@ -89,7 +103,10 @@
       const tint = g.kind === 'arrived' ? '#2E7D32' : color(g.lineId || (journey.legs[pos.legIndex] && journey.legs[pos.legIndex].lineId));
       const canBack = pos.legIndex > 0 || pos.stopIndex > 0;
 
-      container.innerHTML = `
+      // Announce the current instruction to screen readers (headline + detail).
+      srEl.textContent = [d.headline, d.detail, d.sub].filter(Boolean).join('. ');
+
+      contentEl.innerHTML = `
         <div class="go-panel" role="group" aria-label="GO journey guidance" style="max-width:420px;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;">
           <div class="go-head" style="display:flex;gap:8px;align-items:center;color:#666;font-size:14px;font-weight:600;margin-bottom:12px;">
             <span>${esc(origin)}</span><span aria-hidden="true">→</span><span>${esc(dest)}</span>
@@ -114,9 +131,9 @@
           </button>` : ''}
         </div>`;
 
-      const back = container.querySelector('.go-back');
-      const next = container.querySelector('.go-next');
-      const liveBtn = container.querySelector('.go-live');
+      const back = contentEl.querySelector('.go-back');
+      const next = contentEl.querySelector('.go-next');
+      const liveBtn = contentEl.querySelector('.go-live');
       if (back) back.onclick = () => { api.back(); };
       if (next) next.onclick = () => { arrived ? api.reset() : api.advance(); };
       if (liveBtn) liveBtn.onclick = () => { live ? api.stopLive() : api.startLive(); };

--- a/iosApp/iosApp/Features/Go/GoJourneyView.swift
+++ b/iosApp/iosApp/Features/Go/GoJourneyView.swift
@@ -49,6 +49,12 @@ struct GoJourneyView: View {
         .onReceive(location.$currentLocation) { loc in
             if let loc { model.applyLocation(lat: loc.coordinate.latitude, lon: loc.coordinate.longitude) }
         }
+        .onChange(of: model.position) { _, _ in
+            // Announce each new instruction so a VoiceOver rider hears "get off
+            // next" hands-free, the iOS analog of the web panel's aria-live region.
+            let text = [headline, detail].filter { !$0.isEmpty }.joined(separator: ". ")
+            UIAccessibility.post(notification: .announcement, argument: text)
+        }
     }
 
     private var liveToggle: some View {


### PR DESCRIPTION
## Why
Hands-free "your stop is next" guidance is *most* valuable to blind / low-vision riders. GO now announces each instruction change to assistive tech, so a rider who isn't looking at the screen still hears board / change / **get off next**.

## What
- **web-go-panel.js** — a persistent visually-hidden `aria-live="assertive"` / `role="status"` region whose text updates on every render (a re-created live region wouldn't reliably announce); the card renders into a separate content div.
- **GoJourneyView (iOS)** — `.onChange(of: position)` posts a `UIAccessibility` `.announcement` of the current instruction (the VoiceOver analog).

## Verification
- Web: 26/26 node tests; **browser a11y-tree check** — the live region read `Board M2. toward Syntagma...` then, on advancing, `Get off next. Syntagma → change to M3...`.
- iOS: `** BUILD SUCCEEDED **`.

## Risk
Additive a11y only; the panel refactor (content div + live region) preserves behaviour (node tests green). Reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)