### PR TITLE
feat(android): plot live airport express-buses on the map

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/syrmos/app/di/AppModule.kt
@@ -75,6 +75,7 @@ val featureModule = module {
             transitPatternRepository = get(),
             liveTrackerService = get(),
             livePositionsService = get(),
+            airportBusService = get(),
             stationOffsetsRepo = get(),
             scheduleSyncRepository = get(),
             computeActiveTrains = get(),

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -194,6 +194,7 @@ internal actual fun PlatformMapView(
     val stationMarkers = remember { mutableMapOf<String, Marker>() }
     val trainMarkers = remember { mutableMapOf<String, Marker>() }
     val liveTrainMarkers = remember { mutableMapOf<String, Marker>() }
+    val busMarkers = remember { mutableMapOf<String, Marker>() }
     // 0 = country, 1 = city, 2 = district, 3 = street. Mirrors web + iOS buckets.
     var zoomBucket by remember { mutableStateOf(2) }
     // Zoom-tiered decluttering, four bands (mirrors web + iOS): 0 = country
@@ -538,6 +539,42 @@ internal actual fun PlatformMapView(
                     }
                 }
                 liveTrainMarkers[train.id] = marker
+                mapView.overlays.add(marker)
+            }
+        }
+        mapView.invalidate()
+    }
+
+    // Live airport express-buses. Same regional declutter as trains, but plotted
+    // at the raw GPS coordinate (buses follow roads, not a rail polyline, so no
+    // snapping) and drawn in warning-orange to stand apart from the rail dots.
+    LaunchedEffect(uiState.busVehicles, mapBand) {
+        val res = context.resources
+        if (mapBand < 2) {
+            busMarkers.values.forEach { mapView.overlays.remove(it) }
+            busMarkers.clear()
+            mapView.invalidate()
+            return@LaunchedEffect
+        }
+        val activeIds = uiState.busVehicles.map { it.id }.toSet()
+        (busMarkers.keys - activeIds).forEach { id ->
+            busMarkers[id]?.let { mapView.overlays.remove(it) }
+            busMarkers.remove(id)
+        }
+        val busColor = 0xFFD97706.toInt() // SyrmosColorTokens.warning
+        uiState.busVehicles.forEach { bus ->
+            val pos = GeoPoint(bus.latitude, bus.longitude)
+            val existing = busMarkers[bus.id]
+            if (existing != null) {
+                existing.position = pos
+            } else {
+                val marker = Marker(mapView).apply {
+                    position = pos
+                    setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
+                    icon = buildLiveTrainBitmap(res, color = busColor, lineId = bus.lineId)
+                    title = bus.lineId
+                }
+                busMarkers[bus.id] = marker
                 mapView.overlays.add(marker)
             }
         }

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/AirportBusVehicles.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/AirportBusVehicles.kt
@@ -1,0 +1,33 @@
+package com.syrmos.feature.map
+
+import com.syrmos.core.network.OasaAirportBusService
+
+/**
+ * One live airport express-bus position for the map layer.
+ *
+ * The Pi's oasa-airport-bus-watcher serves live vehicle positions (vehicles[])
+ * alongside the ETAs at /api/oasa-airport-buses. Mirrors iOS AirportBusVehicle /
+ * web airportBusVehicles so all three clients plot the same fleet.
+ */
+data class AirportBusVehicle(
+    val id: String,
+    val lineId: String,
+    val latitude: Double,
+    val longitude: Double,
+)
+
+object AirportBusVehicles {
+    /**
+     * Extract plottable vehicles: drop rows without a line id or a finite
+     * non-zero coordinate (the null-island / GPS-less rows the feed can carry).
+     */
+    fun parse(response: OasaAirportBusService.OasaAirportBusResponse?): List<AirportBusVehicle> {
+        if (response == null) return emptyList()
+        return response.vehicles.mapNotNull { v ->
+            if (v.lineId.isBlank()) return@mapNotNull null
+            if (!v.lat.isFinite() || !v.lng.isFinite()) return@mapNotNull null
+            if (v.lat == 0.0 && v.lng == 0.0) return@mapNotNull null
+            AirportBusVehicle(id = v.vehicleId, lineId = v.lineId, latitude = v.lat, longitude = v.lng)
+        }
+    }
+}

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapScreen.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapScreen.kt
@@ -116,6 +116,7 @@ fun MapScreen(
                 uiState = if (uiState.showTrains) uiState else uiState.copy(
                     simulatedTrains = emptyList(),
                     liveTrains = emptyList(),
+                    busVehicles = emptyList(),
                 ),
                 onStationSelected = viewModel::selectStation,
                 onTrainSelected = viewModel::selectTrain,

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
@@ -24,6 +24,7 @@ import com.syrmos.core.model.transit.Station
 import com.syrmos.core.model.alerts.AlertSeverity
 import com.syrmos.core.data.sync.AnnouncementsRepository
 import com.syrmos.core.data.sync.StationOffsetsRepository
+import com.syrmos.core.network.OasaAirportBusService
 import com.syrmos.core.network.RailwayGovLiveTrackerService
 import com.syrmos.core.network.SyrmosLivePositionsService
 import kotlinx.datetime.Instant
@@ -63,6 +64,9 @@ data class MapUiState(
     val selectedStationDepartures: List<StationDepartureUi> = emptyList(),
     val liveTrains: List<LiveSuburbanTrain> = emptyList(),
     val simulatedTrains: List<SimulatedTrain> = emptyList(),
+    // Live airport express-bus positions (X93/95/96/97) from the OASA telematics
+    // feed. Plotted on the map beside the trains; blanked by the vehicles toggle.
+    val busVehicles: List<AirportBusVehicle> = emptyList(),
     val selectedTrain: LiveSuburbanTrain? = null,
     val selectedSimulatedTrain: SimulatedTrain? = null,
     val showTrains: Boolean = true,
@@ -80,6 +84,7 @@ class MapViewModel(
     private val transitPatternRepository: TransitPatternRepositoryImpl,
     private val liveTrackerService: RailwayGovLiveTrackerService,
     private val livePositionsService: SyrmosLivePositionsService,
+    private val airportBusService: OasaAirportBusService,
     private val stationOffsetsRepo: StationOffsetsRepository,
     private val scheduleSyncRepository: com.syrmos.core.data.sync.ScheduleSyncRepository,
     private val computeActiveTrains: ComputeActiveTrainsFromBandsUseCase,
@@ -96,6 +101,7 @@ class MapViewModel(
         loadMapData()
         observeLiveTrains()
         pollLivePositions()
+        pollAirportBuses()
         runTrainSimulation()
         observeStationDisruptions()
     }
@@ -296,6 +302,16 @@ class MapViewModel(
                     }
                 }
                 delay(1_000)
+            }
+        }
+    }
+
+    private fun pollAirportBuses() {
+        scope.launch {
+            while (isActive) {
+                val vehicles = AirportBusVehicles.parse(airportBusService.fetchAirportBuses())
+                _uiState.update { it.copy(busVehicles = vehicles) }
+                delay(15_000)
             }
         }
     }

--- a/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/AirportBusVehiclesTest.kt
+++ b/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/AirportBusVehiclesTest.kt
@@ -1,0 +1,35 @@
+package com.syrmos.feature.map
+
+import com.syrmos.core.network.OasaAirportBusService.OasaAirportBusResponse
+import com.syrmos.core.network.OasaAirportBusService.OasaBusVehicle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Mirrors iOS LiveAirportBusService.parse and web airportBusVehicles so all three
+ * clients plot the same fleet from /api/oasa-airport-buses.
+ */
+class AirportBusVehiclesTest {
+
+    private fun response(vararg vehicles: OasaBusVehicle) =
+        OasaAirportBusResponse(updatedAt = "", vehicles = vehicles.toList(), airportArrivals = emptyList())
+
+    @Test
+    fun parseKeepsValidVehiclesAndDropsBadRows() {
+        val vehicles = AirportBusVehicles.parse(response(
+            OasaBusVehicle(vehicleId = "61233", lat = 37.90, lng = 23.90, lineId = "X95"),
+            OasaBusVehicle(vehicleId = "0", lat = 0.0, lng = 0.0, lineId = "X95"),   // null island
+            OasaBusVehicle(vehicleId = "y", lat = 37.9, lng = 23.9, lineId = ""),    // no line
+        ))
+        assertEquals(1, vehicles.size)
+        assertEquals("61233", vehicles[0].id)
+        assertEquals("X95", vehicles[0].lineId)
+        assertEquals(37.90, vehicles[0].latitude)
+    }
+
+    @Test
+    fun parseHandlesNullResponse() {
+        assertTrue(AirportBusVehicles.parse(null).isEmpty())
+    }
+}


### PR DESCRIPTION
## Why

Completes the airport map-vehicle parity set (iOS #127, web #126). The KMP `OasaAirportBusService` already fetched the feed, but only its ETAs were surfaced (#125). This plots the `vehicles[]` positions on the Android osmdroid map, beside the live trains.

## How

- **`AirportBusVehicles`** — pure, unit-tested extractor (drops line-less / null-island rows), mirroring iOS `LiveAirportBusService.parse` and web `airportBusVehicles`.
- **`MapViewModel`** — polls `OasaAirportBusService` every 15s into `MapUiState.busVehicles`.
- **`PlatformMapView` (android)** — renders each bus as an orange osmdroid `Marker` at its raw GPS coordinate (no rail-polyline snapping — buses follow roads), reusing the live-vehicle bitmap with the line-id badge. Obeys the same regional zoom declutter (`mapBand >= 2`) and the vehicles toggle (`MapScreen` blanks `busVehicles` when trains are hidden).
- **`AppModule`** — injects `OasaAirportBusService` into `MapViewModel`.

## Proof

- `AirportBusVehiclesTest` mirrors the iOS/web suites.
- **Not built locally** — no JDK on the dev machine (Android is CI-only here). Relying on CI: `./gradlew testDebugUnitTest` compiles `commonMain` + `androidMain` and runs the new test; `:composeApp:compileKotlinWasmJs` and the Android build/lint job cover the rest. I'll confirm the run is green.

## Airport telematics — full matrix now closed

| Capability | iOS | Web | Android |
|---|---|---|---|
| Live bus ETAs (lists) | #123 | #124 | #125 |
| Live buses on the map | #127 | #126 | this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)