### PR TITLE
feat(web): per-row confidence chips in the live-trains panel

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.css
+++ b/composeApp/src/wasmJsMain/resources/web-map.css
@@ -604,6 +604,11 @@ body.dark-mode .nav-item--active {
 .panel-item--tappable:active { background: var(--sy-background-subtle); transform: scale(0.99); }
 .panel-item--tappable:focus-visible { outline: 2px solid var(--sy-accent, #2563eb); outline-offset: 1px; }
 .panel-item__body { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+/* Per-row confidence chip in the live-trains panel, mirroring the grouped
+   departure cards. A GPS-only (non-boardable) row is muted so it never reads
+   as a normal live service. */
+.panel-item__body .src-chip { align-self: flex-start; margin-top: 4px; }
+.panel-item--muted { opacity: 0.62; }
 .panel-item--tappable .panel-item__title { flex: none; }
 .panel-item--tappable .panel-item__meta {
     margin-left: 0; flex: none;

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -86,6 +86,7 @@
             train: "Train",
             route: "Route",
             live: "Live",
+            position_only: "Position only",
             updated_ago: "updated {t} ago",
             live_unknown_age: "Live, age unknown",
             estimated: "Estimated",
@@ -186,6 +187,7 @@
             train: "Συρμός",
             route: "Διαδρομή",
             live: "Ζωντανά",
+            position_only: "Μόνο θέση",
             updated_ago: "ενημέρωση πριν {t}",
             live_unknown_age: "Ζωντανά, άγνωστη ώρα",
             estimated: "Εκτίμηση",
@@ -286,6 +288,7 @@
             train: "Tren",
             route: "Itinerari",
             live: "Drejtpërdrejt",
+            position_only: "Vetëm pozicion",
             updated_ago: "përditësuar {t} më parë",
             live_unknown_age: "Drejtpërdrejt, kohë e panjohur",
             estimated: "Vlerësim",
@@ -386,6 +389,7 @@
             train: "Treno",
             route: "Percorso",
             live: "In tempo reale",
+            position_only: "Solo posizione",
             updated_ago: "aggiornato {t} fa",
             live_unknown_age: "In tempo reale, età sconosciuta",
             estimated: "Stimato",
@@ -2738,12 +2742,23 @@
                 const line = lineMap.get(train.lineId);
                 const title = `${line ? line.name : train.lineId} ${train.trainNumber}`;
                 const meta = `${train.origin || t("live")} ${toWord} ${train.destination || t("unknown")}${train.nextStation ? `, ${t("next")} ${train.nextStation}` : ""}`;
+                // Per-row confidence chip, matching the grouped departure cards: a
+                // boardable telematics train reads LIVE, while a GPS-only position
+                // (inService false / status "position_only") reads as the muted
+                // "Position only" — the panel used to hide that distinction that
+                // the map already draws in grey, so a non-boardable dot looked like
+                // a normal live train in the list.
+                const notInService = train.inService === false || train.status === "position_only";
+                const chipMod = notInService ? "offline" : "live";
+                const chipLabel = notInService ? t("position_only") : t("live");
+                const chip = `<span class="src-chip src-chip--${chipMod}"><span class="src-chip__dot"></span>${escapeHtml(chipLabel)}</span>`;
                 // Tappable row -> shared vehicle sheet (same as tapping on the map).
                 return `
-                    <div class="panel-item panel-item--tappable" data-live-suburban data-train-id="${train.id}" data-train-kind="live" role="button" tabindex="0" aria-label="${escapeHtml(`${title}. ${meta}. ${t("open_details")}`)}">
+                    <div class="panel-item panel-item--tappable${notInService ? " panel-item--muted" : ""}" data-live-suburban data-train-id="${train.id}" data-train-kind="live" role="button" tabindex="0" aria-label="${escapeHtml(`${title}. ${meta}. ${chipLabel}. ${t("open_details")}`)}">
                         <div class="panel-item__body">
                             <div class="panel-item__title">🚆 ${escapeHtml(title)}</div>
                             <div class="panel-item__meta">${escapeHtml(meta)}</div>
+                            ${chip}
                         </div>
                         <span class="panel-item__chevron" aria-hidden="true">›</span>
                     </div>
@@ -3950,19 +3965,27 @@
         lastSimPanelTrains = display;
 
         const panelHtml =
-            // These positions are schedule projections (simulateAllTrains), not
-            // observed GPS, so the count row carries an Estimated provenance chip.
-            // Never implies a live fix; the per-train sheet already explains this.
-            `<div class="panel-item panel-item--live-status"><div class="panel-item__count">${t("trains_active", { n: trains.length })}</div><span class="src-chip src-chip--estimated"><span class="src-chip__dot"></span>${t("estimated")}</span></div>` +
+            // Just the active-count summary now; each projected row below carries
+            // its own Estimated chip, so a provenance chip here too would only
+            // repeat it (the same reason the grouped departure cards show one
+            // chip per row, not a redundant section header).
+            `<div class="panel-item panel-item--live-status"><div class="panel-item__count">${t("trains_active", { n: trains.length })}</div></div>` +
             display.map((train) => {
                 const icon = train.isAirport ? "✈" : train.line.type === "tram" ? "🚊" : "🚇";
                 const title = `${train.line.name} → ${train.destination}`;
                 const meta = `${t("near")} ${train.fromStation} · ${t("next")}: ${train.toStation}`;
+                // Per-row confidence chip, matching the grouped departure cards and
+                // the live-telematics rows below. These positions are schedule
+                // projections (simulateAllTrains), never observed GPS, so each row
+                // reads Estimated, so a rider never mistakes a projected metro dot
+                // for a tracked one.
+                const chip = `<span class="src-chip src-chip--estimated"><span class="src-chip__dot"></span>${t("estimated")}</span>`;
                 return `
-                    <div class="panel-item panel-item--tappable" data-train-id="${train.id}" data-train-kind="simulated" role="button" tabindex="0" aria-label="${escapeHtml(`${title}. ${meta}. ${t("open_details")}`)}">
+                    <div class="panel-item panel-item--tappable" data-train-id="${train.id}" data-train-kind="simulated" role="button" tabindex="0" aria-label="${escapeHtml(`${title}. ${meta}. ${t("estimated")}. ${t("open_details")}`)}">
                         <div class="panel-item__body">
                             <div class="panel-item__title">${icon} ${escapeHtml(title)}</div>
                             <div class="panel-item__meta">${escapeHtml(meta)}</div>
+                            ${chip}
                         </div>
                         <span class="panel-item__chevron" aria-hidden="true">›</span>
                     </div>

--- a/web-tests/panel-confidence.test.js
+++ b/web-tests/panel-confidence.test.js
@@ -1,0 +1,47 @@
+'use strict';
+// The live-trains panel rows now carry a per-row confidence chip, mirroring the
+// grouped departure cards: a boardable telematics train reads LIVE, a GPS-only
+// position reads as the muted "Position only". Static-source guardrails (web-map
+// is a window-IIFE, not requireable).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const js = fs.readFileSync(path.join(RES, 'web-map.js'), 'utf8');
+const css = fs.readFileSync(path.join(RES, 'web-map.css'), 'utf8');
+
+test('position_only label is localized in all four language blocks', () => {
+  const count = (js.match(/\bposition_only:/g) || []).length;
+  assert.equal(count, 4, `position_only should exist in all 4 language blocks, found ${count}`);
+  assert.match(js, /position_only: "Solo posizione"/, 'Italian position_only missing');
+  assert.match(js, /position_only: "Μόνο θέση"/, 'Greek position_only missing');
+});
+
+test('live-trains rows render a per-row confidence chip', () => {
+  // the renderLiveTrains row builder classifies each train and emits a src-chip
+  assert.match(js, /const notInService = train\.inService === false \|\| train\.status === "position_only";/,
+    'per-train confidence classification missing');
+  assert.match(js, /const chipMod = notInService \? "offline" : "live";/, 'chip mod selection missing');
+  assert.match(js, /const chip = `<span class="src-chip src-chip--\$\{chipMod\}">/, 'per-row src-chip missing');
+  assert.match(js, /panel-item--muted/, 'muted class for non-boardable rows missing');
+});
+
+test('simulated (projected) train rows carry a per-row Estimated chip', () => {
+  // renderSimulatedTrainsInPanel: each projected metro/tram/airport row gets an
+  // estimated chip, and the section-header provenance chip was dropped so it is
+  // not repeated.
+  const fn = js.slice(js.indexOf('function renderSimulatedTrainsInPanel'),
+                       js.indexOf('function renderSimulatedTrainsInPanel') + 2800);
+  assert.match(fn, /src-chip--estimated"><span class="src-chip__dot"><\/span>\$\{t\("estimated"\)\}/,
+    'per-row estimated chip missing on simulated rows');
+  // the header count row closes straight into the wrapper: no duplicate chip
+  assert.match(fn, /trains_active", \{ n: trains\.length \}\)\}<\/div><\/div>`/,
+    'the simulated section header should no longer duplicate a provenance chip');
+});
+
+test('css: panel chip spacing and muted-row styling exist', () => {
+  assert.match(css, /\.panel-item__body \.src-chip\s*\{[^}]*margin-top/, 'panel chip spacing rule missing');
+  assert.match(css, /\.panel-item--muted\s*\{[^}]*opacity/, 'muted-row opacity rule missing');
+});


### PR DESCRIPTION
## Why

The left panel's live-trains list mixes two provenance classes with **no per-row signal**: schedule-**projected** metro/tram positions (`simulateAllTrains`) and **real** suburban GPS telematics. It only carried section-header chips, so a projected metro dot read the same as a tracked train, and a GPS-only (non-boardable) vehicle looked like a normal live service — even though the map already greys those. Applies the grouped departure-card confidence treatment here for live-vs-scheduled clarity.

## How

Each row now carries its own `src-chip`, mirroring the grouped cards:
- **simulated** metro/tram/airport rows → **Estimated** (and the now-redundant section-header provenance chip was dropped so it isn't repeated — same principle as the grouped cards),
- **suburban telematics** rows → **Live**, or a muted **"Position only"** for `inService=false` / `status: 'position_only'` vehicles (with a `panel-item--muted` row).

New i18n key `position_only` in all four languages (en/el/sq/it).

## Verification

- `web-tests/panel-confidence.test.js` pins the per-row chips, the position_only label in all 4 blocks, and the CSS.
- In-browser (fresh origin to bypass JS cache): the 10 projected rows render styled **Estimated** chips with the dot; full `node --test` suite green (60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)