### PR TITLE
feat(ios): group the airport-hub services list by line

### DIFF
--- a/iosApp/iosApp/Features/Timetables/AirportServiceRows.swift
+++ b/iosApp/iosApp/Features/Timetables/AirportServiceRows.swift
@@ -8,7 +8,10 @@ struct AirportListRow: Identifiable {
     let route: String
     let destination: String
     let detail: String
-    let time: String
+    /// The next few departure times for this (line, destination). The first is
+    /// the dominant countdown; the rest render as a "Then …" tail, so one grouped
+    /// row replaces the old stack of same-line rows.
+    let times: [String]
     let color: Color
     var stationId: String? = nil
     var confidence: SourceConfidence = .scheduled
@@ -45,10 +48,17 @@ enum AirportServiceRows {
     ) -> [AirportListRow] {
         var output: [AirportListRow] = []
 
-        // Metro (M3 / M3_AIR) -> Syntagma. De-dup by time, cap at 3.
+        // Metro (M3 / M3_AIR) -> Syntagma. De-dup by time, next 3, collapsed into
+        // ONE grouped row (was three identical "M3 · Syntagma · Scheduled" rows
+        // differing only by the clock time). Mirrors the grouped station board.
+        var metroTimes: [String] = []
         var seenMetro = Set<String>()
         for dep in metroDepartures where dep.lineId == "M3" || dep.lineId == "M3_AIR" {
             guard seenMetro.insert(dep.time).inserted else { continue }
+            metroTimes.append(dep.time)
+            if metroTimes.count >= 3 { break }
+        }
+        if !metroTimes.isEmpty {
             output.append(AirportListRow(
                 route: "M3",
                 destination: "Syntagma",
@@ -57,35 +67,42 @@ enum AirportServiceRows {
                           "Προγραμματισμένη αναχώρηση μετρό",
                           "Nisje e programuar e metrosë",
                           "Partenza metro programmata"),
-                time: dep.time,
+                times: metroTimes,
                 color: Color.metroBlue,
-                stationId: airportSideStationId(forRoute: dep.lineId),
+                stationId: airportSideStationId(forRoute: "M3"),
                 confidence: .scheduled
             ))
-            if output.count >= 3 { break }
         }
 
-        // Suburban (A1 / A2) -> Piraeus. De-dup by line+time, cap at 2, keep the
-        // real line badge instead of relabeling everything A1.
+        // Suburban (A1 / A2) -> Piraeus. Group by the REAL line (never relabel to
+        // A1), de-dup by time, next 2 each -> one grouped row per line.
+        var suburbanTimes: [String: [String]] = [:]
+        var suburbanOrder: [String] = []
         var seenSuburban = Set<String>()
-        var suburbanCount = 0
         for dep in metroDepartures where dep.lineId == "A1" || dep.lineId == "A2" {
             guard seenSuburban.insert(dep.lineId + dep.time).inserted else { continue }
+            if suburbanTimes[dep.lineId] == nil {
+                suburbanTimes[dep.lineId] = []
+                suburbanOrder.append(dep.lineId)
+            }
+            if suburbanTimes[dep.lineId]!.count < 2 {
+                suburbanTimes[dep.lineId]!.append(dep.time)
+            }
+        }
+        for line in suburbanOrder {
             output.append(AirportListRow(
-                route: dep.lineId,
+                route: line,
                 destination: t(language, "Piraeus", "Πειραιάς", "Pireus", "Pireo"),
                 detail: t(language,
                           "Scheduled suburban departure",
                           "Προγραμματισμένη αναχώρηση προαστιακού",
                           "Nisje e programuar e trenit periferik",
                           "Partenza suburbano programmata"),
-                time: dep.time,
+                times: suburbanTimes[line] ?? [],
                 color: SyrmosTokens.suburban,
-                stationId: airportSideStationId(forRoute: dep.lineId),
+                stationId: airportSideStationId(forRoute: line),
                 confidence: .scheduled
             ))
-            suburbanCount += 1
-            if suburbanCount >= 2 { break }
         }
 
         // Express buses. Live ETA when the Pi is tracking one, else a neutral 24/7.
@@ -99,7 +116,7 @@ enum AirportServiceRows {
                               "Ζωντανή άφιξη στη στάση του αεροδρομίου",
                               "Mbërritje e drejtpërdrejtë në stacionin e aeroportit",
                               "Arrivo in tempo reale alla fermata dell'aeroporto"),
-                    time: etaLabel(minutes: mins, language: language),
+                    times: [etaLabel(minutes: mins, language: language)],
                     color: SyrmosTokens.warning,
                     stationId: nil,
                     confidence: .live
@@ -113,7 +130,7 @@ enum AirportServiceRows {
                               "24ωρο λεωφορείο express",
                               "Autobus express 24 orë",
                               "Bus express 24 ore"),
-                    time: "24/7",
+                    times: ["24/7"],
                     color: SyrmosTokens.warning,
                     stationId: nil,
                     confidence: .operatorLink

--- a/iosApp/iosApp/Features/Timetables/TimetablesView.swift
+++ b/iosApp/iosApp/Features/Timetables/TimetablesView.swift
@@ -994,9 +994,18 @@ private struct AirportDepartureList: View {
                 } else {
                     Text(row.detail).font(.caption).foregroundStyle(.secondary)
                 }
+                // Grouped tail: the next departures after the soonest, so one card
+                // replaces the old stack of same-line rows (matches the featured
+                // tile's "Then …" pattern above).
+                if row.times.count > 1 {
+                    Text(airportText(language, "Then", "Έπειτα", "Pastaj", "Poi") + " " + row.times.dropFirst().joined(separator: " · "))
+                        .font(.caption2)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer()
-            Text(row.time).font(.headline).monospacedDigit().foregroundStyle(row.color)
+            Text(row.times.first ?? "-").font(.headline).monospacedDigit().foregroundStyle(row.color)
             // A chevron signals the row opens the station's full departures.
             if navigable {
                 Image(systemName: "chevron.right")

--- a/iosApp/iosAppTests/AirportServiceTests.swift
+++ b/iosApp/iosAppTests/AirportServiceTests.swift
@@ -44,7 +44,8 @@ final class AirportServiceTests: XCTestCase {
         let deps = [dep("M3", "06:39"), dep("M3_AIR", "06:39"), dep("M3", "06:49")]
         let rows = AirportServiceRows.build(metroDepartures: deps, buses: nil, language: .english)
         let metro = rows.filter { $0.route == "M3" }
-        XCTAssertEqual(metro.map { $0.time }, ["06:39", "06:49"], "one row per distinct time")
+        XCTAssertEqual(metro.count, 1, "one grouped M3 row")
+        XCTAssertEqual(metro.first?.times, ["06:39", "06:49"], "distinct times collapse into one grouped row")
     }
 
     func testSuburbanKeepsRealLineAndIsNotRelabeledMetro() {
@@ -62,13 +63,16 @@ final class AirportServiceTests: XCTestCase {
                     dep("A1", "04:30", dir: "Piraeus"), dep("A1", "05:00", dir: "Piraeus")]
         let rows = AirportServiceRows.build(metroDepartures: deps, buses: nil, language: .english)
         let sub = rows.filter { $0.route == "A1" }
-        XCTAssertEqual(sub.map { $0.time }, ["04:00", "04:30"], "duplicates dropped, capped at 2")
+        XCTAssertEqual(sub.count, 1, "one grouped A1 row")
+        XCTAssertEqual(sub.first?.times, ["04:00", "04:30"], "duplicates dropped, next 2 in one grouped row")
     }
 
     func testMetroCappedAtThree() {
         let deps = (0..<6).map { dep("M3", String(format: "07:%02d", $0 * 5)) }
         let rows = AirportServiceRows.build(metroDepartures: deps, buses: nil, language: .english)
-        XCTAssertEqual(rows.filter { $0.route == "M3" }.count, 3)
+        let metro = rows.filter { $0.route == "M3" }
+        XCTAssertEqual(metro.count, 1, "one grouped M3 row")
+        XCTAssertEqual(metro.first?.times.count, 3, "capped at the next 3 times")
     }
 
     // MARK: - Buses: live vs fallback
@@ -80,11 +84,11 @@ final class AirportServiceTests: XCTestCase {
         ]))
         let rows = AirportServiceRows.build(metroDepartures: [], buses: live, language: .english)
         let x95 = rows.first { $0.route == "X95" }
-        XCTAssertEqual(x95?.time, "5 min")
+        XCTAssertEqual(x95?.times, ["5 min"])
         XCTAssertEqual(x95?.confidence, .live)
         // X96 is untracked in this feed -> neutral fallback, never a fake time.
         let x96 = rows.first { $0.route == "X96" }
-        XCTAssertEqual(x96?.time, "24/7")
+        XCTAssertEqual(x96?.times, ["24/7"])
         XCTAssertEqual(x96?.confidence, .operatorLink)
     }
 
@@ -92,7 +96,7 @@ final class AirportServiceTests: XCTestCase {
         let rows = AirportServiceRows.build(metroDepartures: [], buses: nil, language: .english)
         for line in ["X95", "X93", "X96", "X97"] {
             let row = rows.first { $0.route == line }
-            XCTAssertEqual(row?.time, "24/7")
+            XCTAssertEqual(row?.times, ["24/7"])
             XCTAssertEqual(row?.confidence, .operatorLink)
             XCTAssertFalse(row?.detail.contains("OASA") ?? true, "no passive check-OASA copy")
         }


### PR DESCRIPTION
## Why

The Airport hub **"Airport services"** list (`AirportServiceRows.build`) emitted one `AirportListRow` per departure, so the metro block was up to three identical `M3 · Syntagma · Scheduled metro departure` rows and the suburban block up to two `A1/A2 · Piraeus` rows, differing only by the clock time — the same repeated-row problem the station board had (fixed in #131). Completes the departures grouping on the surface from the redesign brief's screenshot.

## How

Collapse each `(line, destination)` into **one grouped row**:
- `AirportListRow.time: String` → `times: [String]`.
- Metro → one row with the next 3 times.
- Suburban grouped by the **real** line (A1 and A2 stay separate) with the next 2 each.
- Buses stay one-per-line (live ETA or 24/7).
- `rowBody` renders a **"Then HH:MM · HH:MM"** tail after the soonest, reusing the `airportText` "Then" localization the featured `ServiceTile`s already use.

## Verification

- `AirportServiceTests` updated to assert the grouped `times` arrays; **ran locally on the iPhone 17 simulator — TEST SUCCEEDED (11 cases)**.
- **Runtime-verified on the sim**: the hub shows `M3 → Syntagma · 18:35 · Έπειτα 18:39 · 19:11`, with A1 and A2 as separate grouped rows and the X-buses one-per-line with live chips.

Mirrors the station-board grouping (#131) and the Android hub grouping (#137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)