### PR TITLE
feat(android): group the Home nearby-station departures by line

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/ProactiveHome.kt
+++ b/feature/home/src/commonMain/kotlin/com/syrmos/feature/home/ProactiveHome.kt
@@ -39,6 +39,8 @@ import com.syrmos.core.common.StationNameTranslator
 import com.syrmos.core.designsystem.component.toComposeColor
 import com.syrmos.core.designsystem.theme.tokens.SyrmosColorTokens
 import com.syrmos.core.designsystem.theme.tokens.SyrmosTypographyTokens
+import com.syrmos.core.domain.departures.ResolvedDeparture
+import com.syrmos.core.domain.departures.groupDepartures
 import com.syrmos.core.domain.usecase.UpcomingDeparture
 import com.syrmos.core.model.alerts.AlertSeverity
 import com.syrmos.core.model.location.NearestStationResult
@@ -405,10 +407,27 @@ internal fun RadialNearbySection(
                             )
                             Text(formatNearbyDistance(station.distanceMeters), style = MaterialTheme.typography.labelMedium)
                         }
-                        departures.filter { it.lineId in station.lineIds }.take(2).forEach { departure ->
-                            val disrupted = lineDisruptions[departure.lineId]
+                        // Group by line so a line with two imminent departures reads
+                        // as "M3 · 5 min · 12 min" instead of two "M3 · N min" rows.
+                        // Destination is empty because this compact card shows only
+                        // the line + countdowns, so grouping folds purely by line.
+                        val grouped = groupDepartures(
+                            departures.filter { it.lineId in station.lineIds }.map { departure ->
+                                ResolvedDeparture(
+                                    lineId = departure.lineId,
+                                    destination = "",
+                                    minutesAway = departure.minutesAway,
+                                    time = "",
+                                    sourceConfidence = departure.sourceConfidence,
+                                )
+                            },
+                            maxTimes = 3,
+                        ).take(2)
+                        grouped.forEach { group ->
+                            val disrupted = lineDisruptions[group.lineId]
                             Text(
-                                text = "${departure.lineId} · ${formatCountdown(departure.minutesAway, lang)}" +
+                                text = "${group.lineId} · " +
+                                    group.times.joinToString(" · ") { formatCountdown(it.minutesAway, lang) } +
                                     if (disrupted != null && disrupted.rank > 0) " · ⚠" else "",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,


### PR DESCRIPTION
## Why

The Home radial nearby section's selected-station card (`RadialNearbySection` in `ProactiveHome.kt`) rendered `departures.filter { … }.take(2)` as raw `lineId · countdown` rows, so a line with two imminent departures showed as two `M3 · 5 min` / `M3 · 12 min` rows differing only by the time.

## How

Group by line using the shared `groupDepartures` transform (`core/domain`, #132) with an **empty destination** (this compact card shows only line + countdowns, so it folds purely by line), so the line reads as one **`M3 · 5 min · 12 min`** row. Takes the 2 soonest lines with their next 3 times each; disruption `⚠` preserved.

## Verification

No new pure logic — `groupDepartures` is unit-tested in #132. Compose change, no local JDK, so **verified via CI** (Android build + lint + KMP tests). Completes the grouping on the last Android departures-ish surface (station board #132, airport hub #137, now the Home nearby card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)