### PR TITLE
fix(web): localize the region filter chips (were English for el/sq/it)

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -133,6 +133,10 @@
         },
         el: {
             brand_subtitle: "Χάρτης σιδηροδρόμων Αθήνας",
+            athens: "Αθήνα",
+            thessaloniki: "Θεσσαλονίκη",
+            national: "Πανελλαδικά",
+            patras: "Πάτρα",
             search_placeholder: "Αναζήτηση σταθμού (Σύνταγμα, Πειραιάς, Αεροδρόμιο)",
             search_aria: "Αναζήτηση σταθμού",
             locate_me: "Η τοποθεσία μου",
@@ -229,6 +233,10 @@
         },
         sq: {
             brand_subtitle: "Harta e hekurudhave të Athinës",
+            athens: "Athina",
+            thessaloniki: "Selanik",
+            national: "Kombëtare",
+            patras: "Patra",
             search_placeholder: "Kërko stacion (Syntagma, Piraeus, Aeroporti)",
             search_aria: "Kërko stacion",
             locate_me: "Vendndodhja ime",
@@ -325,6 +333,10 @@
         },
         it: {
             brand_subtitle: "Mappa ferroviaria di Atene",
+            athens: "Atene",
+            thessaloniki: "Salonicco",
+            national: "Nazionale",
+            patras: "Patrasso",
             search_placeholder: "Cerca stazione (Syntagma, Pireo, Aeroporto)",
             search_aria: "Cerca stazione",
             locate_me: "La mia posizione",

--- a/web-tests/region-chip-i18n.test.js
+++ b/web-tests/region-chip-i18n.test.js
@@ -1,0 +1,24 @@
+'use strict';
+// The region filter chips (Athens / Thessaloniki / National / Patras) render
+// from I18N keys. Those keys used to live only in the `en` block, so el, sq and
+// it all fell back to English place names. This guardrail pins each key in all
+// four language blocks so a chip cannot silently revert to English again.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const js = fs.readFileSync(path.join(RES, 'web-map.js'), 'utf8');
+
+test('region chip keys are localized in every language block', () => {
+  // I18N has en/el/sq/it blocks, so each region key must appear exactly 4 times.
+  for (const key of ['athens', 'thessaloniki', 'national', 'patras']) {
+    const count = (js.match(new RegExp('\\b' + key + ':', 'g')) || []).length;
+    assert.equal(count, 4, `region key "${key}" should exist in all 4 language blocks, found ${count}`);
+  }
+  // spot-check the localized place names actually landed
+  assert.match(js, /athens: "Αθήνα"/, 'Greek Athens missing');
+  assert.match(js, /thessaloniki: "Salonicco"/, 'Italian Thessaloniki missing');
+  assert.match(js, /patras: "Patra"/, 'Albanian Patras missing');
+});


### PR DESCRIPTION
## Why

The region filter chips (**Athens / Thessaloniki / National / Patras**) render from I18N keys that existed only in the `en` block, so `el`, `sq`, and `it` all fell back to English place names — the odd surface out while everything else localized. Surfaced during the Italian-completeness audit (#133), but it affects Greek and Albanian too.

## How

Add the four keys to the el/sq/it I18N blocks with proper localized names:
- **el:** Αθήνα / Θεσσαλονίκη / Πανελλαδικά / Πάτρα
- **sq:** Athina / Selanik / Kombëtare / Patra
- **it:** Atene / Salonicco / Nazionale / Patrasso

## Verification

- `web-tests/region-chip-i18n.test.js` pins each key in all four language blocks (count == 4) so a chip can't silently revert to English.
- In-browser: switching language flips the chips to Αθήνα.../Atene... (verified el + it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)