### PR TITLE
fix(ci): stamp a unique iOS build number (epoch) to stop upload collisions

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -129,23 +129,25 @@ jobs:
           write_profile widget       "$IOS_PROFILE_WIDGET_BASE64"
           ls -la "$DIR"
 
-      # Read the build number from the Xcode project so the value you set
-      # locally (CURRENT_PROJECT_VERSION) is what appears in App Store Connect.
-      # Bump it in the project before each release to avoid collisions.
-      - name: Read build number from project
+      # Stamp a unique, monotonically increasing build number. App Store Connect
+      # requires CFBundleVersion to be strictly higher than any prior upload in
+      # the same marketing-version train. Reading a static CURRENT_PROJECT_VERSION
+      # forced a manual bump every release and silently collided (3.0.0-beta.1 and
+      # beta.2 both resolved to build 138, so beta.2's upload was rejected). A Unix
+      # epoch is always unique and increasing across releases, so no manual bump is
+      # needed and collisions cannot recur.
+      - name: Stamp a unique build number
         if: ${{ env.IOS_DIST_CERT_P12_BASE64 != '' }}
         run: |
           set -euo pipefail
-          # CFBundleVersion in the source Info.plist is the literal placeholder
-          # "$(CURRENT_PROJECT_VERSION)", so PlistBuddy on it returns that string,
-          # not the number. Read the RESOLVED build setting from the project
-          # instead; otherwise the archive is stamped with an invalid build
-          # number and App Store Connect rejects the upload.
-          BUILD="$(xcodebuild -project iosApp/Syrmos.xcodeproj -scheme "$SCHEME" -configuration Release -showBuildSettings 2>/dev/null | awk -F' = ' '/ CURRENT_PROJECT_VERSION =/{print $2; exit}')"
+          BUILD="$(date +%s)"
           if ! printf '%s' "$BUILD" | grep -Eq '^[0-9]+$'; then
-            echo "::error::Resolved CURRENT_PROJECT_VERSION is not numeric: '$BUILD'"; exit 1
+            echo "::error::Build number is not numeric: '$BUILD'"; exit 1
           fi
           echo "BUILD_NUMBER=$BUILD" >> "$GITHUB_ENV"
+          # The app + widget get this via CURRENT_PROJECT_VERSION on the archive
+          # command; the watch Info.plist has a literal CFBundleVersion, so set it
+          # here too, keeping every embedded target on the same build number.
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD" iosApp/SyrmosWatch/Info.plist
           echo "Build number: $BUILD"
 


### PR DESCRIPTION
## Root cause
3.0.0-beta.2's iOS TestFlight upload was **rejected**: *"bundle version must be higher than the previously uploaded version: 138."* The release read a static `CURRENT_PROJECT_VERSION` (138) as the build number, relying on a manual bump each release. beta.1 already uploaded 3.0.0 **build 138**, so beta.2's build 138 collided. (Android was fine — versionCode incremented.)

## Fix
Stamp a Unix epoch (`date +%s`) as `CFBundleVersion` in the release job — always unique and monotonically increasing, so no manual bump is needed and this collision cannot recur. Matches what `RELEASE.md` already documented.

## Validation
YAML validated. A release **dry-run** (`workflow_dispatch dry_run=true`) archives + runs `altool --validate-app` against App Store Connect with the epoch build number, before any real upload. After merge, a `dry_run=false` dispatch re-delivers the iOS beta.2 build.

## Risk
Release-workflow change, validated by dry-run before the real upload. Reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)