### PR TITLE
feat(go): wire web GO into the Plan workspace

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -535,6 +535,12 @@
 <script src="/llm/ariadne-wllama.js?v=3"></script>
 <script src="/web-router.js"></script>
 <script src="/web-nav.js"></script>
+<!-- GO guided-journey engine + planner + panel (must load before web-map.js,
+     which mounts the panel in the Plan workspace). web-go defines SyrmosGO,
+     which the panel uses. -->
+<script src="/web-go.js"></script>
+<script src="/web-planner.js"></script>
+<script src="/web-go-panel.js"></script>
 <script src="/web-map.js"></script>
 </body>
 </html>

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -3950,13 +3950,83 @@
             };
         })();
 
+        // ---- Web GO in the Plan workspace (guarded, additive) ----
+        // Mounts the GO guided-journey panel (plan A->B, then be told board / ride
+        // / get off next / change here / arrived, with an optional live GPS mode)
+        // when the user is in Plan. Every path is wrapped so a failure only hides
+        // the GO card and leaves Ariadne and the rest of Plan untouched.
+        const goPlan = (function () {
+            let card = null, panelEl = null, mounted = false;
+            function container() {
+                if (card) return card;
+                try {
+                    const rail = document.getElementById("contextRail");
+                    if (!rail) return null;
+                    card = document.createElement("div");
+                    card.className = "panel-card";
+                    card.id = "goPlanCard";
+                    card.style.display = "none";
+                    const title = document.createElement("div");
+                    title.className = "panel-card__title";
+                    title.textContent = ({ el: "GO — καθοδηγούμενο ταξίδι", sq: "GO — udhëtim i udhëhequr", it: "GO — viaggio guidato" }[currentLang]) || "GO — guided journey";
+                    panelEl = document.createElement("div");
+                    panelEl.id = "goPlanPanel";
+                    card.appendChild(title);
+                    card.appendChild(panelEl);
+                    const cards = document.getElementById("contextPanelCards");
+                    if (cards && cards.parentNode) cards.parentNode.insertBefore(card, cards);
+                    else rail.appendChild(card);
+                    return card;
+                } catch (_) { return null; }
+            }
+            function build() {
+                try {
+                    if (!window.SyrmosPlanner) return null;
+                    // Showcase route: M1 origin -> M2 terminus, a real transfer.
+                    const m1 = lines.find((l) => l.id === "M1");
+                    const m2 = lines.find((l) => l.id === "M2");
+                    const fromId = m1 && m1.stations && m1.stations[0] && m1.stations[0].id;
+                    const toId = m2 && m2.stations && m2.stations.length && m2.stations[m2.stations.length - 1].id;
+                    if (!fromId || !toId) return null;
+                    const journey = window.SyrmosPlanner.planDetailed(stations, lines, fromId, toId, currentLang);
+                    if (!journey) return null;
+                    const coords = {};
+                    const byId = new Map(stations.map((s) => [s.id, s]));
+                    for (const leg of journey.legs) for (const stop of leg.stops) {
+                        const rec = byId.get(stop.id);
+                        if (rec) coords[stop.id] = { lat: rec.latitude, lon: rec.longitude };
+                    }
+                    return { journey, coords };
+                } catch (_) { return null; }
+            }
+            function mount() {
+                try {
+                    if (!window.SyrmosGoPanel) return false;
+                    if (!container()) return false;
+                    const built = build();
+                    if (!built) return false;
+                    window.SyrmosGoPanel.mount(panelEl, built.journey, {
+                        language: currentLang,
+                        coords: built.coords,
+                        lineColor: (id) => { const l = lines.find((x) => x.id === id); return l && l.color; },
+                    });
+                    mounted = true;
+                    return true;
+                } catch (_) { return false; }
+            }
+            return {
+                show() { try { if (!mounted) mount(); if (card) card.style.display = ""; } catch (_) {} },
+                hide() { try { if (card) card.style.display = "none"; } catch (_) {} },
+            };
+        })();
+
         window.SyrmosNav.wire(nav, router, {
-            now() { clearSelection(); fitAthensCore(); panelTop(); },              // Athens now view
-            plan() { panelTop(); openAriadne(); },                                 // journey planning via Ariadne
-            explore() { panelTop(); if (stationSearch) stationSearch.focus(); },   // search / discover stations
-            departures() { jumpTo(".departures-card"); },                          // next departures + live trains
-            tickets() { const c = faresCard(); if (c) jumpTo(c); },                // OASA fares
-            more() { jumpTo("#infoLinksList"); },                                  // footer utility: useful info
+            now() { goPlan.hide(); clearSelection(); fitAthensCore(); panelTop(); },   // Athens now view
+            plan() { panelTop(); openAriadne(); goPlan.show(); },                       // journey planning + GO
+            explore() { goPlan.hide(); panelTop(); if (stationSearch) stationSearch.focus(); }, // search / discover
+            departures() { goPlan.hide(); jumpTo(".departures-card"); },                // next departures + live
+            tickets() { goPlan.hide(); const c = faresCard(); if (c) jumpTo(c); },       // OASA fares
+            more() { goPlan.hide(); jumpTo("#infoLinksList"); },                        // footer utility
         });
     })();
 


### PR DESCRIPTION
## Why
Makes web GO reachable in the app: the Plan workspace now shows the GO guided-journey panel (plan → board / ride / get off next / change here / arrived, with the live GPS mode).

## What
- **index.html** loads `web-go.js` + `web-planner.js` + `web-go-panel.js` before `web-map.js`.
- **web-map.js** mounts a GO card in the context rail while the user is in the **Plan** workspace (a showcase M1→M2 transfer route for now; from/to deep-link is a follow-up), hidden in every other workspace.

## Safety
**Guarded + additive:** every path (container creation, planning, mount) is `try/catch`, so any failure only hides the GO card and leaves Ariadne and the rest of Plan untouched. No existing behaviour is modified beyond adding the card and hide/show per workspace.

## Verification
- Local: `web-map.js` syntax OK; script order correct; **30/30 harness tests** pass (athens-time / marker guardrails not tripped).
- The panel + planner + live mode are already **browser-verified end to end** (served harness).
- The in-app mount needs the Compose/Wasm build (no JDK here), so it's **verified on the Pages deploy** after merge (I'll check `syrmos.peterdsp.dev` → Plan and revert if anything's off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)