### PR TITLE
feat(web): surface the map vehicles hide/show toggle

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -347,8 +347,13 @@
             </button>
         </div>
 
-        <!-- Map chrome: bottom-right zoom + locate -->
+        <!-- Map chrome: bottom-right vehicles + zoom + locate -->
         <div class="map-chrome map-chrome--br">
+            <button id="vehiclesToggle" class="chrome-button" type="button"
+                    data-i18n-aria="hide_vehicles" data-i18n-title="hide_vehicles"
+                    aria-label="Hide vehicles" title="Hide vehicles" aria-pressed="false">
+                <svg class="ic" aria-hidden="true"><use href="#ic-vehicles"/></svg>
+            </button>
             <div class="zoom-stack">
                 <button id="zoomInButton" class="chrome-button" type="button" aria-label="Zoom in">
                     <svg class="ic" aria-hidden="true"><use href="#ic-zoom-in"/></svg>
@@ -403,7 +408,6 @@
 
     <!-- Hidden controls for JS backward compatibility -->
     <button id="liveTrainsButton" type="button" aria-hidden="true" style="display:none"></button>
-    <button id="vehiclesToggle" type="button" aria-hidden="true" style="display:none"></button>
 
     <!-- ===== Station Sheet ===== -->
     <section id="stationSheet" class="station-sheet station-sheet--hidden" aria-live="polite">

--- a/composeApp/src/wasmJsMain/resources/web-map.css
+++ b/composeApp/src/wasmJsMain/resources/web-map.css
@@ -805,6 +805,11 @@ body.dark-mode .chrome-button:hover { background: rgba(27,32,40,1); }
 
 .chrome-button--accent .ic { color: var(--sy-accent); }
 
+/* Vehicles toggle in its pressed (vehicles-hidden) state: tint icon + border
+   accent so it reads as an active filter, mirroring the iOS purple bus toggle. */
+.chrome-button--active { border-color: var(--sy-accent); color: var(--sy-accent); }
+.chrome-button--active .ic { color: var(--sy-accent); }
+
 .zoom-stack {
     display: flex; flex-direction: column;
     border: 1px solid var(--sy-border-subtle);

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -2391,11 +2391,15 @@
     if (vehiclesToggle) {
         vehiclesToggle.addEventListener("click", () => {
             vehiclesHidden = !vehiclesHidden;
-            vehiclesToggle.classList.toggle("control-button--active", vehiclesHidden);
-            vehiclesToggle.setAttribute(
-                "aria-label", vehiclesHidden ? t("show_vehicles") : t("hide_vehicles")
-            );
-            vehiclesToggle.title = vehiclesHidden ? t("show_vehicles") : t("hide_vehicles");
+            vehiclesToggle.classList.toggle("chrome-button--active", vehiclesHidden);
+            vehiclesToggle.setAttribute("aria-pressed", vehiclesHidden ? "true" : "false");
+            // Keep the i18n key on the element so a later language switch relabels
+            // the button for whichever state it is currently in, not the default.
+            const labelKey = vehiclesHidden ? "show_vehicles" : "hide_vehicles";
+            vehiclesToggle.setAttribute("data-i18n-aria", labelKey);
+            vehiclesToggle.setAttribute("data-i18n-title", labelKey);
+            vehiclesToggle.setAttribute("aria-label", t(labelKey));
+            vehiclesToggle.title = t(labelKey);
             window.__syrmosVehiclesHidden = vehiclesHidden;
             if (vehiclesHidden) {
                 liveTrainLayer.clearLayers();

--- a/web-tests/vehicles-toggle.test.js
+++ b/web-tests/vehicles-toggle.test.js
@@ -1,0 +1,84 @@
+'use strict';
+// Static-source guardrails for the map "vehicles" hide/show toggle. The button,
+// its handler, its i18n labels and its ic-vehicles icon all shipped, but nothing
+// ever surfaced it: index.html parked it in the hidden "JS backward compat"
+// block (style="display:none" aria-hidden), so there was no user-facing way to
+// declutter the live vehicles. These tests pin the button as a real map control
+// so a regression that re-hides it (or drops the wiring) re-fails CI. iOS already
+// shows a visible bus toggle on the Map tab; this keeps web at parity.
+//
+// Run: `node --test` from web-tests/, or `node --test web-tests/` from the repo root.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const read = (p) => fs.readFileSync(path.join(RES, p), 'utf8');
+
+// Pull the single <button ... id="vehiclesToggle" ...> tag out of the markup.
+function vehiclesToggleTag(html) {
+  const m = /<button\b[^>]*\bid="vehiclesToggle"[^>]*>/.exec(html);
+  assert.notEqual(m, null, 'index.html: no <button id="vehiclesToggle"> found');
+  return m[0];
+}
+
+test('index.html: vehiclesToggle is a surfaced control, not a hidden compat stub', () => {
+  const tag = vehiclesToggleTag(read('index.html'));
+  // The dead state was: style="display:none" aria-hidden="true" in the
+  // "Hidden controls for JS backward compatibility" block. Guard both.
+  assert.doesNotMatch(tag, /display\s*:\s*none/i, 'vehiclesToggle must not be display:none');
+  assert.doesNotMatch(tag, /aria-hidden\s*=\s*"true"/i, 'vehiclesToggle must not be aria-hidden');
+  // It must render as a real map-chrome control with an icon glyph.
+  assert.match(tag, /class="[^"]*\bchrome-button\b[^"]*"/, 'vehiclesToggle must use the chrome-button style');
+});
+
+test('index.html: vehiclesToggle lives in the map chrome and carries i18n + icon', () => {
+  const html = read('index.html');
+  // It sits inside the bottom-right map chrome region (mirrors zoom/locate).
+  const brStart = html.indexOf('map-chrome--br');
+  assert.notEqual(brStart, -1, 'map-chrome--br region not found');
+  const brBlock = html.slice(brStart, html.indexOf('</main>', brStart));
+  assert.match(brBlock, /id="vehiclesToggle"/, 'vehiclesToggle must sit in the bottom-right map chrome');
+  const tag = vehiclesToggleTag(html);
+  // i18n hooks so the accessible label localizes (en/el/sq/it), and the bus icon.
+  assert.match(tag, /data-i18n-aria="(hide|show)_vehicles"/, 'vehiclesToggle needs a data-i18n-aria label');
+  assert.match(brBlock, /<use href="#ic-vehicles"\/>/, 'vehiclesToggle must render the #ic-vehicles glyph');
+  // The referenced icon symbol must actually exist in the sprite sheet.
+  assert.match(html, /<symbol id="ic-vehicles"/, '#ic-vehicles symbol missing from index.html sprite');
+});
+
+test('index.html: the four vehicles i18n labels exist in web-map.js', () => {
+  const js = read('web-map.js');
+  // en/el/sq/it each define both keys; two languages worth of asserts is enough
+  // to catch a wholesale removal of the label set.
+  for (const key of ['show_vehicles', 'hide_vehicles']) {
+    const count = [...js.matchAll(new RegExp(`\\b${key}\\s*:`, 'g'))].length;
+    assert.ok(count >= 4, `${key} should be defined for all 4 locales, found ${count}`);
+  }
+});
+
+test('web-map.js: the toggle handler is wired and drives the vehicles-hidden flag', () => {
+  const js = read('web-map.js');
+  // Grab the handler body so we assert on the wiring, not a stray mention.
+  const start = js.indexOf('const vehiclesToggle = document.getElementById("vehiclesToggle")');
+  assert.notEqual(start, -1, 'vehiclesToggle handler not found in web-map.js');
+  const block = js.slice(start, start + 1600);
+  assert.match(block, /addEventListener\("click"/, 'vehiclesToggle must have a click handler');
+  assert.match(block, /window\.__syrmosVehiclesHidden\s*=\s*vehiclesHidden/, 'handler must set __syrmosVehiclesHidden');
+  // Active-state class must match the CSS rule that tints the button.
+  assert.match(block, /classList\.toggle\("chrome-button--active"/, 'handler must toggle chrome-button--active');
+  // Hiding clears the live train + airport-bus layers; showing replays them.
+  assert.match(block, /liveTrainLayer\.clearLayers\(\)/, 'hiding must clear live trains');
+  assert.match(block, /liveBusLayer\.clearLayers\(\)/, 'hiding must clear live buses');
+  assert.match(block, /renderAirportBusVehicles\(lastBusVehicles\)/, 'showing must replay airport buses');
+});
+
+test('web-map.css: chrome-button--active tints the icon (visible pressed state)', () => {
+  const css = read('web-map.css');
+  assert.match(css, /\.chrome-button--active\b/, 'no .chrome-button--active rule to show the pressed state');
+  const m = /\.chrome-button--active\s*\{[^}]*\}/.exec(css);
+  assert.notEqual(m, null, '.chrome-button--active rule body not found');
+  assert.match(css, /\.chrome-button--active[^{]*\{[^}]*var\(--sy-accent\)/, 'active state must use the accent color');
+});


### PR DESCRIPTION
## Why

The web map's vehicles hide/show control was fully implemented (click handler, i18n labels `show_vehicles`/`hide_vehicles` in en/el/sq/it, `#ic-vehicles` glyph) but its button was parked in the hidden "JS backward compatibility" block (`display:none`, `aria-hidden`). So there was **no user-facing way to declutter** live trains and airport buses, leaving only the zoom guard. Web was the outlier: iOS shows a visible bus toggle on the Map tab, Android a Train-visibility toggle.

Surfaced during QA of the airport-telematics matrix (the toggle logic obeys `window.__syrmosVehiclesHidden`, which the airport bus layer respects, but nothing exposed it).

## How

- Move `#vehiclesToggle` into the bottom-right map chrome (above the zoom stack) as a real `chrome-button` with the bus glyph.
- Handler toggles `chrome-button--active` (accent icon + border, new CSS) and `aria-pressed`, and keeps `data-i18n-aria`/`data-i18n-title` synced with the current state so a language switch relabels correctly.

## Verification

- In-browser: button renders on-screen (40×40, map chrome); hiding drops live-train markers **27 → 0** and clears the airport `liveBusLayer`; showing replays them; `aria-pressed` and the active class track state.
- Guardrail test `web-tests/vehicles-toggle.test.js` pins the button as surfaced so a regression that re-hides it re-fails CI. Full `node --test` suite green (51).

## Stacking

Stacked on #129 (`feat/web-departures-grouping`) because it touches the same web files (`index.html`, `web-map.js`, `web-map.css`). Merge #129 first. Diff vs #129 is toggle-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)