### PR TITLE
feat(web): plot live airport express-buses on the map

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-airport.js
+++ b/composeApp/src/wasmJsMain/resources/web-airport.js
@@ -64,6 +64,41 @@
     return rows;
   }
 
+  // Normalized live vehicle positions for the map layer. Drops rows without a
+  // finite non-zero coordinate or a line id. Direction (toAirport true/false, or
+  // null when unknown) is derived from the routeCode against payload.routes so a
+  // marker can say whether the bus is heading to or from the terminal.
+  function airportBusVehicles(payload) {
+    const routes = (payload && payload.routes) || {};
+    const dirOf = (lineId, routeCode) => {
+      const r = routes[lineId];
+      if (!r) return null;
+      if ((r.toAirport || []).indexOf(routeCode) !== -1) return true;
+      if ((r.fromAirport || []).indexOf(routeCode) !== -1) return false;
+      return null;
+    };
+    const out = [];
+    const vehicles = (payload && Array.isArray(payload.vehicles)) ? payload.vehicles : [];
+    for (const v of vehicles) {
+      if (!v) continue;
+      const lat = Number(v.lat);
+      const lng = Number(v.lng);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+      if (lat === 0 && lng === 0) continue;
+      const lineId = typeof v.lineId === 'string' ? v.lineId : '';
+      if (!lineId) continue;
+      out.push({
+        id: String(v.vehicleId || ''),
+        lineId,
+        lat,
+        lng,
+        heading: Number(v.heading) || 0,
+        toAirport: dirOf(lineId, Number(v.routeCode)),
+      });
+    }
+    return out;
+  }
+
   // True when a station node is an airport station (metro M3_AER or suburban
   // A1_AIR/A2_AIR, or a name that reads "airport"). Same rule as web-map's
   // isAirportStation, duplicated here so callers can gate the bus fetch without
@@ -75,5 +110,5 @@
     return false;
   }
 
-  return { reduceAirportBuses, soonest, airportBusDepartures, isAirportStationId, BUS_DESTINATIONS };
+  return { reduceAirportBuses, soonest, airportBusDepartures, airportBusVehicles, isAirportStationId, BUS_DESTINATIONS };
 });

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -699,6 +699,11 @@
     // marched out into the Saronic Gulf — the "live trains in the sea" the feed
     // never actually reported.
     const liveTrainLayer = L.layerGroup();
+    // Live airport express-bus vehicles (X93/95/96/97) ride in their own layer,
+    // fed by /api/oasa-airport-buses. Kept separate from the train layer so each
+    // clears independently and buses never inherit the train glyph/colour.
+    const liveBusLayer = L.layerGroup();
+    let lastBusVehicles = [];
     let departureRefreshTimer = null;
     const lineStations = new Map(
         routes.map((route) => [
@@ -2367,10 +2372,14 @@
             if (vehiclesHidden) {
                 liveTrainLayer.clearLayers();
                 liveTrainMarkers.clear();
+                liveBusLayer.clearLayers();
                 simulatedTrainMarkers.forEach((marker) => marker.remove());
                 simulatedTrainMarkers.clear();
-            } else if (lastSimulatedTrains.length) {
-                renderSimulatedTrainsOnMap(lastSimulatedTrains);
+            } else {
+                renderAirportBusVehicles(lastBusVehicles);
+                if (lastSimulatedTrains.length) {
+                    renderSimulatedTrainsOnMap(lastSimulatedTrains);
+                }
             }
         });
     }
@@ -2404,6 +2413,7 @@
         // Without this they stayed full-size when zoomed out and collapsed into a
         // single pile on the coastline that read as "trains in the sea".
         renderLiveTrains(lastLiveTrains);
+        renderAirportBusVehicles(lastBusVehicles);
         if (DEBUG) logMarkerAudit(z);
     });
 
@@ -2532,6 +2542,7 @@
     initStep("renderPopularPanel", renderPopularPanel);
     initStep("updateNearbyPanel", updateNearbyPanel);
     initStep("connectLiveTrainStream", connectLiveTrainStream);
+    initStep("connectAirportBusStream", connectAirportBusStream);
     initStep("pollLivePositions", pollLivePositions);
     initStep("setupRightRail", setupRightRail);
     initStep("startTrainSimulation", startTrainSimulation);
@@ -2754,6 +2765,58 @@
                 showTrainSheet("live", train);
             });
             liveTrainMarkers.set(train.id, marker);
+        }
+    }
+
+    // Poll the airport-bus feed and plot each tracked vehicle. Separate from the
+    // train stream: buses come from /api/oasa-airport-buses (positions + ETAs),
+    // trains from /api/trains. 15s cadence matches the watcher's 30s writes.
+    function connectAirportBusStream() {
+        const URL = "https://api-syrmos.peterdsp.dev/api/oasa-airport-buses";
+        async function pollOnce() {
+            try {
+                const res = await fetch(URL, { cache: "no-store" });
+                if (!res.ok) return;
+                const payload = await res.json();
+                renderAirportBusVehicles(SyrmosAirport.airportBusVehicles(payload));
+            } catch (_error) {
+                // Keep the last frame on transient errors.
+            }
+        }
+        pollOnce();
+        setInterval(pollOnce, 15_000);
+    }
+
+    function renderAirportBusVehicles(vehicles) {
+        lastBusVehicles = vehicles;
+        if (!map.hasLayer(liveBusLayer)) liveBusLayer.addTo(map);
+        liveBusLayer.clearLayers();
+        // Same declutter rule as trains: hidden by the manual toggle or when
+        // zoomed out past the regional threshold (avoids a coastline pile-up).
+        if (window.__syrmosVehiclesHidden || map.getZoom() < MAP_TOKENS.majorHubMinZoom) {
+            return;
+        }
+        const busColor = "#D97706"; // SyrmosTokens.warning, matching the bus rows.
+        for (const v of vehicles) {
+            const icon = L.divIcon({
+                className: "live-train-marker",
+                html: `
+                    <span class="live-train-marker__pulse" style="border-color:${busColor}"></span>
+                    <span class="live-train-marker__core" style="background:${busColor}">
+                        <span class="live-train-marker__glyph">🚌</span>
+                    </span>
+                    <span class="live-train-marker__badge" style="background:${busColor}">${v.lineId}</span>
+                `,
+                iconSize: [44, 56],
+                iconAnchor: [22, 22],
+            });
+            const dir = v.toAirport === true
+                ? (currentLang === "el" ? "προς αεροδρόμιο" : currentLang === "sq" ? "drejt aeroportit" : currentLang === "it" ? "verso l'aeroporto" : "to the airport")
+                : v.toAirport === false
+                    ? (currentLang === "el" ? "από αεροδρόμιο" : currentLang === "sq" ? "nga aeroporti" : currentLang === "it" ? "dall'aeroporto" : "from the airport")
+                    : "";
+            const marker = L.marker([v.lat, v.lng], { icon, keyboard: false, zIndexOffset: 900 }).addTo(liveBusLayer);
+            marker.bindTooltip(`${v.lineId}${dir ? " · " + dir : ""}`, { direction: "top", offset: [0, -10] });
         }
     }
 

--- a/web-tests/airport-buses.test.js
+++ b/web-tests/airport-buses.test.js
@@ -52,6 +52,32 @@ test('airportBusDepartures never fabricates a row for an untracked line', () => 
   assert.equal(rows[0].line, 'X95');
 });
 
+test('airportBusVehicles keeps valid positions and derives direction', () => {
+  const payload = {
+    vehicles: [
+      { vehicleId: '61233', lat: 37.90, lng: 23.90, heading: 12, routeCode: 2051, lineId: 'X95' }, // to airport
+      { vehicleId: '61167', lat: 37.93, lng: 23.94, heading: 0, routeCode: 2052, lineId: 'X95' },  // from airport
+      { vehicleId: '0', lat: 0, lng: 0, routeCode: 2051, lineId: 'X95' },   // dropped: null island
+      { vehicleId: 'x', lat: 'n/a', lng: 23.9, routeCode: 2051, lineId: 'X95' }, // dropped: bad coord
+      { vehicleId: 'y', lat: 37.9, lng: 23.9, routeCode: 999, lineId: '' },  // dropped: no line
+    ],
+    routes: { X95: { toAirport: [2051], fromAirport: [2052] } },
+  };
+  const v = A.airportBusVehicles(payload);
+  assert.equal(v.length, 2);
+  assert.equal(v[0].toAirport, true);
+  assert.equal(v[1].toAirport, false);
+  assert.equal(v[0].id, '61233');
+});
+
+test('airportBusVehicles tolerates missing vehicles / routes', () => {
+  assert.deepEqual(A.airportBusVehicles({}), []);
+  assert.equal(A.airportBusVehicles(null).length, 0);
+  const v = A.airportBusVehicles({ vehicles: [{ lat: 37.9, lng: 23.9, lineId: 'X93', routeCode: 5675 }] });
+  assert.equal(v.length, 1);
+  assert.equal(v[0].toAirport, null, 'unknown direction when no routes map');
+});
+
 test('isAirportStationId matches metro/suburban airport ids and names', () => {
   assert.equal(A.isAirportStationId('M3_AER'), true);
   assert.equal(A.isAirportStationId('A1_AIR'), true);


### PR DESCRIPTION
## Why

Stacked on #124. The `/api/oasa-airport-buses` payload carries live vehicle **positions** (`vehicles[]`), not just the ETAs #124 surfaces in the station sheet. This plots those vehicles on the map, next to the existing live-train layer.

> Base branch is `feat/web-airport-live-telematics` (#124), which this depends on for `web-airport.js`. Merge #124 first, or retarget to `master` after it lands.

## How

- **`web-airport.js`** — `airportBusVehicles(payload)`: pure extractor that drops rows without a finite non-zero coordinate or a line id, and derives to/from-airport direction from `routeCode` against `payload.routes`.
- **`web-map.js`** — a dedicated `liveBusLayer` + `renderAirportBusVehicles` (orange bus `divIcon` reusing the `live-train-marker` styling, line-id badge, direction tooltip), polled every 15s via `connectAirportBusStream`. Obeys the same declutter rules as trains (the manual Hide-vehicles toggle and the regional zoom guard) and re-renders on `zoomend`.
- **`web-tests/airport-buses.test.js`** — 2 new cases (valid/invalid positions + direction derivation; missing feed).

## Proof

- **37/37** web tests pass.
- In-browser against the live feed: the map shows **17 orange bus markers matching the 17 live vehicles** in the feed, clustered on the X95/X93 corridors between Athens and the airport; they hide with the vehicles toggle and declutter when zoomed out.

## Scope

Web map. iOS map-vehicle parity is the sibling follow-up (the feed and the marker concept are identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)