### PR TITLE
feat(airport): live express-bus ETAs + de-duplicated departures (iOS)

### DIFF
--- a/iosApp/Syrmos.xcodeproj/project.pbxproj
+++ b/iosApp/Syrmos.xcodeproj/project.pbxproj
@@ -151,6 +151,9 @@
 		F547F60AEDEF7EE113E77B7B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8FAA054C866F04CB39A4C07 /* Assets.xcassets */; };
 		FAB11EB401D5464F9E009564 /* SyrmosLineTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32687A748EF4519991403D6 /* SyrmosLineTokens.swift */; };
 		FFDDCB33EB8ADA0BA119A64C /* WatchConnectivityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEA07DD99223CD5AAE17E70 /* WatchConnectivityProvider.swift */; };
+		2D82DB91972D4DB8BBDE77DB /* AirportBusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F8EA0447A54742B5757B83 /* AirportBusService.swift */; };
+		2A2181AFDFE94E2B8CEBD412 /* AirportServiceRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75EB12B0AA648BCB7AD0BB5 /* AirportServiceRows.swift */; };
+		02CA5092C4E9490DBFD4C185 /* AirportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A7818792314F8DBE8F37C6 /* AirportServiceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -358,6 +361,9 @@
 		F9632839850F8DA49BA56324 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		FE854D92A6C68AEAC8E0603F /* AriadneModelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AriadneModelStore.swift; path = iosApp/Features/Assistant/AriadneModelStore.swift; sourceTree = SOURCE_ROOT; };
 		FF201314EADCD2EA1936941F /* Complications-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "SyrmosWatch/Complications-Info.plist"; sourceTree = SOURCE_ROOT; };
+		C0F8EA0447A54742B5757B83 /* AirportBusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Networking/AirportBusService.swift; sourceTree = SOURCE_ROOT; };
+		D75EB12B0AA648BCB7AD0BB5 /* AirportServiceRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Timetables/AirportServiceRows.swift; sourceTree = SOURCE_ROOT; };
+		90A7818792314F8DBE8F37C6 /* AirportServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AirportServiceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -407,6 +413,7 @@
 			isa = PBXGroup;
 			children = (
 				87C1AB3CF938A60DF7285C1F /* ScheduleProjectorTests.swift */,
+				90A7818792314F8DBE8F37C6 /* AirportServiceTests.swift */,
 				DA7A0004F00D0004F00D0004 /* HomeFeaturesTests.swift */,
 				DA7A0031F00D0031F00D0031 /* MapRouteGeometryTests.swift */,
 				DA7A0019F00D0019F00D0019 /* AriadneParserTests.swift */,
@@ -581,6 +588,7 @@
 				C5D6E7F8A9B0C1D2E3F40507 /* SyrmosLinesService.swift */,
 				0F174A75E7C14871B9B77CAE /* SyrmosSchedulesService.swift */,
 				E1A2B3C4D5E60718293A4B5D /* SyrmosDeparturesService.swift */,
+				C0F8EA0447A54742B5757B83 /* AirportBusService.swift */,
 				E1A2B3C4D5E60718293A4B6F /* LivePositionsService.swift */,
 				D1E2F3A4B5C6071829304142 /* STASYService.swift */,
 				31E31FFAA5B22EE54B9E980E /* RailNewsService.swift */,
@@ -669,6 +677,7 @@
 			isa = PBXGroup;
 			children = (
 				09288EF8307B4CDC9D065AED /* TimetablesView.swift */,
+				D75EB12B0AA648BCB7AD0BB5 /* AirportServiceRows.swift */,
 				DBADA13AF3954288A721329B /* TimetablesIcons.swift */,
 			);
 			name = Timetables;
@@ -971,6 +980,8 @@
 				8A72EAE7260D46FDA05D490B /* SafariSheet.swift in Sources */,
 				4DFE1212D427449286398220 /* StationMapSheet.swift in Sources */,
 				B264406F57304E569BAAED79 /* TimetablesView.swift in Sources */,
+				2A2181AFDFE94E2B8CEBD412 /* AirportServiceRows.swift in Sources */,
+				2D82DB91972D4DB8BBDE77DB /* AirportBusService.swift in Sources */,
 				AAAA111111111111111111B1 /* OnboardingView.swift in Sources */,
 				DA7A0011F00D0011F00D0011 /* AriadneParser.swift in Sources */,
 				DA7A0211F00D0211F00D0211 /* AriadneDomain.swift in Sources */,
@@ -1055,6 +1066,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3CC04D0831F54B17495246AC /* ScheduleProjectorTests.swift in Sources */,
+				02CA5092C4E9490DBFD4C185 /* AirportServiceTests.swift in Sources */,
 				DA7A0003F00D0003F00D0003 /* HomeFeaturesTests.swift in Sources */,
 				DA7A0030F00D0030F00D0030 /* MapRouteGeometryTests.swift in Sources */,
 				DA7A0018F00D0018F00D0018 /* AriadneParserTests.swift in Sources */,

--- a/iosApp/iosApp/Core/Networking/AirportBusService.swift
+++ b/iosApp/iosApp/Core/Networking/AirportBusService.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Live OASA airport express-bus ETAs, from the Pi at /api/oasa-airport-buses.
+///
+/// The Pi's `oasa-airport-bus-watcher` polls OASA Telematics `getStopArrivals`
+/// for the airport stop (10705) every 30s and writes real per-vehicle ETAs to
+/// the airport stop. `minutesAway` is OASA's own `btime2` estimate for that bus
+/// to reach the airport, so the soonest per line is genuinely the next X-bus a
+/// rider can board at the airport. That makes these `.live`, not scheduled - we
+/// no longer fall back to a passive "check OASA" message when the feed answers.
+@MainActor
+enum AirportBusService {
+    private static let base = "https://api-syrmos.peterdsp.dev"
+    /// Short TTL so the 15s Airport refresh timer picks up fresh ETAs but a
+    /// burst of reloads in the same tick reuses one response.
+    private static let ttl: TimeInterval = 12
+    private static var cache: (Date, LiveAirportBuses)?
+
+    /// Soonest-first live ETAs (minutes) per airport express line (X93/X95/X96/X97).
+    struct LiveAirportBuses: Equatable {
+        let updatedAt: Date?
+        let etasByLine: [String: [Int]]
+
+        var isEmpty: Bool { etasByLine.isEmpty }
+        /// The next tracked bus of `line` reaching the airport stop, if any.
+        func soonest(_ line: String) -> Int? { etasByLine[line]?.first }
+    }
+
+    /// Fetch live ETAs. Returns nil on any failure or in offline-only mode so the
+    /// caller falls back to the neutral 24/7 presentation. Never throws to the UI.
+    static func fetch() async -> LiveAirportBuses? {
+        if SyrmosSchedulesStore.shared.offlineOnly { return nil }
+        if let cached = cache, Date().timeIntervalSince(cached.0) < ttl {
+            return cached.1
+        }
+        guard let url = URL(string: "\(base)/api/oasa-airport-buses") else { return nil }
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 6
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            let payload = try JSONDecoder().decode(Payload.self, from: data)
+            let live = reduce(payload)
+            cache = (Date(), live)
+            return live
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Pure mapping (unit-tested, no network)
+
+    /// Collapse the raw feed into soonest-first ETAs per line. Negative ETAs are
+    /// clamped to 0 (bus at the stop). Lines with no tracked vehicle are absent.
+    static func reduce(_ payload: Payload) -> LiveAirportBuses {
+        var byLine: [String: [Int]] = [:]
+        for arrival in payload.airportArrivals where !arrival.lineId.isEmpty {
+            byLine[arrival.lineId, default: []].append(max(0, arrival.minutesAway))
+        }
+        for (line, etas) in byLine {
+            byLine[line] = etas.sorted()
+        }
+        return LiveAirportBuses(updatedAt: parseTimestamp(payload.updatedAt), etasByLine: byLine)
+    }
+
+    static func parseTimestamp(_ value: String) -> Date? {
+        guard !value.isEmpty else { return nil }
+        let withFraction = ISO8601DateFormatter()
+        withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFraction.date(from: value) { return date }
+        return ISO8601DateFormatter().date(from: value)
+    }
+
+    // MARK: - Decoding
+
+    struct Payload: Decodable {
+        let updatedAt: String
+        let airportArrivals: [Arrival]
+
+        init(updatedAt: String, airportArrivals: [Arrival]) {
+            self.updatedAt = updatedAt
+            self.airportArrivals = airportArrivals
+        }
+
+        enum CodingKeys: String, CodingKey { case updatedAt, airportArrivals }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            updatedAt = (try? c.decode(String.self, forKey: .updatedAt)) ?? ""
+            airportArrivals = (try? c.decode([Arrival].self, forKey: .airportArrivals)) ?? []
+        }
+
+        struct Arrival: Decodable {
+            let lineId: String
+            let minutesAway: Int
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Timetables/AirportServiceRows.swift
+++ b/iosApp/iosApp/Features/Timetables/AirportServiceRows.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+
+/// One row in the airport "Airport services" list. `stationId` is the airport
+/// side station a metro/suburban row opens; buses have none. `confidence` drives
+/// how honestly the time reads: live ETAs vs a neutral 24/7 badge.
+struct AirportListRow: Identifiable {
+    let id = UUID()
+    let route: String
+    let destination: String
+    let detail: String
+    let time: String
+    let color: Color
+    var stationId: String? = nil
+    var confidence: SourceConfidence = .scheduled
+}
+
+/// Airport-side station a metro/suburban row opens in StationDetailView. Buses
+/// (X..) have no per-stop timetable, so nil keeps their row non-navigable.
+func airportSideStationId(forRoute route: String) -> String? {
+    switch route {
+    case "M3", "M3_AIR": return "M3_AER"
+    case "A1": return "A1_AIR"
+    case "A2": return "A2_AIR"
+    default: return nil
+    }
+}
+
+/// Pure builder for the airport-departures list. Kept free of SwiftUI plumbing
+/// and network so ordering, de-duplication, labeling and the live/fallback bus
+/// treatment are all unit-testable (see AirportServiceRowsTests).
+///
+/// Three defects this fixes versus the old inline `rows`:
+///   1. M3 and M3_AIR project the same physical train, so the raw list held two
+///      identical "M3 Syntagma 06:39" rows. We de-dup metro by departure time.
+///   2. The old code took the first 3 departures regardless of mode and always
+///      labeled them "M3 / Syntagma / metro departure", so an A1 slot showed up
+///      as a metro to Syntagma. We now section by real mode.
+///   3. Buses showed a passive "24/7 - check OASA" even though the Pi tracks
+///      their live ETA to the airport. We surface that ETA as `.live` when present.
+enum AirportServiceRows {
+    static func build(
+        metroDepartures: [Departure],
+        buses: AirportBusService.LiveAirportBuses?,
+        language: AppLanguage
+    ) -> [AirportListRow] {
+        var output: [AirportListRow] = []
+
+        // Metro (M3 / M3_AIR) -> Syntagma. De-dup by time, cap at 3.
+        var seenMetro = Set<String>()
+        for dep in metroDepartures where dep.lineId == "M3" || dep.lineId == "M3_AIR" {
+            guard seenMetro.insert(dep.time).inserted else { continue }
+            output.append(AirportListRow(
+                route: "M3",
+                destination: "Syntagma",
+                detail: t(language,
+                          "Scheduled metro departure",
+                          "Προγραμματισμένη αναχώρηση μετρό",
+                          "Nisje e programuar e metrosë",
+                          "Partenza metro programmata"),
+                time: dep.time,
+                color: Color.metroBlue,
+                stationId: airportSideStationId(forRoute: dep.lineId),
+                confidence: .scheduled
+            ))
+            if output.count >= 3 { break }
+        }
+
+        // Suburban (A1 / A2) -> Piraeus. De-dup by line+time, cap at 2, keep the
+        // real line badge instead of relabeling everything A1.
+        var seenSuburban = Set<String>()
+        var suburbanCount = 0
+        for dep in metroDepartures where dep.lineId == "A1" || dep.lineId == "A2" {
+            guard seenSuburban.insert(dep.lineId + dep.time).inserted else { continue }
+            output.append(AirportListRow(
+                route: dep.lineId,
+                destination: t(language, "Piraeus", "Πειραιάς", "Pireus", "Pireo"),
+                detail: t(language,
+                          "Scheduled suburban departure",
+                          "Προγραμματισμένη αναχώρηση προαστιακού",
+                          "Nisje e programuar e trenit periferik",
+                          "Partenza suburbano programmata"),
+                time: dep.time,
+                color: SyrmosTokens.suburban,
+                stationId: airportSideStationId(forRoute: dep.lineId),
+                confidence: .scheduled
+            ))
+            suburbanCount += 1
+            if suburbanCount >= 2 { break }
+        }
+
+        // Express buses. Live ETA when the Pi is tracking one, else a neutral 24/7.
+        for bus in busLines(language) {
+            if let mins = buses?.soonest(bus.line) {
+                output.append(AirportListRow(
+                    route: bus.line,
+                    destination: bus.destination,
+                    detail: t(language,
+                              "Live arrival at the airport stop",
+                              "Ζωντανή άφιξη στη στάση του αεροδρομίου",
+                              "Mbërritje e drejtpërdrejtë në stacionin e aeroportit",
+                              "Arrivo in tempo reale alla fermata dell'aeroporto"),
+                    time: etaLabel(minutes: mins, language: language),
+                    color: SyrmosTokens.warning,
+                    stationId: nil,
+                    confidence: .live
+                ))
+            } else {
+                output.append(AirportListRow(
+                    route: bus.line,
+                    destination: bus.destination,
+                    detail: t(language,
+                              "24-hour express bus",
+                              "24ωρο λεωφορείο express",
+                              "Autobus express 24 orë",
+                              "Bus express 24 ore"),
+                    time: "24/7",
+                    color: SyrmosTokens.warning,
+                    stationId: nil,
+                    confidence: .operatorLink
+                ))
+            }
+        }
+        return output
+    }
+
+    /// Localized minutes badge for a live bus ETA. "Now" when it is at the stop.
+    static func etaLabel(minutes: Int, language: AppLanguage) -> String {
+        if minutes <= 1 {
+            switch language {
+            case .greek: return "Τώρα"
+            case .albanian: return "Tani"
+            case .italian: return "Ora"
+            default: return "Now"
+            }
+        }
+        let minAbbr: String
+        switch language {
+        case .greek: minAbbr = "λεπ"
+        default: minAbbr = "min"
+        }
+        if minutes < 60 { return "\(minutes) \(minAbbr)" }
+        let h = minutes / 60
+        let m = minutes % 60
+        let hAbbr = language == .greek ? "ω" : "h"
+        return m == 0 ? "\(h)\(hAbbr)" : "\(h)\(hAbbr) \(m) \(minAbbr)"
+    }
+
+    private struct BusLine { let line: String; let destination: String }
+
+    private static func busLines(_ language: AppLanguage) -> [BusLine] {
+        [
+            BusLine(line: "X95", destination: "Syntagma"),
+            BusLine(line: "X93", destination: "Kifisos"),
+            BusLine(line: "X96", destination: t(language, "Piraeus", "Πειραιάς", "Pireus", "Pireo")),
+            BusLine(line: "X97", destination: t(language, "Elliniko", "Ελληνικό", "Elliniko", "Elliniko")),
+        ]
+    }
+
+    private static func t(_ language: AppLanguage, _ en: String, _ el: String, _ al: String, _ it: String) -> String {
+        switch language {
+        case .greek: return el
+        case .albanian: return al
+        case .italian: return it
+        default: return en
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Timetables/TimetablesView.swift
+++ b/iosApp/iosApp/Features/Timetables/TimetablesView.swift
@@ -100,6 +100,7 @@ struct TimetablesView: View {
     @State private var selectedRoute = "M3"
     @State private var airportDepartures: [Departure] = []
     @State private var cityAirportDepartures: [Departure] = []
+    @State private var liveBuses: AirportBusService.LiveAirportBuses? = nil
     /// Thessaloniki only: next metro departures at each interchange station
     /// (Mikra on L2, Nea Elvetia on L1) that feeds an airport shuttle, keyed by
     /// station id. Athens is fed by direct rail so it uses the two lists above.
@@ -156,7 +157,8 @@ struct TimetablesView: View {
                         AirportNextServicesCard(
                             language: loc.language,
                             dayOffset: dayOffset,
-                            metroDepartures: airportDepartures
+                            metroDepartures: airportDepartures,
+                            liveBuses: liveBuses
                         )
 
                         airportSectionTitle(
@@ -172,7 +174,8 @@ struct TimetablesView: View {
                         AirportDepartureList(
                             language: loc.language,
                             dayOffset: dayOffset,
-                            metroDepartures: airportDepartures
+                            metroDepartures: airportDepartures,
+                            liveBuses: liveBuses
                         )
                     } else {
                         AirportConnectionsCard(hub: hub, language: loc.language)
@@ -236,6 +239,7 @@ struct TimetablesView: View {
                 // at each interchange that feeds an airport shuttle.
                 airportDepartures = []
                 cityAirportDepartures = []
+                liveBuses = nil
                 var legs: [String: [Departure]] = [:]
                 for leg in currentHub.metroLegs {
                     legs[leg.stationId] = ScheduleProjector.nextDepartures(
@@ -262,6 +266,15 @@ struct TimetablesView: View {
                 limit: 80,
                 dayOffset: selectedDay
             ).filter { AirportData.isAirportBoundDirection($0.direction) || $0.serviceType == "airport" }
+
+            // Live express-bus ETAs are Athens-only (X93/95/96/97 tracked by the
+            // Pi). Only the live schedule (today) is meaningful, so skip the fetch
+            // when browsing a future day, where "in 5 min" would be misleading.
+            if currentHub.city == .athens && selectedDay == 0 {
+                liveBuses = await AirportBusService.fetch()
+            } else {
+                liveBuses = nil
+            }
         }
     }
 }
@@ -841,6 +854,7 @@ private struct AirportNextServicesCard: View {
     let language: AppLanguage
     let dayOffset: Int
     let metroDepartures: [Departure]
+    var liveBuses: AirportBusService.LiveAirportBuses? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -864,15 +878,27 @@ private struct AirportNextServicesCard: View {
                 } else {
                     m3Tile
                 }
-                AirportNextServiceTile(
-                    route: "X95",
-                    icon: "bus.fill",
-                    destination: "Syntagma",
-                    primary: "24/7",
-                    secondary: airportText(language, "Check OASA for current bus times", "Ελέγξτε τον ΟΑΣΑ για τα τρέχοντα δρομολόγια", "Kontrollo OASA për oraret aktuale", "Controlla OASA per gli orari attuali"),
-                    status: airportText(language, "Express", "Express", "Express", "Express"),
-                    color: SyrmosTokens.warning
-                )
+                if let mins = liveBuses?.soonest("X95") {
+                    AirportNextServiceTile(
+                        route: "X95",
+                        icon: "bus.fill",
+                        destination: "Syntagma",
+                        primary: AirportServiceRows.etaLabel(minutes: mins, language: language),
+                        secondary: airportText(language, "Live to the airport stop", "Ζωντανά στη στάση του αεροδρομίου", "Drejtpërdrejt te stacioni i aeroportit", "In tempo reale alla fermata dell'aeroporto"),
+                        status: SourceConfidence.live.label(language),
+                        color: SyrmosTokens.warning
+                    )
+                } else {
+                    AirportNextServiceTile(
+                        route: "X95",
+                        icon: "bus.fill",
+                        destination: "Syntagma",
+                        primary: "24/7",
+                        secondary: airportText(language, "24-hour express bus", "24ωρο λεωφορείο express", "Autobus express 24 orë", "Bus express 24 ore"),
+                        status: airportText(language, "Express", "Express", "Express", "Express"),
+                        color: SyrmosTokens.warning
+                    )
+                }
             }
         }
     }
@@ -929,6 +955,7 @@ private struct AirportDepartureList: View {
     let language: AppLanguage
     let dayOffset: Int
     let metroDepartures: [Departure]
+    var liveBuses: AirportBusService.LiveAirportBuses? = nil
 
     var body: some View {
         VStack(spacing: 8) {
@@ -954,9 +981,19 @@ private struct AirportDepartureList: View {
                 .foregroundStyle(.white)
                 .frame(width: 38, height: 38)
                 .background(row.color, in: Circle())
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text(row.destination).font(.subheadline.weight(.semibold))
-                Text(row.detail).font(.caption).foregroundStyle(.secondary)
+                // Live bus rows carry a pulsing Live chip instead of a static
+                // detail line, so the source reads the same as every other
+                // departure surface. Scheduled/operator rows keep their text.
+                if row.confidence == .live {
+                    HStack(spacing: 6) {
+                        SourceConfidenceChip(confidence: .live, language: language)
+                        Text(row.detail).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                    }
+                } else {
+                    Text(row.detail).font(.caption).foregroundStyle(.secondary)
+                }
             }
             Spacer()
             Text(row.time).font(.headline).monospacedDigit().foregroundStyle(row.color)
@@ -972,32 +1009,13 @@ private struct AirportDepartureList: View {
     }
 
     private var rows: [AirportListRow] {
-        let busDetail = airportText(language, "24-hour express bus. Check OASA for current times.", "24ωρο λεωφορείο express. Ελέγξτε τον ΟΑΣΑ για τα τρέχοντα δρομολόγια.", "Autobus express 24 orë. Kontrollo OASA për oraret aktuale.", "Bus express 24 ore. Controlla OASA per gli orari attuali.")
-        var output = metroDepartures.prefix(3).map {
-            AirportListRow(route: $0.lineId == "M3_AIR" ? "M3" : $0.lineId, destination: "Syntagma", detail: airportText(language, "Scheduled metro departure", "Προγραμματισμένη αναχώρηση μετρό", "Nisje e programuar e metrosë", "Partenza metro programmata"), time: $0.time, color: Color.metroBlue, stationId: airportStationId(forRoute: $0.lineId))
-        }
-        let suburbanDeps = metroDepartures.filter { $0.lineId == "A1" || $0.lineId == "A2" }.prefix(2)
-        for dep in suburbanDeps {
-            output.append(AirportListRow(route: dep.lineId, destination: airportText(language, "Piraeus", "Πειραιάς", "Pireus", "Pireo"), detail: airportText(language, "Scheduled suburban departure", "Προγραμματισμένη αναχώρηση προαστιακού", "Nisje e programuar e trenit periferik", "Partenza suburbano programmata"), time: dep.time, color: SyrmosTokens.suburban, stationId: airportStationId(forRoute: dep.lineId)))
-        }
-        output.append(AirportListRow(route: "X95", destination: "Syntagma", detail: busDetail, time: "24/7", color: SyrmosTokens.warning))
-        output.append(AirportListRow(route: "X93", destination: "Kifisos", detail: busDetail, time: "24/7", color: SyrmosTokens.warning))
-        output.append(AirportListRow(route: "X96", destination: airportText(language, "Piraeus", "Πειραιάς", "Pireus", "Pireo"), detail: busDetail, time: "24/7", color: SyrmosTokens.warning))
-        output.append(AirportListRow(route: "X97", destination: airportText(language, "Elliniko", "Ελληνικό", "Elliniko", "Elliniko"), detail: busDetail, time: "24/7", color: SyrmosTokens.warning))
-        return output
+        AirportServiceRows.build(
+            metroDepartures: metroDepartures,
+            buses: liveBuses,
+            language: language
+        )
     }
 
-}
-
-private struct AirportListRow {
-    let route: String
-    let destination: String
-    let detail: String
-    let time: String
-    let color: Color
-    // Airport-side station to open in StationDetailView; nil for buses (no
-    // per-stop timetable), which keeps their row non-navigable.
-    var stationId: String? = nil
 }
 
 // MARK: - Thessaloniki connections (metro + shuttle, or direct bus)
@@ -1183,19 +1201,6 @@ private struct AirportServiceAlertCard: View {
 
 private func airportSectionTitle(_ title: String) -> some View {
     Text(title).font(.title3.bold()).padding(.top, 2)
-}
-
-// Resolve the airport-side station a service tile/row/leg should open in
-// StationDetailView. Metro maps to the M3 airport station, the suburban lines
-// to their own airport stops; buses (X..) have no station detail, so nil keeps
-// the row non-navigable. Returns nil when the id is unknown so a tap never dead-ends.
-private func airportStationId(forRoute route: String) -> String? {
-    switch route {
-    case "M3", "M3_AIR": return "M3_AER"
-    case "A1": return "A1_AIR"
-    case "A2": return "A2_AIR"
-    default: return nil
-    }
 }
 
 private func airportStation(id: String?) -> TransitStation? {

--- a/iosApp/iosAppTests/AirportServiceTests.swift
+++ b/iosApp/iosAppTests/AirportServiceTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Syrmos
+
+/// Covers the airport-services redesign: live express-bus ETA reduction and the
+/// de-duplicated, correctly-labeled airport departures list. Pins the three bugs
+/// that shipped in the old inline `rows`:
+///   1. duplicate "M3 Syntagma HH:MM" rows (M3 + M3_AIR project one train),
+///   2. non-metro slots relabeled as "M3 / Syntagma / metro departure",
+///   3. buses stuck on a passive "24/7 - check OASA" despite a live ETA feed.
+@MainActor
+final class AirportServiceTests: XCTestCase {
+
+    private func dep(_ line: String, _ time: String, dir: String = "Syntagma") -> Departure {
+        Departure(time: time, lineId: line, direction: dir, minutesAway: 0, serviceType: "", trainNo: nil)
+    }
+
+    // MARK: - AirportBusService.reduce
+
+    func testReduceGroupsSortsAndClampsEtas() {
+        let payload = AirportBusService.Payload(updatedAt: "2026-09-03T21:42:32.703144+00:00", airportArrivals: [
+            .init(lineId: "X95", minutesAway: 19),
+            .init(lineId: "X95", minutesAway: 5),
+            .init(lineId: "X93", minutesAway: -3), // clamps to 0
+            .init(lineId: "", minutesAway: 4),     // dropped: no line
+        ])
+        let live = AirportBusService.reduce(payload)
+        XCTAssertEqual(live.soonest("X95"), 5, "soonest X95 ETA wins")
+        XCTAssertEqual(live.etasByLine["X95"], [5, 19], "ETAs sorted ascending")
+        XCTAssertEqual(live.soonest("X93"), 0, "negative ETA clamps to 0")
+        XCTAssertNil(live.soonest("X97"), "untracked line absent")
+        XCTAssertNotNil(live.updatedAt, "fractional-second ISO timestamp parses")
+    }
+
+    func testReduceEmptyFeed() {
+        let live = AirportBusService.reduce(.init(updatedAt: "", airportArrivals: []))
+        XCTAssertTrue(live.isEmpty)
+        XCTAssertNil(live.updatedAt)
+    }
+
+    // MARK: - De-duplication + labeling
+
+    func testMetroDuplicatesCollapseByTime() {
+        // M3 and M3_AIR both project the 06:39 airport train.
+        let deps = [dep("M3", "06:39"), dep("M3_AIR", "06:39"), dep("M3", "06:49")]
+        let rows = AirportServiceRows.build(metroDepartures: deps, buses: nil, language: .english)
+        let metro = rows.filter { $0.route == "M3" }
+        XCTAssertEqual(metro.map { $0.time }, ["06:39", "06:49"], "one row per distinct time")
+    }
+
+    func testSuburbanKeepsRealLineAndIsNotRelabeledMetro() {
+        // The old prefix(3) turned an A1 slot into "M3 / Syntagma / metro departure".
+        let deps = [dep("M3", "06:39"), dep("A1", "04:00", dir: "Piraeus"), dep("A2", "04:10", dir: "Piraeus")]
+        let rows = AirportServiceRows.build(metroDepartures: deps, buses: nil, language: .english)
+        XCTAssertFalse(rows.contains { $0.route == "A1" && $0.destination == "Syntagma" },
+                       "A1 must never be relabeled a metro to Syntagma")
+        XCTAssertTrue(rows.contains { $0.route == "A1" && $0.destination == "Piraeus" })
+        XCTAssertTrue(rows.contains { $0.route == "A2" && $0.destination == "Piraeus" })
+    }
+
+    func testSuburbanDedupAndCap() {
+        let deps = [dep("A1", "04:00", dir: "Piraeus"), dep("A1", "04:00", dir: "Piraeus"),
+                    dep("A1", "04:30", dir: "Piraeus"), dep("A1", "05:00", dir: "Piraeus")]
+        let rows = AirportServiceRows.build(metroDepartures: deps, buses: nil, language: .english)
+        let sub = rows.filter { $0.route == "A1" }
+        XCTAssertEqual(sub.map { $0.time }, ["04:00", "04:30"], "duplicates dropped, capped at 2")
+    }
+
+    func testMetroCappedAtThree() {
+        let deps = (0..<6).map { dep("M3", String(format: "07:%02d", $0 * 5)) }
+        let rows = AirportServiceRows.build(metroDepartures: deps, buses: nil, language: .english)
+        XCTAssertEqual(rows.filter { $0.route == "M3" }.count, 3)
+    }
+
+    // MARK: - Buses: live vs fallback
+
+    func testBusesShowLiveEtaWhenTracked() {
+        let live = AirportBusService.reduce(.init(updatedAt: "", airportArrivals: [
+            .init(lineId: "X95", minutesAway: 5),
+            .init(lineId: "X93", minutesAway: 9),
+        ]))
+        let rows = AirportServiceRows.build(metroDepartures: [], buses: live, language: .english)
+        let x95 = rows.first { $0.route == "X95" }
+        XCTAssertEqual(x95?.time, "5 min")
+        XCTAssertEqual(x95?.confidence, .live)
+        // X96 is untracked in this feed -> neutral fallback, never a fake time.
+        let x96 = rows.first { $0.route == "X96" }
+        XCTAssertEqual(x96?.time, "24/7")
+        XCTAssertEqual(x96?.confidence, .operatorLink)
+    }
+
+    func testBusesFallBackWhenNoLiveData() {
+        let rows = AirportServiceRows.build(metroDepartures: [], buses: nil, language: .english)
+        for line in ["X95", "X93", "X96", "X97"] {
+            let row = rows.first { $0.route == line }
+            XCTAssertEqual(row?.time, "24/7")
+            XCTAssertEqual(row?.confidence, .operatorLink)
+            XCTAssertFalse(row?.detail.contains("OASA") ?? true, "no passive check-OASA copy")
+        }
+    }
+
+    func testEtaLabelFormatting() {
+        XCTAssertEqual(AirportServiceRows.etaLabel(minutes: 0, language: .english), "Now")
+        XCTAssertEqual(AirportServiceRows.etaLabel(minutes: 1, language: .english), "Now")
+        XCTAssertEqual(AirportServiceRows.etaLabel(minutes: 7, language: .english), "7 min")
+        XCTAssertEqual(AirportServiceRows.etaLabel(minutes: 65, language: .english), "1h 5 min")
+    }
+}

--- a/scripts/add-airport-service-files.py
+++ b/scripts/add-airport-service-files.py
@@ -1,0 +1,76 @@
+"""Register the airport-services redesign Swift files in project.pbxproj.
+
+Idempotent: skips anything already present. Anchors insertions on existing
+sibling entries so the app and test Sources phases each get the right files.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PBX = ROOT / "iosApp/Syrmos.xcodeproj/project.pbxproj"
+
+# filename, SOURCE_ROOT path or None (=> "<group>"), group-anchor sibling,
+# sources-phase-anchor sibling (a filename already in the right phase)
+FILES = [
+    ("AirportBusService.swift", "iosApp/Core/Networking/AirportBusService.swift",
+     "SyrmosDeparturesService.swift", "TimetablesView.swift"),
+    ("AirportServiceRows.swift", "iosApp/Features/Timetables/AirportServiceRows.swift",
+     "TimetablesView.swift", "TimetablesView.swift"),
+    ("AirportServiceTests.swift", None,
+     "ScheduleProjectorTests.swift", "ScheduleProjectorTests.swift"),
+]
+
+
+def gen_id() -> str:
+    return uuid.uuid4().hex[:24].upper()
+
+
+def main() -> None:
+    src = PBX.read_text()
+
+    for filename, src_path, group_anchor, phase_anchor in FILES:
+        if f"/* {filename} */" in src:
+            print(f"already registered: {filename}")
+            continue
+
+        file_ref = gen_id()
+        build_ref = gen_id()
+
+        if src_path:
+            ref_line = (f"\t\t{file_ref} /* {filename} */ = {{isa = PBXFileReference; "
+                        f"lastKnownFileType = sourcecode.swift; path = {src_path}; "
+                        f"sourceTree = SOURCE_ROOT; }};\n")
+        else:
+            ref_line = (f"\t\t{file_ref} /* {filename} */ = {{isa = PBXFileReference; "
+                        f"includeInIndex = 1; lastKnownFileType = sourcecode.swift; "
+                        f"path = {filename}; sourceTree = \"<group>\"; }};\n")
+
+        build_line = (f"\t\t{build_ref} /* {filename} in Sources */ = "
+                      f"{{isa = PBXBuildFile; fileRef = {file_ref} /* {filename} */; }};\n")
+
+        src = src.replace("/* End PBXFileReference section */", ref_line + "/* End PBXFileReference section */", 1)
+        src = src.replace("/* End PBXBuildFile section */", build_line + "/* End PBXBuildFile section */", 1)
+
+        # Group children: insert after the anchor sibling's child line.
+        child = f"\t\t\t\t{file_ref} /* {filename} */,\n"
+        gm = re.search(r"[0-9A-F]{24} /\* " + re.escape(group_anchor) + r" \*/,\n", src)
+        assert gm, f"group anchor {group_anchor} not found"
+        src = src[:gm.end()] + child + src[gm.end():]
+
+        # Sources phase: insert after the anchor sibling's "in Sources" build line.
+        srcline = f"\t\t\t\t{build_ref} /* {filename} in Sources */,\n"
+        pm = re.search(r"[0-9A-F]{24} /\* " + re.escape(phase_anchor) + r" in Sources \*/,\n", src)
+        assert pm, f"phase anchor {phase_anchor} not found"
+        src = src[:pm.end()] + srcline + src[pm.end():]
+
+        print(f"+ registered {filename}")
+
+    PBX.write_text(src)
+    print("project.pbxproj updated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The Airport tab shipped three defects visible in the current TestFlight screenshots:

1. **Duplicate rows** — M3 and M3_AIR project the same physical airport train, so the list showed two identical `M3 Syntagma HH:MM` rows; A1 slots appeared twice too.
2. **Mislabeling** — the old `prefix(3)` took the first three departures regardless of mode and always labeled them `M3 / Syntagma / metro departure`, so an A1 slot surfaced as a metro to Syntagma.
3. **Passive bus copy** — X93/95/96/97 showed a static `24/7 — Check OASA for current times`, even though Syrmos already tracks their **live ETA to the airport** (OASA Telematics `getStopArrivals` @ stop 10705, served by the Pi at `/api/oasa-airport-buses`).

## How

- **`AirportBusService`** — fetches `/api/oasa-airport-buses` and a pure, unit-tested `reduce` that collapses the feed into soonest-first live ETAs per line (respects offline-only mode, 6s timeout, 12s TTL).
- **`AirportServiceRows`** — a pure, unit-tested builder that de-dups metro by time and suburban by line+time, sections by real mode (fixing the mislabel), and surfaces live bus ETAs with a `.live` `SourceConfidence` chip — falling back to a neutral `24/7` badge (no more "check OASA") when the feed is silent or a line is untracked.
- **`TimetablesView`** — fetches live buses on reload (Athens, today only — never shows "in 5 min" for a future day) and wires them into the Next-services X95 tile and the Airport services list.

Honesty: ETAs are labeled `.live` only because `minutesAway` is OASA's own real-time `btime2` estimate for a tracked vehicle reaching the airport stop. No scheduled data is dressed up as live.

## Proof

- `BUILD SUCCEEDED` (Xcode 26.6, iOS 26.5 simulator)
- `9/9` `AirportServiceTests` pass (reduce mapping, metro dedup, suburban relabel/dedup/caps, live-vs-fallback buses, ETA formatting)
- Visual QA on the simulator: deduped rows, correct suburban labels, real live ETAs (X95 19 min, X93 33 min) with pulsing Live chips.

## Scope

iOS only. Android (Compose) and Web (web-map.js — which currently shows **no** airport buses at all) parity is tracked as follow-up in the 3.0 airport program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)