### PR TITLE
fix(web): relabel the trains panel on language change

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -1135,6 +1135,18 @@
         }
     });
 
+    // The live-trains + simulated-trains panel renders on the simulation timer,
+    // not on language change, so a flip left its rows (titles, meta, and the
+    // per-row confidence chips) in the old language until the next tick. Re-render
+    // both from the cached batches so the panel relabels immediately, mirroring
+    // the fares panel above. Guarded so a flip before any batch arrives is a
+    // no-op. (renderSimulatedTrainsInPanel overwrites #liveTrainList, then
+    // renderLiveTrains re-appends the suburban rows, the same order as a poll.)
+    onLanguageChange(() => {
+        if (lastSimulatedTrains && lastSimulatedTrains.length) renderSimulatedTrainsInPanel(lastSimulatedTrains);
+        if (lastLiveTrains && lastLiveTrains.length) renderLiveTrains(lastLiveTrains);
+    });
+
     function escapeHtml(s) {
         return String(s).replace(/[&<>"']/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
     }

--- a/web-tests/panel-lang-refresh.test.js
+++ b/web-tests/panel-lang-refresh.test.js
@@ -1,0 +1,19 @@
+'use strict';
+// The live-trains / simulated-trains panel renders on the simulation timer, not
+// on language change, so a language flip left its rows in the old language until
+// the next tick. A dedicated onLanguageChange handler now re-renders both panels
+// from their cached batches. Static-source guardrail (web-map is a window-IIFE).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const js = fs.readFileSync(path.join(RES, 'web-map.js'), 'utf8');
+
+test('a language-change handler re-renders the trains panel', () => {
+  // an onLanguageChange callback that re-runs both panel renderers off the
+  // cached batches
+  assert.match(js, /onLanguageChange\(\(\) => \{\s*if \(lastSimulatedTrains && lastSimulatedTrains\.length\) renderSimulatedTrainsInPanel\(lastSimulatedTrains\);\s*if \(lastLiveTrains && lastLiveTrains\.length\) renderLiveTrains\(lastLiveTrains\);\s*\}\);/,
+    'missing onLanguageChange handler that re-renders the simulated + live trains panel');
+});


### PR DESCRIPTION
## Why

The live-trains + simulated-trains panel renders on the simulation timer, **not** on language change, so a language flip left its rows (titles, meta, and the per-row confidence chips added in #135) in the old language until the next tick, seconds later, while every other surface flipped instantly. Discovered while runtime-verifying #135.

## How

Add an `onLanguageChange` handler that re-renders both panels from their cached batches (`lastSimulatedTrains` / `lastLiveTrains`), mirroring the fares panel's existing handler. Guarded so a flip before any batch arrives is a no-op.

## Verification

- `web-tests/panel-lang-refresh.test.js` pins the handler.
- In-browser (fresh origin): switching to Italian relabels the panel **immediately** (chip `Estimated` → `Stimato`, meta `Near X · next: Y` → `Vicino a Y · prossimo: Z`) with no timer wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)