### PR TITLE
feat(web): make Italian selectable and fill it localization gaps

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -341,6 +341,7 @@
                 <button class="lang-seg language-pill" type="button" data-lang="en" aria-pressed="false">EN</button>
                 <button class="lang-seg language-pill" type="button" data-lang="el" aria-pressed="false">EL</button>
                 <button class="lang-seg language-pill" type="button" data-lang="sq" aria-pressed="false">SQ</button>
+                <button class="lang-seg language-pill" type="button" data-lang="it" aria-pressed="false">IT</button>
             </div>
             <button id="themeToggleMap" class="chrome-button" type="button" aria-label="Toggle dark mode">
                 <svg class="ic" aria-hidden="true"><use href="#ic-theme"/></svg>

--- a/composeApp/src/wasmJsMain/resources/web-ariadne.js
+++ b/composeApp/src/wasmJsMain/resources/web-ariadne.js
@@ -769,11 +769,13 @@
     function help(lang) {
         switch (lang) {
             case 'el':
-                return 'Μπορώ να βρω επόμενες αναχωρήσεις, τελευταίο τρένο, να σχεδιάσω διαδρομή, να δείξω ειδοποιήσεις, να ανοίξω σταθμό στον χάρτη ή να πω τιμές εισιτηρίων. Ρώτα με στα Ελληνικά, Αγγλικά ή Αλβανικά.';
+                return 'Μπορώ να βρω επόμενες αναχωρήσεις, τελευταίο τρένο, να σχεδιάσω διαδρομή, να δείξω ειδοποιήσεις, να ανοίξω σταθμό στον χάρτη ή να πω τιμές εισιτηρίων. Ρώτα με στα Ελληνικά, Αγγλικά, Αλβανικά ή Ιταλικά.';
             case 'sq':
-                return 'Mund të gjej nisjet e ardhshme, trenin e fundit, të planifikoj një udhëtim, të tregoj njoftime, të hap një stacion në hartë ose të tregoj çmimet e biletave. Pyet mua në shqip, anglisht ose greqisht.';
+                return 'Mund të gjej nisjet e ardhshme, trenin e fundit, të planifikoj një udhëtim, të tregoj njoftime, të hap një stacion në hartë ose të tregoj çmimet e biletave. Pyet mua në shqip, anglisht, greqisht ose italisht.';
+            case 'it':
+                return "Posso trovare le prossime partenze, l'ultimo treno della sera, pianificare un viaggio, mostrare gli avvisi di servizio, aprire una stazione sulla mappa o indicarti i prezzi dei biglietti. Chiedimi in italiano, inglese, greco o albanese.";
             default:
-                return 'I can find next departures, the last train tonight, plan a trip, show service alerts, open a station on the map, or tell you ticket prices. Ask in English, Greek, or Albanian.';
+                return 'I can find next departures, the last train tonight, plan a trip, show service alerts, open a station on the map, or tell you ticket prices. Ask in English, Greek, Albanian, or Italian.';
         }
     }
 
@@ -783,6 +785,8 @@
                 return 'Δεν είμαι σίγουρη ότι είναι σχετικό με τα ΜΜΜ Αθήνας. Δοκίμασε "επόμενα τρένα από Σύνταγμα" ή "πώς πάω από Πειραιά στο Αεροδρόμιο".';
             case 'sq':
                 return 'S\'jam e sigurt që kjo lidhet me transportin publik të Athinës. Provo "nisjet e ardhshme nga Syntagma" ose "si shkoj nga Piraeus në aeroport".';
+            case 'it':
+                return "Non sono sicura che riguardi i trasporti di Atene. Prova \"prossimi treni da Syntagma\" o \"come arrivo da Pireo all'aeroporto\".";
             default:
                 return "I'm not sure that's about Athens transit. Try 'next trains from Syntagma' or 'how do I get from Piraeus to the airport'.";
         }
@@ -794,16 +798,19 @@
                 en: 'Which station?',
                 el: 'Ποιος σταθμός;',
                 sq: 'Cili stacion?',
+                it: 'Quale stazione?',
             },
             ORIGIN_STATION: {
                 en: 'From which station?',
                 el: 'Από ποιον σταθμό;',
                 sq: 'Nga cili stacion?',
+                it: 'Da quale stazione?',
             },
             DESTINATION_STATION: {
                 en: 'To which station?',
                 el: 'Προς ποιον σταθμό;',
                 sq: 'Për te cili stacion?',
+                it: 'Verso quale stazione?',
             },
         };
         const row = map[missing] || map.STATION;

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -4758,6 +4758,7 @@
             const table = {
                 el: { "clear": "καθαρός", "partly-cloudy": "μερική συννεφιά", "cloudy": "συννεφιασμένος", "fog": "ομίχλη", "drizzle": "ψιχάλα", "rain": "βροχή", "snow": "χιόνι", "showers": "μπόρες", "thunderstorm": "καταιγίδα", "unknown": "άγνωστη" },
                 sq: { "clear": "kthjellët", "partly-cloudy": "pjesërisht i vranët", "cloudy": "i vranët", "fog": "mjegull", "drizzle": "shi i lehtë", "rain": "shi", "snow": "borë", "showers": "reshje", "thunderstorm": "stuhi", "unknown": "e panjohur" },
+                it: { "clear": "sereno", "partly-cloudy": "parzialmente nuvoloso", "cloudy": "nuvoloso", "fog": "nebbia", "drizzle": "pioviggine", "rain": "pioggia", "snow": "neve", "showers": "rovesci", "thunderstorm": "temporale", "unknown": "sconosciuto" },
                 en: { "clear": "clear", "partly-cloudy": "partly cloudy", "cloudy": "cloudy", "fog": "foggy", "drizzle": "drizzling", "rain": "raining", "snow": "snowing", "showers": "showery", "thunderstorm": "thunderstorm", "unknown": "unknown" },
             };
             return (table[lang] || table.en)[bucket];
@@ -4780,6 +4781,13 @@
                     "Pse ishte macja ulur mbi kompjuter? Për të vëzhguar miun.",
                     "Cila është ëmbëlsira e preferuar e maces? Muslet me çokollatë.",
                     "Si e mbyllin macet një grindje? Me një fshirje dhe një mjau.",
+                ],
+                it: [
+                    "Perché i gatti non giocano a poker nella giungla? Ci sono troppi ghepardi.",
+                    "Come si chiama un mucchio di gattini? Una miao-ntagna.",
+                    "Perché il gatto stava sul computer? Per tenere d'occhio il mouse.",
+                    "Qual è il dolce preferito dei gatti? La mousse al cioccolato.",
+                    "Come finisce una lite tra due gatti? Con un soffio e poi fanno pace.",
                 ],
                 en: [
                     "Why don't cats play poker in the jungle? Too many cheetahs.",
@@ -4889,18 +4897,24 @@
                             ? `Δύσκολο. Για να είσαι στο ${toName} στις ${arriveLabel} έπρεπε να έχεις ξεκινήσει πριν ${-slack} λεπτά.`
                             : currentLang === "sq"
                             ? `E vështirë. Për të qenë në ${toName} në ${arriveLabel} duhej të kishe nisur ${-slack} minuta më parë.`
+                            : currentLang === "it"
+                            ? `Ci siamo per un pelo. Per essere a ${toName} alle ${arriveLabel} avresti dovuto partire ${-slack} minuti fa.`
                             : `Cutting it close. To make ${toName} by ${arriveLabel} you'd have needed to leave ${-slack} min ago.`;
                     } else if (slack < 5) {
                         msg = currentLang === "el"
                             ? `Στριμωγμένα. Πάρε το${linePart} στις ${leaveLabel} από ${fromName} για να προλάβεις στο ${toName} στις ${arriveLabel}.`
                             : currentLang === "sq"
                             ? `Ngushtë. Merr${linePart} në ${leaveLabel} nga ${fromName} për të arritur në ${toName} në ${arriveLabel}.`
+                            : currentLang === "it"
+                            ? `Di poco. Prendi il${linePart} delle ${leaveLabel} da ${fromName} per arrivare a ${toName} alle ${arriveLabel}.`
                             : `Tight. Board the ${leaveLabel}${linePart} at ${fromName} to make ${toName} by ${arriveLabel}.`;
                     } else if (slack > roughDuration + 45) {
                         msg = currentLang === "el"
                             ? `Έχεις άπλα. Το επόμενο${linePart} στις ${leaveLabel} από ${fromName} σε φτάνει στο ${toName} στις ${arriveLabel}.`
                             : currentLang === "sq"
                             ? `Ke kohë. ${linePart ? "Merri" + linePart : "Nis"} në ${leaveLabel} nga ${fromName} dhe do të jesh në ${toName} në ${arriveLabel}.`
+                            : currentLang === "it"
+                            ? `Hai tempo. Il prossimo${linePart} delle ${leaveLabel} da ${fromName} ti porta a ${toName} alle ${arriveLabel}.`
                             : `You have time. Board the ${leaveLabel}${linePart} at ${fromName} to reach ${toName} by ${arriveLabel}.`;
                     } else {
                         msg = leaveByExact
@@ -4908,11 +4922,15 @@
                                 ? `Πάρε το${linePart} στις ${leaveLabel} από ${fromName} και θα είσαι στο ${toName} στις ${arriveLabel}. ${slack} λεπτά περιθώριο.`
                                 : currentLang === "sq"
                                 ? `Merr${linePart} në ${leaveLabel} nga ${fromName} dhe do të jesh në ${toName} në ${arriveLabel}. ${slack} minuta hapësirë.`
+                                : currentLang === "it"
+                                ? `Prendi il${linePart} delle ${leaveLabel} da ${fromName} e sarai a ${toName} alle ${arriveLabel}. ${slack} minuti di margine.`
                                 : `Board the ${leaveLabel}${linePart} at ${fromName} and you'll be at ${toName} by ${arriveLabel}. ${slack} min to spare.`)
                             : (currentLang === "el"
                                 ? `Ξεκίνα από ${fromName} έως ${leaveLabel} και θα είσαι στο ${toName} στις ${arriveLabel}. ${slack} λεπτά περιθώριο.`
                                 : currentLang === "sq"
                                 ? `Nis nga ${fromName} deri në ${leaveLabel} dhe do të jesh në ${toName} në ${arriveLabel}. ${slack} minuta hapësirë.`
+                                : currentLang === "it"
+                                ? `Parti da ${fromName} entro le ${leaveLabel} e sarai a ${toName} alle ${arriveLabel}. ${slack} minuti di margine.`
                                 : `Leave ${fromName} by ${leaveLabel} and you'll be at ${toName} by ${arriveLabel}. ${slack} min to spare.`);
                     }
                     return { text: msg, sourceConf: leaveByExact ? "scheduled" : "estimated" };
@@ -4923,10 +4941,11 @@
                     const lng = anchor ? anchor.longitude : 23.7275;
                     const name = anchor
                         ? (currentLang === "el" ? (anchor.name_el || anchor.nameEl || anchor.name) : anchor.name)
-                        : (currentLang === "el" ? "Αθήνα" : currentLang === "sq" ? "Athina" : "Athens");
+                        : (currentLang === "el" ? "Αθήνα" : currentLang === "sq" ? "Athina" : currentLang === "it" ? "Atene" : "Athens");
                     return {
                         text: currentLang === "el" ? `Αναζήτηση καιρού για ${name}…`
                             : currentLang === "sq" ? `Po kërkoj motin për ${name}…`
+                            : currentLang === "it" ? `Cerco il meteo per ${name}…`
                             : `Fetching weather for ${name}…`,
                         sourceConf: "live",
                         act: async () => {
@@ -4942,12 +4961,15 @@
                                     ? `${name} τώρα: ${temp}°C, ${cond}. Αίσθηση ${feels}°C.`
                                     : currentLang === "sq"
                                     ? `${name} tani: ${temp}°C, ${cond}. Ndihet si ${feels}°C.`
+                                    : currentLang === "it"
+                                    ? `${name} ora: ${temp}°C, ${cond}. Percepiti ${feels}°C.`
                                     : `${name} right now: ${temp}°C, ${cond}. Feels like ${feels}°C.`;
                                 appendMessage(reply, "assistant", "live");
                             } catch (_) {
                                 appendMessage(
                                     currentLang === "el" ? "Δεν έχω δεδομένα καιρού. Δοκίμασε ξανά."
                                     : currentLang === "sq" ? "S'kam të dhëna moti. Provo përsëri."
+                                    : currentLang === "it" ? "Non ho dati meteo. Riprova."
                                     : "I don't have weather data. Try again.",
                                     "assistant"
                                 );
@@ -4993,9 +5015,11 @@
                     const text = acc
                         ? (currentLang === "el" ? `Ο ${nm} είναι προσβάσιμος για ΑμεΑ (ασανσέρ / ισόπεδη πρόσβαση).`
                             : currentLang === "sq" ? `${nm} është i aksesueshëm pa shkallë (ashensor / qasje e sheshtë).`
+                            : currentLang === "it" ? `${nm} è accessibile senza scale (ascensore / accesso a raso).`
                             : `${nm} is step-free accessible (lift / level access).`)
                         : (currentLang === "el" ? `Ο ${nm} δεν είναι σημειωμένος ως προσβάσιμος ΑμεΑ. Ίσως έχει μόνο σκάλες.`
                             : currentLang === "sq" ? `${nm} nuk shënohet si i aksesueshëm pa shkallë. Mund të ketë vetëm shkallë.`
+                            : currentLang === "it" ? `${nm} non risulta accessibile senza scale. Potrebbe avere solo scale.`
                             : `${nm} is not marked step-free. Check for stairs-only access before you go.`);
                     return { text: text, sourceConf: "offline" };
                 }
@@ -5005,6 +5029,7 @@
                         return {
                             text: currentLang === "el" ? "Πες μου πρώτα μια διαδρομή, μετά τη γυρίζω για την επιστροφή."
                                 : currentLang === "sq" ? "Më trego fillimisht një udhëtim, pastaj e kthej për rrugën e kthimit."
+                                : currentLang === "it" ? "Dimmi prima un viaggio, poi lo inverto per il ritorno."
                                 : "Tell me a trip first, then I can flip it for the way back.",
                         };
                     }
@@ -5017,11 +5042,15 @@
                     const nm = stationName(st.id);
                     if (!ids.length) {
                         return { text: currentLang === "el" ? `Δεν έχω γραμμές για ${nm}.`
-                            : currentLang === "sq" ? `Nuk kam linja për ${nm}.` : `I don't have any lines listed for ${nm}.` };
+                            : currentLang === "sq" ? `Nuk kam linja për ${nm}.`
+                            : currentLang === "it" ? `Non ho linee elencate per ${nm}.`
+                            : `I don't have any lines listed for ${nm}.` };
                     }
                     const list = ids.join(", ");
                     return { text: currentLang === "el" ? `Ο ${nm} εξυπηρετείται από: ${list}.`
-                        : currentLang === "sq" ? `${nm} shërbehet nga: ${list}.` : `${nm} is served by: ${list}.`, sourceConf: "offline" };
+                        : currentLang === "sq" ? `${nm} shërbehet nga: ${list}.`
+                        : currentLang === "it" ? `${nm} è servito da: ${list}.`
+                        : `${nm} is served by: ${list}.`, sourceConf: "offline" };
                 }
                 case "stopsBetween": {
                     // The web has no JS stop-counting planner, so delegate to the
@@ -5121,11 +5150,15 @@
                             ? `Κατέβα στον επόμενο σταθμό και πάρε το αντίθετο δρομολόγιο πίσω προς ${nm}.`
                             : currentLang === "sq"
                             ? `Zbrit në stacionin e ardhshëm dhe merr trenin e kundërt drejt ${nm}.`
+                            : currentLang === "it"
+                            ? `Scendi alla prossima fermata e prendi la corsa in senso opposto verso ${nm}.`
                             : `Get off at the next stop and take the reverse service back towards ${nm}.`)
                         : (currentLang === "el"
                             ? "Κατέβα στον επόμενο σταθμό και πάρε το αντίθετο δρομολόγιο."
                             : currentLang === "sq"
                             ? "Zbrit në stacionin e ardhshëm dhe merr trenin e kundërt."
+                            : currentLang === "it"
+                            ? "Scendi alla prossima fermata e prendi la corsa in senso opposto."
                             : "Get off at the next stop and take the reverse service.");
                     return { text, sourceConf: "offline" };
                 }
@@ -5137,11 +5170,15 @@
                             ? `Κατέβα στον επόμενο σταθμό και γύρνα πίσω προς ${tName}.`
                             : currentLang === "sq"
                             ? `Zbrit në stacionin e ardhshëm dhe kthehu drejt ${tName}.`
+                            : currentLang === "it"
+                            ? `Scendi alla prossima fermata e torna indietro verso ${tName}.`
                             : `Get off at the next stop and double back to ${tName}.`)
                         : (currentLang === "el"
                             ? "Κατέβα στον επόμενο σταθμό και πάρε το αντίθετο δρομολόγιο."
                             : currentLang === "sq"
                             ? "Zbrit në stacionin e ardhshëm dhe merr trenin e kundërt."
+                            : currentLang === "it"
+                            ? "Scendi alla prossima fermata e prendi la corsa in senso opposto."
                             : "Get off at the next stop and take the reverse service.");
                     return { text, sourceConf: "offline" };
                 }
@@ -5177,6 +5214,8 @@
                             ? `Ναι. Επόμενο δρομολόγιο από ${fromName} στις ${nextDep.time} (σε ${wait} λεπτά) προς ${toName}.`
                             : currentLang === "sq"
                             ? `Po. Treni i ardhshëm nga ${fromName} në ${nextDep.time} (pas ${wait} minutash) drejt ${toName}.`
+                            : currentLang === "it"
+                            ? `Sì. Prossima corsa da ${fromName} alle ${nextDep.time} (tra ${wait} minuti) verso ${toName}.`
                             : `Yes. Next service from ${fromName} at ${nextDep.time} (${wait} min away) towards ${toName}.`;
                         return { text, sourceConf: "scheduled" };
                     }
@@ -5185,11 +5224,15 @@
                             ? `Δεν βρήκα επόμενο δρομολόγιο από ${fromName} προς ${toName}. Δοκίμασε "δρομολόγια ${fromName}".`
                             : currentLang === "sq"
                             ? `Nuk gjeta nisje të ardhshme nga ${fromName} drejt ${toName}. Provo "nisjet ${fromName}".`
+                            : currentLang === "it"
+                            ? `Non ho trovato una corsa in arrivo da ${fromName} verso ${toName}. Prova "partenze ${fromName}".`
                             : `I couldn't find an upcoming service from ${fromName} to ${toName}. Try "departures ${fromName}".`)
                         : (currentLang === "el"
                             ? `Πες μου από ποιον σταθμό ξεκινάς, για να ελέγξω αν προλαβαίνεις.`
                             : currentLang === "sq"
                             ? `Më thuaj nga cili stacion nisesh, që të kontrolloj nëse e arrin.`
+                            : currentLang === "it"
+                            ? `Dimmi da quale stazione parti, così controllo se ce la fai.`
                             : `Tell me which station you're at so I can check if you can make it.`);
                     return { text, sourceConf: "estimated" };
                 }

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -1036,13 +1036,13 @@
     // suburban, intercity) under clear headers instead of one flat OASA list.
     const FARE_GROUPS = [
         { key: "athens", sections: ["single", "airport", "offers", "passes"],
-          label: { en: "Athens - OASA", el: "Αθηνα - OASA", sq: "Athine - OASA" } },
+          label: { en: "Athens - OASA", el: "Αθηνα - OASA", sq: "Athine - OASA", it: "Atene - OASA" } },
         { key: "thessaloniki", sections: ["thessaloniki"],
-          label: { en: "Thessaloniki - OSETH", el: "Θεσσαλονικη - OSETH", sq: "Selanik - OSETH" } },
+          label: { en: "Thessaloniki - OSETH", el: "Θεσσαλονικη - OSETH", sq: "Selanik - OSETH", it: "Salonicco - OSETH" } },
         { key: "patras", sections: ["patras"],
-          label: { en: "Patras suburban", el: "Προαστιακός Πάτρας", sq: "Suburban Patra" } },
+          label: { en: "Patras suburban", el: "Προαστιακός Πάτρας", sq: "Suburban Patra", it: "Suburbano di Patrasso" } },
         { key: "intercity", sections: ["intercity"],
-          label: { en: "Intercity / regional", el: "Υπεραστικά / περιφερειακά", sq: "Ndërqytetëse" } },
+          label: { en: "Intercity / regional", el: "Υπεραστικά / περιφερειακά", sq: "Ndërqytetëse", it: "Intercity / regionale" } },
     ];
 
     function renderFaresPanel(payload) {
@@ -4195,8 +4195,9 @@
         const lang = currentLang;
         const title = lang === "el" ? "Τι νέο υπάρχει στο Syrmos"
             : lang === "sq" ? "Çfarë ka të re në Syrmos"
+            : lang === "it" ? "Novità in Syrmos"
             : "What's new in Syrmos";
-        const gotIt = lang === "el" ? "Εντάξει" : lang === "sq" ? "Në rregull" : "Got it";
+        const gotIt = lang === "el" ? "Εντάξει" : lang === "sq" ? "Në rregull" : lang === "it" ? "Ho capito" : "Got it";
         const bullets = lang === "el" ? [
             "Hellenic Rail Atlas: νεος σχεδιασμος με απαντησεις στη μια ματια.",
             "Η Αριαδνη τωρα συνδεεται με σταθμους και γραμμες: πατα και πηγαινε κατευθειαν.",
@@ -4209,6 +4210,12 @@
             "Shfleto te gjitha stacionet me harta dhe etiketa linjash.",
             "Kartela Eksploro e ridizajnuar me karta destinacionesh dhe stacione te fundit.",
             "Gjeolokalizim ne web per stacionet me te aferta.",
+        ] : lang === "it" ? [
+            "Hellenic Rail Atlas: un nuovo design chiaro con risposte a colpo d'occhio.",
+            "Ariadne ora collega stazioni e linee: tocca una risposta per andarci subito.",
+            "Sfoglia tutte le stazioni con mappe interattive ed etichette delle linee.",
+            "Scheda Esplora ridisegnata con schede destinazione e stazioni recenti.",
+            "Geolocalizzazione web per le stazioni vicine.",
         ] : [
             "Hellenic Rail Atlas: a fresh light-first design built around one-glance answers.",
             "Ariadne now links to stations and lines: tap any answer to jump straight there.",
@@ -4306,21 +4313,25 @@
             banner.className = "severe-weather-banner";
             const lang = currentLang;
             const title = code === 95 || code === 96 || code === 99
-                ? (lang === "el" ? "Καταιγίδα σε εξέλιξη" : lang === "sq" ? "Stuhi në zhvillim" : "Storm in progress")
-                : (lang === "el" ? "Έντονη κακοκαιρία" : lang === "sq" ? "Mot i keq" : "Severe weather");
+                ? (lang === "el" ? "Καταιγίδα σε εξέλιξη" : lang === "sq" ? "Stuhi në zhvillim" : lang === "it" ? "Temporale in corso" : "Storm in progress")
+                : (lang === "el" ? "Έντονη κακοκαιρία" : lang === "sq" ? "Mot i keq" : lang === "it" ? "Maltempo intenso" : "Severe weather");
             const body = lang === "el"
                 ? "Οι υπόγειες γραμμές μετρό είναι η πιο ασφαλής επιλογή. Πρόσεχε στη μετακίνηση."
                 : lang === "sq"
                 ? "Metroja nëntokësore është zgjidhja më e sigurt. Ki kujdes gjatë udhëtimit."
+                : lang === "it"
+                ? "Le linee metro sotterranee sono l'opzione più sicura. Fai attenzione negli spostamenti."
                 : "Underground metro lines are the safest option. Take care on your journey.";
             const numbersHeader = lang === "el" ? "ΤΗΛΕΦΩΝΑ ΕΚΤΑΚΤΗΣ ΑΝΑΓΚΗΣ"
                 : lang === "sq" ? "NUMRAT E EMERGJENCËS"
+                : lang === "it" ? "NUMERI DI EMERGENZA"
                 : "EMERGENCY NUMBERS";
             const num112 = lang === "el" ? "Ευρωπαϊκή γραμμή έκτακτης ανάγκης"
                 : lang === "sq" ? "Numri europian i emergjencës"
+                : lang === "it" ? "Numero unico di emergenza europeo"
                 : "European emergency line";
-            const numFire = lang === "el" ? "Πυροσβεστική" : lang === "sq" ? "Zjarrfikësit" : "Fire service";
-            const numOASA = lang === "el" ? "Πληροφορίες OASA" : lang === "sq" ? "Informacione OASA" : "OASA transit info";
+            const numFire = lang === "el" ? "Πυροσβεστική" : lang === "sq" ? "Zjarrfikësit" : lang === "it" ? "Vigili del fuoco" : "Fire service";
+            const numOASA = lang === "el" ? "Πληροφορίες OASA" : lang === "sq" ? "Informacione OASA" : lang === "it" ? "Info trasporti OASA" : "OASA transit info";
             banner.innerHTML = `
                 <div class="severe-weather-banner__head">
                     <span class="severe-weather-banner__cloud">☁️</span>
@@ -4338,6 +4349,7 @@
                     <div class="severe-weather-banner__hint">${
                         lang === "el" ? "Πατήστε έναν αριθμό για κλήση."
                         : lang === "sq" ? "Prek një numër për të thirrur."
+                        : lang === "it" ? "Tocca un numero per chiamare."
                         : "Tap a number to call."
                     }</div>
                 </div>

--- a/web-tests/italian-completeness.test.js
+++ b/web-tests/italian-completeness.test.js
@@ -49,3 +49,16 @@ test('web-map.js: notification + fare strings have Italian branches', () => {
   assert.match(js, /it: "Atene - OASA"/, 'fare group headers missing it');
   assert.match(js, /it: "Intercity \/ regionale"/, 'fare group headers missing it');
 });
+
+test('web-map.js: every sq language branch has an it sibling (parity guardrail)', () => {
+  const js = read('web-map.js');
+  const count = (re) => (js.match(re) || []).length;
+  // The offline Ariadne respond() block and the notification banners branch on
+  // currentLang/lang; Italian must not silently fall back to English again.
+  assert.equal(count(/currentLang === "it"/g), count(/currentLang === "sq"/g),
+    'currentLang it/sq branch counts diverged - an it branch is missing');
+  assert.equal(count(/lang === "it"/g), count(/lang === "sq"/g),
+    'lang it/sq branch counts diverged - an it branch is missing');
+  // weather + easter-egg language tables gained an it entry
+  assert.match(js, /"clear": "sereno"/, 'weatherCodeLabel missing the it table');
+});

--- a/web-tests/italian-completeness.test.js
+++ b/web-tests/italian-completeness.test.js
@@ -1,0 +1,51 @@
+'use strict';
+// Guardrails for Italian (it) localization on the web. The static UI dictionary
+// and auto-detection were already complete, but Italian was NOT selectable (no
+// pill) and several dynamic assistant/notification strings fell back to English.
+// These static-source checks pin the fixes so a regression re-fails CI. They are
+// deliberately source-level: web-ariadne.js / web-map.js are window-IIFEs, not
+// requireable modules.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const read = (p) => fs.readFileSync(path.join(RES, p), 'utf8');
+
+test('index.html: the language switcher offers an Italian pill', () => {
+  const html = read('index.html');
+  assert.match(html, /<button[^>]*data-lang="it"[^>]*>\s*IT\s*<\/button>/,
+    'a data-lang="it" IT button must exist in #languagePicker so Italian is selectable');
+  // and all four advertised languages are present
+  for (const lang of ['en', 'el', 'sq', 'it']) {
+    assert.match(html, new RegExp(`data-lang="${lang}"`), `missing language pill: ${lang}`);
+  }
+});
+
+test('web-ariadne.js: help / outOfScope / clarify all handle it', () => {
+  const js = read('web-ariadne.js');
+  // help() and outOfScope() gained an it case
+  assert.ok(/case 'it':/.test(js), "web-ariadne.js: no `case 'it':` in help/outOfScope");
+  // the English help fallback must now name Italian too (it used to omit it)
+  assert.match(js, /English, Greek, Albanian, or Italian/,
+    'the English help blurb should advertise Italian');
+  // every clarify map entry carries an it string
+  const clarifyBlock = js.slice(js.indexOf('function clarify'), js.indexOf('function clarify') + 700);
+  const itCount = (clarifyBlock.match(/\bit:\s*'/g) || []).length;
+  assert.equal(itCount, 3, `clarify map should have 3 it entries, found ${itCount}`);
+});
+
+test('web-map.js: notification + fare strings have Italian branches', () => {
+  const js = read('web-map.js');
+  // what's-new modal
+  assert.match(js, /lang === "it" \? "Novità in Syrmos"/, "what's-new title missing it");
+  assert.match(js, /Sfoglia tutte le stazioni/, "what's-new bullets missing it");
+  // severe-weather banner
+  assert.match(js, /lang === "it" \? "Temporale in corso"/, 'severe-weather title missing it');
+  assert.match(js, /NUMERI DI EMERGENZA/, 'severe-weather numbers header missing it');
+  assert.match(js, /Tocca un numero per chiamare\./, 'severe-weather tap hint missing it');
+  // fare group headers
+  assert.match(js, /it: "Atene - OASA"/, 'fare group headers missing it');
+  assert.match(js, /it: "Intercity \/ regionale"/, 'fare group headers missing it');
+});


### PR DESCRIPTION
## Why

Italian (`it`) had a complete static-UI dictionary and browser-locale auto-detection, but **users could not select it** (the switcher only offered EN/EL/SQ pills, despite the marketing advertising Italian), and every *dynamic* assistant/notification string silently fell back to English.

## How (full Italian completeness)

- **index.html:** add the **IT language pill** — the critical fix that makes Italian selectable (existing highlight + click wiring pick it up automatically).
- **web-ariadne.js:** `it` branch in `help()` / `outOfScope()` / `clarify()`; the EN/EL/SQ help blurbs now name Italian too.
- **web-map.js:** `it` branches in the what's-new modal, severe-weather emergency banner, `FARE_GROUPS` headers, and the **entire offline Ariadne `respond()` block** (planByArrival all tiers, weatherAt + `weatherCodeLabel`, stationAccessibility, reverseTrip, whichLines, wrongTrain, missedStop, canIStillMakeIt, catJoke).

## Verification

- `web-tests/italian-completeness.test.js`: pins the IT pill, the `it` branches, and a **parity guardrail** (`currentLang`/`lang` it-vs-sq branch counts must match) so a future sq-without-it regression re-fails CI.
- `node --check` clean on both files; full `node --test` suite green (55).
- In-browser: switching to IT sets the UI to Italian ("Informazioni utili") and `SyrmosAriadne.help('it')`/`clarify('it')` return Italian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)