### PR TITLE
feat(ios): plot live airport express-buses on the map

### DIFF
--- a/iosApp/Syrmos.xcodeproj/project.pbxproj
+++ b/iosApp/Syrmos.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		2D82DB91972D4DB8BBDE77DB /* AirportBusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F8EA0447A54742B5757B83 /* AirportBusService.swift */; };
 		2A2181AFDFE94E2B8CEBD412 /* AirportServiceRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75EB12B0AA648BCB7AD0BB5 /* AirportServiceRows.swift */; };
 		02CA5092C4E9490DBFD4C185 /* AirportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A7818792314F8DBE8F37C6 /* AirportServiceTests.swift */; };
+		916AAEDEC08D4BF3B6705852 /* AirportBusVehicles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EB2F2BCAE242BAB284D68C /* AirportBusVehicles.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -364,6 +365,7 @@
 		C0F8EA0447A54742B5757B83 /* AirportBusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Networking/AirportBusService.swift; sourceTree = SOURCE_ROOT; };
 		D75EB12B0AA648BCB7AD0BB5 /* AirportServiceRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Features/Timetables/AirportServiceRows.swift; sourceTree = SOURCE_ROOT; };
 		90A7818792314F8DBE8F37C6 /* AirportServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AirportServiceTests.swift; sourceTree = "<group>"; };
+		34EB2F2BCAE242BAB284D68C /* AirportBusVehicles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp/Core/Networking/AirportBusVehicles.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -588,6 +590,7 @@
 				C5D6E7F8A9B0C1D2E3F40507 /* SyrmosLinesService.swift */,
 				0F174A75E7C14871B9B77CAE /* SyrmosSchedulesService.swift */,
 				E1A2B3C4D5E60718293A4B5D /* SyrmosDeparturesService.swift */,
+				34EB2F2BCAE242BAB284D68C /* AirportBusVehicles.swift */,
 				C0F8EA0447A54742B5757B83 /* AirportBusService.swift */,
 				E1A2B3C4D5E60718293A4B6F /* LivePositionsService.swift */,
 				D1E2F3A4B5C6071829304142 /* STASYService.swift */,
@@ -980,6 +983,7 @@
 				8A72EAE7260D46FDA05D490B /* SafariSheet.swift in Sources */,
 				4DFE1212D427449286398220 /* StationMapSheet.swift in Sources */,
 				B264406F57304E569BAAED79 /* TimetablesView.swift in Sources */,
+				916AAEDEC08D4BF3B6705852 /* AirportBusVehicles.swift in Sources */,
 				2A2181AFDFE94E2B8CEBD412 /* AirportServiceRows.swift in Sources */,
 				2D82DB91972D4DB8BBDE77DB /* AirportBusService.swift in Sources */,
 				AAAA111111111111111111B1 /* OnboardingView.swift in Sources */,

--- a/iosApp/iosApp/Core/Networking/AirportBusVehicles.swift
+++ b/iosApp/iosApp/Core/Networking/AirportBusVehicles.swift
@@ -1,0 +1,133 @@
+import Foundation
+import CoreLocation
+import Combine
+
+/// One live airport express-bus position for the map layer. `toAirport` is nil
+/// when the route code doesn't resolve to a known direction.
+struct AirportBusVehicle: Identifiable {
+    let id: String
+    let lineId: String
+    let coordinate: CLLocationCoordinate2D
+    let toAirport: Bool?
+}
+
+/// Polls /api/oasa-airport-buses for live X93/95/96/97 vehicle positions and
+/// publishes them for the map. Mirrors LiveTrainService (a single shared poller)
+/// and the web `airportBusVehicles` transform, so all clients plot the same
+/// vehicles. ETAs for the departure lists come from `AirportBusService`; this is
+/// only the positions[] side of the same feed.
+@MainActor
+final class LiveAirportBusService: ObservableObject {
+    static let shared = LiveAirportBusService()
+
+    @Published var vehicles: [AirportBusVehicle] = []
+
+    private var task: Task<Void, Never>?
+
+    init() { startPolling() }
+
+    func startPolling() {
+        guard task == nil else { return }
+        task = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.fetchOnce()
+                try? await Task.sleep(nanoseconds: 15_000_000_000)
+            }
+        }
+    }
+
+    private func fetchOnce() async {
+        guard !SyrmosSchedulesStore.shared.offlineOnly else {
+            vehicles = []
+            return
+        }
+        guard let url = URL(string: "https://api-syrmos.peterdsp.dev/api/oasa-airport-buses") else { return }
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 8
+        req.cachePolicy = .reloadIgnoringLocalCacheData
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return }
+            let payload = try JSONDecoder().decode(Payload.self, from: data)
+            vehicles = Self.parse(payload)
+        } catch {
+            // Keep the last frame on transient errors.
+        }
+    }
+
+    // MARK: - Pure mapping (unit-tested via AirportServiceTests)
+
+    /// Extract plottable vehicles: drop rows without a finite non-zero coordinate
+    /// or a line id, and resolve to/from-airport from the route code.
+    static func parse(_ payload: Payload) -> [AirportBusVehicle] {
+        payload.vehicles.compactMap { v in
+            guard !v.lineId.isEmpty else { return nil }
+            guard v.lat.isFinite, v.lng.isFinite, !(v.lat == 0 && v.lng == 0) else { return nil }
+            let dir = payload.routes[v.lineId].flatMap { route -> Bool? in
+                if route.toAirport.contains(v.routeCode) { return true }
+                if route.fromAirport.contains(v.routeCode) { return false }
+                return nil
+            }
+            return AirportBusVehicle(
+                id: v.vehicleId,
+                lineId: v.lineId,
+                coordinate: CLLocationCoordinate2D(latitude: v.lat, longitude: v.lng),
+                toAirport: dir
+            )
+        }
+    }
+
+    struct Payload: Decodable {
+        let vehicles: [Vehicle]
+        let routes: [String: RouteDirs]
+
+        init(vehicles: [Vehicle], routes: [String: RouteDirs]) {
+            self.vehicles = vehicles
+            self.routes = routes
+        }
+
+        enum CodingKeys: String, CodingKey { case vehicles, routes }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            vehicles = (try? c.decode([Vehicle].self, forKey: .vehicles)) ?? []
+            routes = (try? c.decode([String: RouteDirs].self, forKey: .routes)) ?? [:]
+        }
+
+        struct Vehicle: Decodable {
+            let vehicleId: String
+            let lat: Double
+            let lng: Double
+            let routeCode: Int
+            let lineId: String
+
+            enum CodingKeys: String, CodingKey { case vehicleId, lat, lng, routeCode, lineId }
+            init(vehicleId: String, lat: Double, lng: Double, routeCode: Int, lineId: String) {
+                self.vehicleId = vehicleId; self.lat = lat; self.lng = lng
+                self.routeCode = routeCode; self.lineId = lineId
+            }
+            init(from decoder: Decoder) throws {
+                let c = try decoder.container(keyedBy: CodingKeys.self)
+                vehicleId = (try? c.decode(String.self, forKey: .vehicleId)) ?? ""
+                lat = (try? c.decode(Double.self, forKey: .lat)) ?? .nan
+                lng = (try? c.decode(Double.self, forKey: .lng)) ?? .nan
+                routeCode = (try? c.decode(Int.self, forKey: .routeCode)) ?? 0
+                lineId = (try? c.decode(String.self, forKey: .lineId)) ?? ""
+            }
+        }
+
+        struct RouteDirs: Decodable {
+            let toAirport: [Int]
+            let fromAirport: [Int]
+            init(toAirport: [Int], fromAirport: [Int]) {
+                self.toAirport = toAirport; self.fromAirport = fromAirport
+            }
+            enum CodingKeys: String, CodingKey { case toAirport, fromAirport }
+            init(from decoder: Decoder) throws {
+                let c = try decoder.container(keyedBy: CodingKeys.self)
+                toAirport = (try? c.decode([Int].self, forKey: .toAirport)) ?? []
+                fromAirport = (try? c.decode([Int].self, forKey: .fromAirport)) ?? []
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/Views/Map/MapView.swift
+++ b/iosApp/iosApp/Views/Map/MapView.swift
@@ -267,6 +267,7 @@ struct TransitMapView: View {
     // work by ~50% and avoids the multi-view re-render storms that were
     // freezing the UI on iOS.
     @ObservedObject private var liveTrainService = LiveTrainService.shared
+    @ObservedObject private var airportBusService = LiveAirportBusService.shared
     @ObservedObject private var trainSimulator = TrainSimulatorService.shared
     @StateObject private var stasyService = STASYService()
     @StateObject private var locationManager = MapLocationManager()
@@ -377,6 +378,7 @@ struct TransitMapView: View {
                         return trainSimulator.trains.filter { !coveredLines.contains($0.lineId) }
                     }(),
                     liveTrains: vehiclesHidden ? [] : liveTrainService.trains,
+                    busVehicles: vehiclesHidden ? [] : airportBusService.vehicles,
                     stationDisruptions: stasyService.stationDisruptions,
                     recenterToUserPing: recenterToUserPing,
                     onStationTap: { stationId in
@@ -1034,6 +1036,7 @@ struct SyrmosMKMapView: UIViewRepresentable {
     let routeLines: [RouteLine]
     let simulatedTrains: [SimulatedTrain]
     let liveTrains: [LiveTrain]
+    let busVehicles: [AirportBusVehicle]
     let stationDisruptions: [String: String]
     /// Bumped from the parent's "Locate me" button to re-center on the
     /// user. Reading it in updateUIView() lets us tell a fresh request
@@ -1245,6 +1248,23 @@ struct SyrmosMKMapView: UIViewRepresentable {
             let ann = SyrmosTrainAnnotation(live: train)
             mv.addAnnotation(ann)
             ann.coordinate = context.coordinator.snapToPolyline(coord: train.coordinate, lineId: train.lineId)
+        }
+
+        // Sync live airport buses. Same move-in-place reconcile as live trains,
+        // but plotted at their true road coordinate (no rail-polyline snapping).
+        let busLang = LocalizationManager.shared.language
+        let wantBus = Dictionary(busVehicles.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+        var seenBus: Set<String> = []
+        for ann in mv.annotations.compactMap({ $0 as? SyrmosBusAnnotation }) {
+            if let v = wantBus[ann.busId] {
+                ann.refresh(v, lang: busLang)
+                seenBus.insert(ann.busId)
+            } else {
+                mv.removeAnnotation(ann)
+            }
+        }
+        for v in busVehicles where !seenBus.contains(v.id) {
+            mv.addAnnotation(SyrmosBusAnnotation(vehicle: v, lang: busLang))
         }
     }
 
@@ -1648,6 +1668,20 @@ struct SyrmosMKMapView: UIViewRepresentable {
                 v.isHidden = currentBand < 2
                 return v
             }
+            if let bus = annotation as? SyrmosBusAnnotation {
+                let id = "airportBus"
+                let v = (mapView.dequeueReusableAnnotationView(withIdentifier: id) as? MKMarkerAnnotationView)
+                    ?? MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: id)
+                v.annotation = annotation
+                v.canShowCallout = true
+                // Orange balloon with the line id, distinct from the rail dots.
+                v.markerTintColor = UIColor(SyrmosTokens.warning)
+                v.glyphText = bus.lineId
+                v.displayPriority = .defaultHigh
+                // Same regional declutter rule as trains.
+                v.isHidden = currentBand < 2
+                return v
+            }
             return nil
         }
 
@@ -1672,7 +1706,7 @@ struct SyrmosMKMapView: UIViewRepresentable {
                 guard let view = mapView.view(for: annotation) else { continue }
                 if let station = annotation as? SyrmosStationAnnotation {
                     view.isHidden = !inView(station.coordinate) || !shouldShow(station.station, band: b)
-                } else if annotation is SyrmosTrainAnnotation {
+                } else if annotation is SyrmosTrainAnnotation || annotation is SyrmosBusAnnotation {
                     // Vehicles follow the station decluttering rule: hidden below
                     // the regional band so the fleet never piles into a coastal blob.
                     view.isHidden = b < 2
@@ -1853,6 +1887,56 @@ final class SyrmosTrainAnnotation: NSObject, MKAnnotation {
     init(live: LiveTrain) {
         self.kind = .live(live)
         self.coordinate = live.coordinate
+    }
+}
+
+/// A live airport express-bus on the map. Buses follow roads (not a rail
+/// polyline), so unlike SyrmosTrainAnnotation they plot at their true reported
+/// coordinate with no snapping.
+final class SyrmosBusAnnotation: NSObject, MKAnnotation {
+    let busId: String
+    var lineId: String
+    var toAirport: Bool?
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+    // Stored (not computed) so the MKAnnotation getters stay nonisolated under
+    // Swift 6: the localized direction is baked in at construction, on the main
+    // actor where the language is read, and refreshed on reconcile.
+    var title: String?
+    var subtitle: String?
+    var id: String { "bus:\(busId)" }
+
+    init(vehicle: AirportBusVehicle, lang: AppLanguage) {
+        self.busId = vehicle.id
+        self.lineId = vehicle.lineId
+        self.toAirport = vehicle.toAirport
+        self.coordinate = vehicle.coordinate
+        super.init()
+        self.title = vehicle.lineId
+        self.subtitle = Self.directionText(vehicle.toAirport, lang: lang)
+    }
+
+    func refresh(_ vehicle: AirportBusVehicle, lang: AppLanguage) {
+        lineId = vehicle.lineId
+        toAirport = vehicle.toAirport
+        coordinate = vehicle.coordinate
+        title = vehicle.lineId
+        subtitle = Self.directionText(vehicle.toAirport, lang: lang)
+    }
+
+    static func directionText(_ toAirport: Bool?, lang: AppLanguage) -> String {
+        func tr(_ en: String, _ el: String, _ sq: String, _ it: String) -> String {
+            switch lang {
+            case .greek: return el
+            case .albanian: return sq
+            case .italian: return it
+            default: return en
+            }
+        }
+        switch toAirport {
+        case .some(true): return tr("To the airport", "Προς το αεροδρόμιο", "Drejt aeroportit", "Verso l'aeroporto")
+        case .some(false): return tr("From the airport", "Από το αεροδρόμιο", "Nga aeroporti", "Dall'aeroporto")
+        case .none: return tr("Express bus", "Λεωφορείο express", "Autobus express", "Bus express")
+        }
     }
 }
 

--- a/iosApp/iosAppTests/AirportServiceTests.swift
+++ b/iosApp/iosAppTests/AirportServiceTests.swift
@@ -98,6 +98,35 @@ final class AirportServiceTests: XCTestCase {
         }
     }
 
+    // MARK: - LiveAirportBusService.parse (map vehicles)
+
+    func testParseKeepsValidVehiclesAndDerivesDirection() {
+        let payload = LiveAirportBusService.Payload(
+            vehicles: [
+                .init(vehicleId: "61233", lat: 37.90, lng: 23.90, routeCode: 2051, lineId: "X95"), // to airport
+                .init(vehicleId: "61167", lat: 37.93, lng: 23.94, routeCode: 2052, lineId: "X95"), // from airport
+                .init(vehicleId: "0", lat: 0, lng: 0, routeCode: 2051, lineId: "X95"),   // dropped: null island
+                .init(vehicleId: "y", lat: 37.9, lng: 23.9, routeCode: 999, lineId: ""), // dropped: no line
+            ],
+            routes: ["X95": .init(toAirport: [2051], fromAirport: [2052])]
+        )
+        let vehicles = LiveAirportBusService.parse(payload)
+        XCTAssertEqual(vehicles.count, 2)
+        XCTAssertEqual(vehicles[0].toAirport, true)
+        XCTAssertEqual(vehicles[1].toAirport, false)
+        XCTAssertEqual(vehicles[0].id, "61233")
+    }
+
+    func testParseUnknownDirectionWhenNoRoutes() {
+        let payload = LiveAirportBusService.Payload(
+            vehicles: [.init(vehicleId: "1", lat: 37.9, lng: 23.9, routeCode: 5675, lineId: "X93")],
+            routes: [:]
+        )
+        let vehicles = LiveAirportBusService.parse(payload)
+        XCTAssertEqual(vehicles.count, 1)
+        XCTAssertNil(vehicles[0].toAirport)
+    }
+
     func testEtaLabelFormatting() {
         XCTAssertEqual(AirportServiceRows.etaLabel(minutes: 0, language: .english), "Now")
         XCTAssertEqual(AirportServiceRows.etaLabel(minutes: 1, language: .english), "Now")

--- a/scripts/add-airport-service-files.py
+++ b/scripts/add-airport-service-files.py
@@ -17,6 +17,8 @@ PBX = ROOT / "iosApp/Syrmos.xcodeproj/project.pbxproj"
 FILES = [
     ("AirportBusService.swift", "iosApp/Core/Networking/AirportBusService.swift",
      "SyrmosDeparturesService.swift", "TimetablesView.swift"),
+    ("AirportBusVehicles.swift", "iosApp/Core/Networking/AirportBusVehicles.swift",
+     "SyrmosDeparturesService.swift", "TimetablesView.swift"),
     ("AirportServiceRows.swift", "iosApp/Features/Timetables/AirportServiceRows.swift",
      "TimetablesView.swift", "TimetablesView.swift"),
     ("AirportServiceTests.swift", None,


### PR DESCRIPTION
## Why

Stacked on #123. `/api/oasa-airport-buses` carries live vehicle **positions** (`vehicles[]`), not just the ETAs #123 surfaces in the Airport tab. This plots them on the Map tab, beside the existing live-train layer — the iOS sibling of #126 (web).

> Base branch is `feat/airport-live-telematics-dedup` (#123). Merge #123 first, or retarget to `master` after it lands.

## How

- **`AirportBusVehicles.swift`** — `AirportBusVehicle` model + `LiveAirportBusService`, a shared 15s poller (mirrors `LiveTrainService`) with a pure, unit-tested `parse` that drops coord-less / line-less rows and derives to/from-airport from `routeCode`.
- **`MapView`** — `SyrmosBusAnnotation` + a move-in-place reconcile (plotted at the true road coordinate, no rail-polyline snapping); an orange `MKMarkerAnnotationView` with the line-id glyph and a localized direction callout (EN/EL/SQ/IT). Obeys the same Hide-vehicles toggle and regional zoom declutter as trains. Stored (not computed) `title`/`subtitle` keep the MKAnnotation getters nonisolated under Swift 6.
- **Tests** — 2 new cases in `AirportServiceTests` (parse validity + direction derivation).

## Proof

- `BUILD SUCCEEDED` (Xcode 26.6, iOS 26.5 sim)
- **11/11** `AirportServiceTests` pass
- On the simulator (location set to Athens), the Map tab shows the live **X95** as an orange marker on its corridor near Syntagma/Kolonaki.

## Airport map-vehicle parity

| Platform | PR |
|---|---|
| Web | #126 |
| iOS | this |

Android map-vehicle plotting would be the remaining sibling (its map is Compose; CI-only to verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)