### PR TITLE
feat(web): live airport express-bus ETAs in the station sheet

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -539,6 +539,7 @@
      which mounts the panel in the Plan workspace). web-go defines SyrmosGO,
      which the panel uses. -->
 <script src="/web-go.js"></script>
+<script src="/web-airport.js"></script>
 <script src="/web-planner.js"></script>
 <script src="/web-go-panel.js"></script>
 <script src="/web-map.js"></script>

--- a/composeApp/src/wasmJsMain/resources/web-airport.js
+++ b/composeApp/src/wasmJsMain/resources/web-airport.js
@@ -1,0 +1,79 @@
+'use strict';
+// Syrmos airport express-bus telematics (web reference implementation).
+//
+// The Pi's oasa-airport-bus-watcher polls OASA Telematics getStopArrivals for
+// the airport stop (10705) and serves live per-vehicle ETAs at
+// /api/oasa-airport-buses. `minutesAway` is OASA's own btime2 estimate for a
+// tracked bus to reach the airport, so the soonest per line is genuinely the
+// next X-bus a rider can board at the airport - a real .live source, never a
+// timetable dressed up as live. Mirrors iOS AirportBusService/AirportServiceRows
+// so the three clients agree on the transform.
+//
+// This module is the PURE, testable core: no DOM, no network, no clock. web-map.js
+// fetches the JSON and hands the payload to reduceAirportBuses; presentation
+// (chips, clock time, localized copy) stays in web-map.js.
+//
+// UMD: usable as `require('./web-airport.js')` in node and as
+// `window.SyrmosAirport` in the browser.
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.SyrmosAirport = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  // X-bus -> its city-side terminal. Proper-noun destinations; localization of
+  // Piraeus/Elliniko is a web-map.js presentation concern.
+  const BUS_DESTINATIONS = {
+    X95: 'Syntagma',
+    X93: 'Kifisos',
+    X96: 'Piraeus',
+    X97: 'Elliniko',
+  };
+
+  // Collapse the raw feed into soonest-first live ETAs per line. Negative ETAs
+  // clamp to 0 (bus at the stop). Lines with no tracked vehicle are absent.
+  function reduceAirportBuses(payload) {
+    const etasByLine = {};
+    const arrivals = (payload && Array.isArray(payload.airportArrivals)) ? payload.airportArrivals : [];
+    for (const a of arrivals) {
+      const line = a && typeof a.lineId === 'string' ? a.lineId : '';
+      if (!line) continue;
+      const mins = Math.max(0, Math.round(Number(a.minutesAway)));
+      if (!Number.isFinite(mins)) continue;
+      (etasByLine[line] || (etasByLine[line] = [])).push(mins);
+    }
+    for (const line of Object.keys(etasByLine)) etasByLine[line].sort((x, y) => x - y);
+    const updatedAt = (payload && typeof payload.updatedAt === 'string' && payload.updatedAt) ? payload.updatedAt : null;
+    return { updatedAt, etasByLine };
+  }
+
+  function soonest(reduced, line) {
+    const etas = reduced && reduced.etasByLine ? reduced.etasByLine[line] : null;
+    return (etas && etas.length) ? etas[0] : null;
+  }
+
+  // One departure-shaped row per tracked X-bus, soonest first across lines.
+  // Only tracked lines appear: an untracked line is omitted rather than shown
+  // with a fabricated "24/7" time (web is map-first, so a dead row is noise).
+  function airportBusDepartures(reduced) {
+    const rows = [];
+    for (const line of Object.keys(BUS_DESTINATIONS)) {
+      const mins = soonest(reduced, line);
+      if (mins == null) continue;
+      rows.push({ line, destination: BUS_DESTINATIONS[line], minutesAway: mins });
+    }
+    rows.sort((a, b) => a.minutesAway - b.minutesAway);
+    return rows;
+  }
+
+  // True when a station node is an airport station (metro M3_AER or suburban
+  // A1_AIR/A2_AIR, or a name that reads "airport"). Same rule as web-map's
+  // isAirportStation, duplicated here so callers can gate the bus fetch without
+  // reaching into the map closure.
+  function isAirportStationId(id, name, nameEl) {
+    if (/(^|_)(AIR|AER)/.test(id || '')) return true;
+    if (/airport/i.test(name || '')) return true;
+    if (/Αεροδρ/.test(nameEl || '')) return true;
+    return false;
+  }
+
+  return { reduceAirportBuses, soonest, airportBusDepartures, isAirportStationId, BUS_DESTINATIONS };
+});

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -90,6 +90,7 @@
             live_unknown_age: "Live, age unknown",
             estimated: "Estimated",
             offline_snapshot: "Offline snapshot",
+            airport_bus_live: "Live to the airport stop",
             check_operator: "Check operator",
             unknown: "unknown",
             next: "next",
@@ -185,6 +186,7 @@
             live_unknown_age: "Ζωντανά, άγνωστη ώρα",
             estimated: "Εκτίμηση",
             offline_snapshot: "Εκτός σύνδεσης",
+            airport_bus_live: "Ζωντανά στη στάση του αεροδρομίου",
             check_operator: "Δείτε πάροχο",
             unknown: "άγνωστο",
             next: "επόμενος",
@@ -280,6 +282,7 @@
             live_unknown_age: "Drejtpërdrejt, kohë e panjohur",
             estimated: "Vlerësim",
             offline_snapshot: "Pa internet",
+            airport_bus_live: "Drejtpërdrejt te stacioni i aeroportit",
             check_operator: "Kontrolloni operatorin",
             unknown: "i panjohur",
             next: "tjetër",
@@ -375,6 +378,7 @@
             live_unknown_age: "In tempo reale, età sconosciuta",
             estimated: "Stimato",
             offline_snapshot: "Snapshot offline",
+            airport_bus_live: "In tempo reale alla fermata dell'aeroporto",
             check_operator: "Verifica operatore",
             unknown: "sconosciuto",
             next: "prossimo",
@@ -1941,6 +1945,42 @@
         }
     }
 
+    // Live airport express-bus ETAs (X93/95/96/97). Fetched only when an airport
+    // station sheet is open. Short TTL so the 15s countdown timer picks up fresh
+    // ETAs without a network hit every tick. Returns the reduced shape from
+    // web-airport.js, or null on any failure (the sheet just omits bus rows).
+    let airportBusCache = null; // { at: epochMs, data }
+    async function fetchAirportBuses() {
+        const now = Date.now();
+        if (airportBusCache && (now - airportBusCache.at) < 12_000) return airportBusCache.data;
+        try {
+            const r = await fetch("https://api-syrmos.peterdsp.dev/api/oasa-airport-buses");
+            if (!r.ok) return null;
+            const payload = await r.json();
+            const data = SyrmosAirport.reduceAirportBuses(payload);
+            airportBusCache = { at: now, data };
+            return data;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    // Turn a pure airport-bus row into a departure-card-shaped object. Live by
+    // construction: minutesAway is OASA's real ETA to the airport stop.
+    function toBusDeparture(row) {
+        return {
+            line: { id: row.line, name: row.line, color: "#D97706" },
+            direction: row.destination,
+            destination: row.destination,
+            minutesAway: row.minutesAway,
+            time: formatTimeFromNow(row.minutesAway),
+            serviceType: "",
+            source: "live",
+            sourceLabel: t("live"),
+            ariaNote: t("airport_bus_live"),
+        };
+    }
+
     // Honest service-state for a station whose live/scheduled departures are
     // empty. A seasonal or suspended line must never look like a plain "no
     // departures right now" glitch: it has a real, explainable reason, so the
@@ -2023,11 +2063,21 @@
     }
 
     async function renderDepartures(station) {
-        const apiDepartures = await fetchApiDepartures(station);
-        const departures = (apiDepartures && apiDepartures.length)
+        // Rail departures and (for airport stations) live express-bus ETAs load
+        // in parallel so the sheet paints once with both.
+        const isAirport = SyrmosAirport.isAirportStationId(station.id, station.name, station.nameEl);
+        const [apiDepartures, busReduced] = await Promise.all([
+            fetchApiDepartures(station),
+            isAirport ? fetchAirportBuses() : Promise.resolve(null),
+        ]);
+        const railDepartures = (apiDepartures && apiDepartures.length)
             ? apiDepartures
             : buildStationDepartures(station);
-        if (!departures.length) {
+        const busRows = busReduced
+            ? SyrmosAirport.airportBusDepartures(busReduced).map(toBusDeparture)
+            : [];
+
+        if (!railDepartures.length && !busRows.length) {
             const svc = stationServiceState(station);
             stationDepartures.innerHTML = svc
                 ? serviceStateCardHtml(svc)
@@ -2036,15 +2086,18 @@
             return;
         }
 
-        // Source-confidence: API departures are the live timetable feed
-        // (SCHEDULED); the bundled fallback is the offline snapshot. One source
-        // per render because both branches produce a single homogeneous list.
+        // Source-confidence is per row: rail is the live timetable feed
+        // (SCHEDULED) or the offline snapshot; airport buses carry their own
+        // LIVE chip. Trains first, then the live buses grouped after them.
         const fromApi = !!(apiDepartures && apiDepartures.length);
-        const sourceMod = fromApi ? "scheduled" : "offline";
-        const sourceLabel = t(fromApi ? "scheduled" : "offline_snapshot");
-        const sourceChip = `<span class="src-chip src-chip--${sourceMod}"><span class="src-chip__dot"></span>${sourceLabel}</span>`;
+        const railMod = fromApi ? "scheduled" : "offline";
+        const railLabel = t(fromApi ? "scheduled" : "offline_snapshot");
+        const departures = [...railDepartures, ...busRows];
 
         stationDepartures.innerHTML = departures.map((departure, idx) => {
+            const sourceMod = departure.source || railMod;
+            const sourceLabel = departure.sourceLabel || railLabel;
+            const sourceChip = `<span class="src-chip src-chip--${sourceMod}"><span class="src-chip__dot"></span>${sourceLabel}</span>`;
             const entranceCls = idx <= 8 ? ` sy-entrance sy-entrance-${idx}` : "";
             const minutesLabel = formatMinutesAway(departure.minutesAway);
             const lineId = departure.line?.id || "";
@@ -2062,7 +2115,7 @@
                 ? `<span class="departure-card__pill departure-card__pill--airport">Airport</span>`
                 : "";
             return `
-                <div class="departure-card${entranceCls}" role="listitem" aria-label="${lineId} towards ${destination}, ${minutesLabel}, at ${departure.time || ''}">
+                <div class="departure-card${entranceCls}" role="listitem" aria-label="${lineId} towards ${destination}, ${minutesLabel}, at ${departure.time || ''}${departure.ariaNote ? ', ' + departure.ariaNote : ''}">
                     <div class="departure-card__header">
                         ${iconHtml}
                         <div class="departure-card__text">

--- a/web-tests/airport-buses.test.js
+++ b/web-tests/airport-buses.test.js
@@ -1,0 +1,61 @@
+'use strict';
+// Web airport express-bus telematics, mirroring iOS AirportServiceTests so the
+// two clients reduce the /api/oasa-airport-buses feed identically.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const A = require(path.join(
+  __dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources', 'web-airport.js'
+));
+
+const payload = (arrivals, updatedAt = '2026-09-03T21:42:32.703144+00:00') => ({ updatedAt, airportArrivals: arrivals });
+
+test('reduceAirportBuses groups, sorts ascending, and clamps negatives', () => {
+  const r = A.reduceAirportBuses(payload([
+    { lineId: 'X95', minutesAway: 19 },
+    { lineId: 'X95', minutesAway: 5 },
+    { lineId: 'X93', minutesAway: -3 }, // clamps to 0
+    { lineId: '', minutesAway: 4 },     // dropped: no line
+  ]));
+  assert.deepEqual(r.etasByLine.X95, [5, 19]);
+  assert.equal(A.soonest(r, 'X95'), 5);
+  assert.equal(A.soonest(r, 'X93'), 0);
+  assert.equal(A.soonest(r, 'X97'), null, 'untracked line absent');
+  assert.equal(r.updatedAt, '2026-09-03T21:42:32.703144+00:00');
+});
+
+test('reduceAirportBuses tolerates a malformed / empty feed', () => {
+  assert.deepEqual(A.reduceAirportBuses({}).etasByLine, {});
+  assert.deepEqual(A.reduceAirportBuses(null).etasByLine, {});
+  assert.equal(A.reduceAirportBuses({ airportArrivals: [{ minutesAway: 3 }] }).etasByLine.X95, undefined);
+});
+
+test('airportBusDepartures emits one soonest row per tracked line, sorted', () => {
+  const r = A.reduceAirportBuses(payload([
+    { lineId: 'X95', minutesAway: 19 },
+    { lineId: 'X95', minutesAway: 5 },
+    { lineId: 'X93', minutesAway: 9 },
+    { lineId: 'X97', minutesAway: 2 },
+  ]));
+  const rows = A.airportBusDepartures(r);
+  assert.deepEqual(rows.map((x) => [x.line, x.minutesAway]), [
+    ['X97', 2], ['X95', 5], ['X93', 9],
+  ], 'soonest-first across lines, one row per line');
+  assert.equal(rows.find((x) => x.line === 'X95').destination, 'Syntagma');
+  assert.equal(rows.find((x) => x.line === 'X97').destination, 'Elliniko');
+});
+
+test('airportBusDepartures never fabricates a row for an untracked line', () => {
+  const r = A.reduceAirportBuses(payload([{ lineId: 'X95', minutesAway: 5 }]));
+  const rows = A.airportBusDepartures(r);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].line, 'X95');
+});
+
+test('isAirportStationId matches metro/suburban airport ids and names', () => {
+  assert.equal(A.isAirportStationId('M3_AER'), true);
+  assert.equal(A.isAirportStationId('A1_AIR'), true);
+  assert.equal(A.isAirportStationId('M3_SYN'), false);
+  assert.equal(A.isAirportStationId('X', 'Airport Terminal'), true);
+  assert.equal(A.isAirportStationId('X', '', 'Αεροδρόμιο'), true);
+});


### PR DESCRIPTION
## Why

Web parity for #123 (iOS airport telematics). `web-map.js` had **zero** airport-bus support — the airport station sheet showed only rail, and the live X93/95/96/97 feed the Pi already serves at `/api/oasa-airport-buses` (OASA Telematics `getStopArrivals` @ airport stop 10705) was never surfaced on web.

## How

- **`web-airport.js`** — new UMD module (`require` in node, `window.SyrmosAirport` in the browser) holding the pure, testable transform: `reduceAirportBuses` (group by line, sort ascending, clamp negatives) and `airportBusDepartures` (soonest per tracked line, sorted across lines). Mirrors the iOS `AirportBusService`/`AirportServiceRows` contract so the clients agree.
- **`web-map.js`** — when an airport station sheet opens, fetch the feed (12s TTL) in parallel with rail and append live bus rows after the trains. Source chips are now **per-row**: rail stays Scheduled/Offline, buses carry a **LIVE** chip. Untracked lines are omitted rather than shown with a fabricated `24/7` time (web is map-first — a dead row is noise). Added `airport_bus_live` copy in all four languages (EN/EL/SQ/IT).
- **`index.html`** — load `web-airport.js` before `web-map.js`.
- **`web-tests/airport-buses.test.js`** — 5 tests mirroring iOS `AirportServiceTests`.

Honesty: rows are `.live` only because `minutesAway` is OASA's real-time ETA for a tracked vehicle reaching the airport stop.

## Proof

- **35/35** web tests pass (5 new + 30 existing, incl. the Athens-time and seed guardrails).
- Rendered in the browser against the **live** feed: the Airport sheet shows rail (Scheduled chips) then live buses — Elliniko 1 min, Syntagma 12 min, Kifisos 15 min — each with a green Live chip and a localized "Live to the airport stop" aria note.

## Scope

Web station sheet. iOS shipped in #123. Android (Compose) parity — `OasaAirportBusService.kt` exists but is unused by UI — remains the next follow-up, plus plotting the live `vehicles[]` on the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)