### PR TITLE
feat(android): honest live-train marker staleness + offline-aware livestream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ The long-range product roadmap by version (1.1 through 2.0, with quarterly targe
 
 Product direction: Syrmos is a companion, not a schedule. Every feature is measured against the answer-first / proactive / reassuring / low-decision rules in [docs/PRODUCT_PRINCIPLES.md](docs/PRODUCT_PRINCIPLES.md).
 
+## Unreleased
+
+Honest live-vehicle freshness on the map, and an offline-aware livestream, across
+every client. Answers the offline-first data-status rule that an aged position
+must never be shown as live. See [docs/OFFLINE_FIRST_AND_DATA_SOURCES.md](docs/OFFLINE_FIRST_AND_DATA_SOURCES.md).
+
+- **Live-GPS markers age out honestly (iOS + Android + web).** A real train/bus
+  position is now classified by the age of its own `updatedAt`: fresh (<=90s)
+  draws live; stale (90s-600s) draws de-emphasised (grey, no pulse), never a plain
+  live dot; expired (>600s) is dropped so the line falls back to the schedule
+  projector. Freshness is recomputed on a timer, so a marker ages LIVE -> STALE ->
+  gone even when the feed stops emitting (offline / dropped) with no new data. Root
+  cause fixed on Android/KMP where live trains carried no timestamp at all
+  (`updatedAt = ""`) and a frozen ghost both looked live and blocked its line's
+  offline projection. One shared rule: `core/model/status/LiveVehicleFreshness.kt`
+  (KMP), `LiveVehicleFreshnessRule` (iOS), `classifyLiveBatch` (web).
+- **Offline-aware livestream.** iOS gained an explicit "Livestream requires an
+  internet connection" state, automatic reconnect when connectivity returns (no
+  restart), and background/foreground pause-resume; Android no longer offers a
+  dead "Watch Live" link when the train is not currently tracked, showing the same
+  offline message instead.
+- **Tests.** `LiveVehicleFreshnessTest` (KMP, 12), `LiveTrainClassificationTest`
+  (KMP, 5), iOS `SuburbanProjectionTests` (+3, 7 total), web
+  `live-train-freshness.test.js` (8). Full suites green: iOS 173, web 68, Android
+  build + unit tests.
+
 ## 3.0.0-beta.2 - 2026-09-03
 
 Live GO: the get-off cue that is the point of the whole feature. GO no longer waits for you to tap through

--- a/core/model/src/commonMain/kotlin/com/syrmos/core/model/status/LiveVehicleFreshness.kt
+++ b/core/model/src/commonMain/kotlin/com/syrmos/core/model/status/LiveVehicleFreshness.kt
@@ -1,0 +1,136 @@
+package com.syrmos.core.model.status
+
+import kotlinx.datetime.Instant
+
+/**
+ * Rendering-facing freshness of a REAL-GPS live vehicle marker (a suburban /
+ * national train position, or an airport-bus position) computed from that
+ * vehicle's OWN `updatedAt` against the current instant.
+ *
+ * This is the map/marker counterpart of the per-item [Freshness] axis: where
+ * [Freshness] answers "fresh vs stale vs unknown-age", this collapses the answer
+ * into the three buckets a moving-dot renderer actually needs, adding the
+ * [EXPIRED] tier that [Freshness] does not model:
+ *
+ * - [LIVE]    — within the fresh window: draw as a live, boardable position.
+ * - [STALE]   — older than the fresh window but still recent enough to be the
+ *               best-known last position: draw DE-EMPHASISED and label it with
+ *               its age ("updated Nm ago"). It must NEVER render as a plain live
+ *               dot — showing an aged position as live is the exact dishonesty
+ *               the data-status rules forbid.
+ * - [EXPIRED] — so old it is no longer meaningful: the renderer drops the marker
+ *               (and, where a schedule-projected equivalent exists, that takes
+ *               over instead).
+ *
+ * A missing / blank / malformed timestamp resolves to [STALE] with a `null`
+ * age: we hold a position but cannot vouch for its recency, so it is never shown
+ * as live. A timestamp in the future beyond the clock-skew tolerance is treated
+ * the same way.
+ */
+enum class LiveVehicleState { LIVE, STALE, EXPIRED }
+
+/**
+ * The classification of a single live vehicle: its [state] plus the age of its
+ * position in seconds (`null` when the timestamp was missing/unusable, or when
+ * the position is within the future-skew tolerance and treated as just-now).
+ */
+data class LiveVehicleFreshness(
+    val state: LiveVehicleState,
+    val ageSeconds: Long?,
+)
+
+/**
+ * A live vehicle's position within this many seconds is [LiveVehicleState.LIVE].
+ * Matches [DEFAULT_FRESHNESS_WINDOW_SECONDS] so the marker layer and the
+ * per-item [Freshness] axis agree on what "fresh" means.
+ */
+const val LIVE_VEHICLE_FRESH_WINDOW_SECONDS: Long = 90
+
+/**
+ * Older than [LIVE_VEHICLE_FRESH_WINDOW_SECONDS] but within this many seconds is
+ * [LiveVehicleState.STALE] (shown de-emphasised, with its age). Beyond it the
+ * position is [LiveVehicleState.EXPIRED] and the marker is dropped. Ten minutes:
+ * long enough that a brief signal loss keeps the last-known dot on screen
+ * (clearly marked), short enough that a truly dead feed hands the map back to
+ * the schedule projector.
+ */
+const val LIVE_VEHICLE_EXPIRY_SECONDS: Long = 600
+
+/**
+ * Pure classification of a live vehicle from its own `updatedAt` (epoch
+ * seconds). Clock-injected so it unit-tests without a real clock.
+ *
+ * @param updatedAtEpochSeconds the vehicle's own position timestamp (epoch
+ *   seconds), or `null` when it carries none -> [LiveVehicleState.STALE].
+ * @param nowEpochSeconds the current instant (epoch seconds).
+ * @param freshWindowSeconds the LIVE window (default
+ *   [LIVE_VEHICLE_FRESH_WINDOW_SECONDS]); must be `>= 0`.
+ * @param expirySeconds the STALE->EXPIRED cutoff (default
+ *   [LIVE_VEHICLE_EXPIRY_SECONDS]); must be `>= freshWindowSeconds`.
+ * @param futureSkewToleranceSeconds tolerated future offset for device clock
+ *   skew (default [DEFAULT_FUTURE_SKEW_TOLERANCE_SECONDS]); must be `>= 0`.
+ */
+fun classifyLiveVehicle(
+    updatedAtEpochSeconds: Long?,
+    nowEpochSeconds: Long,
+    freshWindowSeconds: Long = LIVE_VEHICLE_FRESH_WINDOW_SECONDS,
+    expirySeconds: Long = LIVE_VEHICLE_EXPIRY_SECONDS,
+    futureSkewToleranceSeconds: Long = DEFAULT_FUTURE_SKEW_TOLERANCE_SECONDS,
+): LiveVehicleFreshness {
+    require(freshWindowSeconds >= 0) { "freshWindowSeconds must be >= 0, was $freshWindowSeconds" }
+    require(expirySeconds >= freshWindowSeconds) {
+        "expirySeconds ($expirySeconds) must be >= freshWindowSeconds ($freshWindowSeconds)"
+    }
+    require(futureSkewToleranceSeconds >= 0) {
+        "futureSkewToleranceSeconds must be >= 0, was $futureSkewToleranceSeconds"
+    }
+    // No usable timestamp: we hold a position but cannot vouch for it, so it is
+    // never LIVE. STALE with no age so the UI shows a de-emphasised dot without a
+    // fabricated "N min ago".
+    if (updatedAtEpochSeconds == null) return LiveVehicleFreshness(LiveVehicleState.STALE, null)
+    val age = nowEpochSeconds - updatedAtEpochSeconds
+    if (age < 0) {
+        // Future timestamp: tolerate small device clock skew as just-now, but do
+        // not trust one that sits far ahead of us.
+        return if (-age <= futureSkewToleranceSeconds) {
+            LiveVehicleFreshness(LiveVehicleState.LIVE, 0)
+        } else {
+            LiveVehicleFreshness(LiveVehicleState.STALE, null)
+        }
+    }
+    return when {
+        age <= freshWindowSeconds -> LiveVehicleFreshness(LiveVehicleState.LIVE, age)
+        age <= expirySeconds -> LiveVehicleFreshness(LiveVehicleState.STALE, age)
+        else -> LiveVehicleFreshness(LiveVehicleState.EXPIRED, age)
+    }
+}
+
+/**
+ * Convenience over [classifyLiveVehicle] that parses an ISO-8601 `updatedAt`
+ * string as the live feeds carry it. A `null`, blank or malformed string
+ * resolves to [LiveVehicleState.STALE] with a `null` age.
+ */
+fun classifyLiveVehicleIso(
+    updatedAtIso: String?,
+    now: Instant,
+    freshWindowSeconds: Long = LIVE_VEHICLE_FRESH_WINDOW_SECONDS,
+    expirySeconds: Long = LIVE_VEHICLE_EXPIRY_SECONDS,
+    futureSkewToleranceSeconds: Long = DEFAULT_FUTURE_SKEW_TOLERANCE_SECONDS,
+): LiveVehicleFreshness {
+    require(freshWindowSeconds >= 0) { "freshWindowSeconds must be >= 0, was $freshWindowSeconds" }
+    require(expirySeconds >= freshWindowSeconds) {
+        "expirySeconds ($expirySeconds) must be >= freshWindowSeconds ($freshWindowSeconds)"
+    }
+    require(futureSkewToleranceSeconds >= 0) {
+        "futureSkewToleranceSeconds must be >= 0, was $futureSkewToleranceSeconds"
+    }
+    val epoch = parseIsoToEpochSeconds(updatedAtIso)
+        ?: return LiveVehicleFreshness(LiveVehicleState.STALE, null)
+    return classifyLiveVehicle(
+        epoch,
+        now.epochSeconds,
+        freshWindowSeconds,
+        expirySeconds,
+        futureSkewToleranceSeconds,
+    )
+}

--- a/core/model/src/commonTest/kotlin/com/syrmos/core/model/status/LiveVehicleFreshnessTest.kt
+++ b/core/model/src/commonTest/kotlin/com/syrmos/core/model/status/LiveVehicleFreshnessTest.kt
@@ -1,0 +1,105 @@
+package com.syrmos.core.model.status
+
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+/**
+ * The real-GPS marker freshness classifier. A live vehicle must render as a
+ * plain live dot ONLY within the fresh window; past it, it is de-emphasised and
+ * aged (STALE) and eventually dropped (EXPIRED). Missing/unusable and far-future
+ * timestamps never read as live. Fixed test clock; no real clock used.
+ */
+class LiveVehicleFreshnessTest {
+
+    private val now = 1_000_000L // epoch seconds, fixed test clock
+    private val nowInstant = Instant.fromEpochSeconds(now)
+
+    @Test
+    fun freshPositionIsLive() {
+        val f = classifyLiveVehicle(now - 10, now)
+        assertEquals(LiveVehicleState.LIVE, f.state)
+        assertEquals(10, f.ageSeconds)
+    }
+
+    @Test
+    fun exactlyAtFreshBoundaryIsLiveOneMoreIsStale() {
+        assertEquals(LiveVehicleState.LIVE, classifyLiveVehicle(now - 90, now).state)
+        assertEquals(LiveVehicleState.STALE, classifyLiveVehicle(now - 91, now).state)
+    }
+
+    @Test
+    fun staleCarriesItsAge() {
+        val f = classifyLiveVehicle(now - 200, now)
+        assertEquals(LiveVehicleState.STALE, f.state)
+        assertEquals(200, f.ageSeconds)
+    }
+
+    @Test
+    fun exactlyAtExpiryIsStaleOneMoreIsExpired() {
+        assertEquals(LiveVehicleState.STALE, classifyLiveVehicle(now - 600, now).state)
+        assertEquals(LiveVehicleState.EXPIRED, classifyLiveVehicle(now - 601, now).state)
+    }
+
+    @Test
+    fun expiredCarriesItsAge() {
+        val f = classifyLiveVehicle(now - 3600, now)
+        assertEquals(LiveVehicleState.EXPIRED, f.state)
+        assertEquals(3600, f.ageSeconds)
+    }
+
+    @Test
+    fun missingTimestampIsStaleWithNoAgeNeverLive() {
+        val f = classifyLiveVehicle(null, now)
+        assertEquals(LiveVehicleState.STALE, f.state)
+        assertNull(f.ageSeconds)
+    }
+
+    @Test
+    fun smallFutureSkewIsTreatedAsJustNowLive() {
+        // within the default 120s tolerance
+        val f = classifyLiveVehicle(now + 60, now)
+        assertEquals(LiveVehicleState.LIVE, f.state)
+        assertEquals(0, f.ageSeconds)
+    }
+
+    @Test
+    fun farFutureTimestampIsStaleNotLive() {
+        val f = classifyLiveVehicle(now + 100_000, now)
+        assertEquals(LiveVehicleState.STALE, f.state)
+        assertNull(f.ageSeconds)
+    }
+
+    @Test
+    fun isoConvenienceParsesAndClassifies() {
+        val fresh = classifyLiveVehicleIso(Instant.fromEpochSeconds(now - 5).toString(), nowInstant)
+        assertEquals(LiveVehicleState.LIVE, fresh.state)
+        val stale = classifyLiveVehicleIso(Instant.fromEpochSeconds(now - 300).toString(), nowInstant)
+        assertEquals(LiveVehicleState.STALE, stale.state)
+    }
+
+    @Test
+    fun isoBlankOrMalformedIsStaleWithNoAge() {
+        assertEquals(LiveVehicleState.STALE, classifyLiveVehicleIso(null, nowInstant).state)
+        assertEquals(LiveVehicleState.STALE, classifyLiveVehicleIso("", nowInstant).state)
+        assertEquals(LiveVehicleState.STALE, classifyLiveVehicleIso("not-a-date", nowInstant).state)
+        assertNull(classifyLiveVehicleIso("not-a-date", nowInstant).ageSeconds)
+    }
+
+    @Test
+    fun customWindowsAreHonoured() {
+        // 30s fresh, 120s expiry
+        assertEquals(LiveVehicleState.LIVE, classifyLiveVehicle(now - 30, now, freshWindowSeconds = 30, expirySeconds = 120).state)
+        assertEquals(LiveVehicleState.STALE, classifyLiveVehicle(now - 31, now, freshWindowSeconds = 30, expirySeconds = 120).state)
+        assertEquals(LiveVehicleState.EXPIRED, classifyLiveVehicle(now - 121, now, freshWindowSeconds = 30, expirySeconds = 120).state)
+    }
+
+    @Test
+    fun invalidConfigurationRejected() {
+        assertFailsWith<IllegalArgumentException> { classifyLiveVehicle(now, now, freshWindowSeconds = -1) }
+        assertFailsWith<IllegalArgumentException> { classifyLiveVehicle(now, now, freshWindowSeconds = 100, expirySeconds = 50) }
+        assertFailsWith<IllegalArgumentException> { classifyLiveVehicle(now, now, futureSkewToleranceSeconds = -1) }
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/RailwayGovLiveTrackerService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/RailwayGovLiveTrackerService.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
+import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -48,6 +49,14 @@ class RailwayGovLiveTrackerService(
                 }
                 val body = response.bodyAsText()
                 val payload = json.decodeFromString<TrainsPayload>(body)
+                // The feed stamps every snapshot with a single generation time
+                // (railway.gov's own). Carry it onto each position so the map can
+                // age a marker out honestly: an offline / dropped poll no longer
+                // emits, so the retained trains keep this timestamp and grow stale
+                // against wall-clock instead of freezing on screen as "live".
+                // Fall back to receive-time when the feed omits it.
+                val stamp = payload.updatedAt?.takeIf { it.isNotBlank() }
+                    ?: Clock.System.now().toString()
                 val trains = payload.trains
                     .asSequence()
                     // Skip a train that has no coordinate rather than letting the
@@ -57,7 +66,7 @@ class RailwayGovLiveTrackerService(
                     // on the previous frame. Mirrors the web map's null guard.
                     .filter { it.lat != null && it.lng != null }
                     .filter { lineIds.isNullOrEmpty() || it.lineId in lineIds }
-                    .map { it.toDomain() }
+                    .map { it.toDomain(stamp) }
                     .sortedWith(
                         compareBy<LiveSuburbanTrain> { it.delayMinutes }
                             .thenBy { it.trainNumber },
@@ -76,7 +85,7 @@ class RailwayGovLiveTrackerService(
         }
     }
 
-    private fun TrainItem.toDomain(): LiveSuburbanTrain {
+    private fun TrainItem.toDomain(updatedAtStamp: String): LiveSuburbanTrain {
         return LiveSuburbanTrain(
             id = id,
             lineId = lineId,
@@ -95,7 +104,7 @@ class RailwayGovLiveTrackerService(
             speedKph = speed,
             latitude = lat ?: 0.0,
             longitude = lng ?: 0.0,
-            updatedAt = "",
+            updatedAt = updatedAtStamp,
             course = course,
             altitude = altitude,
             locomotiveNumber = locomotiveNumber,

--- a/docs/OFFLINE_FIRST_AND_DATA_SOURCES.md
+++ b/docs/OFFLINE_FIRST_AND_DATA_SOURCES.md
@@ -1,0 +1,101 @@
+# Offline-first & transport data sources
+
+How Syrmos stays fully usable with no connection, where its data comes from, and
+how each on-screen value is classified as live, estimated, scheduled, cached or
+unavailable. Companion to [PLAN_API_SCHEDULES.md](PLAN_API_SCHEDULES.md) and the
+memory note `deploy-and-seed-playbook`.
+
+## The backend ("PI") and the official sources
+
+Clients never call a government API directly and hold no operator secrets. All
+official feeds are normalised and proxied by the Syrmos backend, a **Raspberry
+Pi** running the FastAPI `syrmos_admin` service behind a Cloudflare Tunnel at
+`https://api-syrmos.peterdsp.dev`. That proxy is the "PI" integration.
+
+| Source | Kind | What it feeds | How |
+|---|---|---|---|
+| **OASA Telematics** `telematics.oasa.gr/api/` (Athens transport authority, government) | Real-time | Airport express-bus positions + ETAs (X93/X95/X96/X97) | `getBusLocation` + `getStopArrivals` (btime2), polled 30s by `oasa-airport-bus-watcher.py` → `/api/oasa-airport-buses` |
+| **railway.gov.gr** `/api/train-stream` (SSE) + `/api/public/trains/` (government railway) | Real-time GPS | Live suburban + intercity train positions | `railway-gov-sse.py` holds one SSE, relays a ~1.5 KB JSON → `/api/trains` |
+| **Hellenic Train** `hellenictrain.gr` (operator) | Scheduled | Timetables, transcribed into the bundled seed | manual/scripted import |
+| **STASY** (Athens metro/tram operator) | Scheduled + alerts | Last-trains, tram offsets, announcements | `scrape-stasy-*`, `stasy-*-watcher.py` |
+
+Metro (M1/M2/M3) and tram (T6/T7) have **no operator live-GPS feed**. Their moving
+map dots are the server's own schedule **projection** (`/api/live-positions` →
+`active_trains`: `originDepartureMinute` / `elapsedMinutes` / `totalTravelMinutes`,
+no lat/lng) — the client interpolates the position from progress. This is true
+**online and offline**, so those dots are always "estimated from timetable", never
+GPS.
+
+## What is live vs estimated vs scheduled vs offline
+
+| Data | Provenance | Notes |
+|---|---|---|
+| Airport-bus positions & ETAs | **LIVE** (real GPS + `updatedAt`) | soonest ETA is OASA `btime2` |
+| Suburban / intercity train positions | **LIVE** (real GPS, `/api/trains` batch `updatedAt`) | absent overnight (no service) |
+| Metro / tram map dots | **ESTIMATED** (interpolated from the timetable) | same online and offline |
+| Station departures | **SCHEDULED** (projected from frequency bands / trip stops) | server + client projectors kept in lockstep |
+| Anything when the Pi is unreachable | **OFFLINE** (bundled seed) | full snapshot ships in the app |
+
+## The data-status model
+
+Two orthogonal axes live in `core/model` and are mirrored per platform:
+
+- **Provenance** — `SourceConfidence` (`LIVE`, `SCHEDULED`, `ESTIMATED`, `OFFLINE`,
+  `OPERATOR_LINK`, `UNKNOWN`). Rendered as the calm source chip.
+- **Freshness** — `Freshness` (`Fresh` / `Stale(age)` / `UnknownAge` /
+  `NotApplicable` / `Unavailable`) resolved with provenance into a `DisplayKind`
+  (`LIVE`, `LIVE_UNKNOWN_AGE`, `SCHEDULED`, `ESTIMATED`, `CACHED`, `OFFLINE`,
+  `OPERATOR`, `UNAVAILABLE`).
+
+### Live-vehicle marker freshness (map)
+
+Real-GPS markers (suburban/intercity trains, airport buses) are classified by the
+age of their **own** timestamp so an aged position is never drawn as live. One
+rule, mirrored on all three clients:
+
+- `core/model/status/LiveVehicleFreshness.kt` — `classifyLiveVehicle`/`…Iso`
+- iOS `Core/Schedule/DataFreshness.swift` — `LiveVehicleFreshnessRule.classify`
+- web `web-map.js` — `classifyLiveBatch`
+
+| Age | State | Rendering |
+|---|---|---|
+| ≤ 90 s | **LIVE** | full styling, boardable |
+| 90 s – 600 s | **STALE** | de-emphasised (grey, no pulse) + "updated N m ago"; never a plain live dot |
+| > 600 s | **EXPIRED** | marker dropped; the line falls back to the schedule projector |
+| no / bad / far-future timestamp | **STALE** (no age) | never live |
+
+Freshness is recomputed against wall-clock on a timer (Android 1 s sim loop, iOS a
+5 s `nowTick`, web a 15 s re-render), so a marker ages LIVE → STALE → gone even
+when the feed stops emitting (offline / dropped) with no new data. A still-tracked
+(LIVE or STALE) train hides its line's projected dot; an EXPIRED one releases the
+line so the projector fills back in.
+
+## Offline behaviour per platform
+
+- **iOS / Android** bundle a full seed (`seed-schedules-v2/`) loaded synchronously
+  at launch with **no blocking network call**; the DB seed is replaced atomically
+  (Android `DataSeeder.seed()` in one transaction). Route shapes, stations and
+  projected metro/tram/suburban dots all render offline.
+- **Web** reads the bundled `lines.json` + geometry it serves and caches API
+  augmentations in `localStorage`. (The base map tiles are remote, so the basemap
+  is online-only by design; vector overlays still draw.)
+
+## Known limitations
+
+- Base-map tiles (Esri) are remote on every client; offline the basemap is blank
+  while route shapes, stations and vehicle dots still render. (No unauthorized
+  bulk tile download is performed.)
+- Metro/tram positions are always estimated (no operator GPS exists).
+- Live suburban/intercity trains are absent overnight (no service to track).
+- Livestream (an on-train camera on some live suburban trains) needs connectivity
+  by nature; offline it shows a clear "requires an internet connection" state and
+  reconnects automatically when back online.
+- The web app has no Service Worker yet, so a first cold start still needs the
+  network to fetch the page shell (tracked as a follow-up).
+
+## Verification
+
+- Live feeds: `curl https://api-syrmos.peterdsp.dev/api/{trains,live-positions,oasa-airport-buses,schedules/manifest}`.
+- Freshness logic: unit tests on all three clients (`LiveVehicleFreshnessTest`,
+  `LiveTrainClassificationTest`, iOS `SuburbanProjectionTests`, web
+  `live-train-freshness.test.js`).

--- a/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
+++ b/feature/map/src/androidMain/kotlin/com/syrmos/feature/map/PlatformMapView.android.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.syrmos.core.designsystem.component.toComposeColor
 import com.syrmos.core.common.map.MapDesignTokens
+import com.syrmos.core.model.status.LiveVehicleState
 import com.syrmos.core.model.transit.Direction
 import com.syrmos.core.model.transit.LineType
 import com.syrmos.core.model.transit.SimulatedTrain
@@ -498,7 +499,7 @@ internal actual fun PlatformMapView(
         mapView.invalidate()
     }
 
-    LaunchedEffect(uiState.liveTrains, mapBand) {
+    LaunchedEffect(uiState.visibleLiveTrains, mapBand) {
         val res = context.resources
         if (mapBand < 2) {
             liveTrainMarkers.values.forEach { mapView.overlays.remove(it) }
@@ -506,40 +507,49 @@ internal actual fun PlatformMapView(
             mapView.invalidate()
             return@LaunchedEffect
         }
-        val activeIds = uiState.liveTrains.map { it.id }.toSet()
-        val staleIds = liveTrainMarkers.keys - activeIds
-        staleIds.forEach { id ->
+        // visibleLiveTrains already dropped EXPIRED positions, so a marker that
+        // aged out disappears here instead of freezing on its last GPS fix.
+        val activeIds = uiState.visibleLiveTrains.map { it.train.id }.toSet()
+        val goneIds = liveTrainMarkers.keys - activeIds
+        goneIds.forEach { id ->
             liveTrainMarkers[id]?.let { mapView.overlays.remove(it) }
             liveTrainMarkers.remove(id)
         }
 
-        uiState.liveTrains.forEach { train ->
-            // A "position only" / not-in-service live vehicle is a real GPS dot
-            // but NOT boardable, so draw it de-emphasized (grey, faded) to match
-            // its detail card. Assigned trains keep the line colour.
+        uiState.visibleLiveTrains.forEach { marker ->
+            val train = marker.train
+            // Two independent reasons to de-emphasize a real GPS dot:
+            //  - notInService: a "position only" vehicle is a real dot but NOT
+            //    boardable (grey to match its detail card).
+            //  - stale: the position is older than the fresh window. Drawing an
+            //    aged position with full live styling would be the exact "old
+            //    position shown as live" the data-status rules forbid, so it is
+            //    muted and its sheet says how long ago it was seen.
             val notInService = !train.inService || train.status == "position_only"
-            val color = if (notInService) 0xFF9CA3AF.toInt()
+            val stale = marker.state == LiveVehicleState.STALE
+            val muted = notInService || stale
+            val color = if (muted) 0xFF9CA3AF.toInt()
                 else uiState.lines.find { it.id == train.lineId }?.color?.toComposeColor()?.toArgb()
                     ?: 0xFF7C4DFF.toInt()
             val snappedPos = snapToPolyline(train.latitude, train.longitude, train.lineId, effectiveShapes)
             val existing = liveTrainMarkers[train.id]
             if (existing != null) {
                 existing.position = snappedPos
-                existing.icon = buildLiveTrainBitmap(res, color = color, lineId = train.lineId, muted = notInService)
+                existing.icon = buildLiveTrainBitmap(res, color = color, lineId = train.lineId, muted = muted)
             } else {
                 val trainId = train.id
-                val marker = Marker(mapView).apply {
+                val newMarker = Marker(mapView).apply {
                     position = snappedPos
                     setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
-                    icon = buildLiveTrainBitmap(res, color = color, lineId = train.lineId, muted = notInService)
+                    icon = buildLiveTrainBitmap(res, color = color, lineId = train.lineId, muted = muted)
                     title = "${train.lineId} ${train.trainNumber}"
                     setOnMarkerClickListener { _, _ ->
                         onTrainSelected(trainId)
                         true
                     }
                 }
-                liveTrainMarkers[train.id] = marker
-                mapView.overlays.add(marker)
+                liveTrainMarkers[train.id] = newMarker
+                mapView.overlays.add(newMarker)
             }
         }
         mapView.invalidate()

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/FallbackMapView.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/FallbackMapView.kt
@@ -261,7 +261,9 @@ private fun DrawScope.drawFallbackMap(
     )
 
     drawLiveTrains(
-        trains = uiState.liveTrains,
+        // EXPIRED positions already dropped, so the fallback canvas never draws a
+        // frozen ghost either (parity with the osmdroid map).
+        trains = uiState.visibleLiveTrains.map { it.train },
         geometry = uiState.effectiveGeometry,
         canvasWidth = canvasWidth,
         canvasHeight = canvasHeight,

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/LiveTrainClassification.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/LiveTrainClassification.kt
@@ -1,0 +1,46 @@
+package com.syrmos.feature.map
+
+import com.syrmos.core.model.status.LiveVehicleState
+import com.syrmos.core.model.status.classifyLiveVehicleIso
+import com.syrmos.core.model.transit.LiveSuburbanTrain
+import kotlinx.datetime.Instant
+
+/**
+ * The stale-aware live-train fleet ready to plot, plus the set of line ids a
+ * still-tracked live train covers.
+ *
+ * [coveredLineIds] intentionally excludes EXPIRED positions: only a LIVE or
+ * STALE train suppresses its line's schedule-projected dot. Once a train
+ * expires (feed offline / dropped) its line is released, so the projector fills
+ * back in - the offline fallback a frozen ghost used to block.
+ */
+data class LiveTrainClassification(
+    val markers: List<LiveTrainMarker>,
+    val coveredLineIds: Set<String>,
+)
+
+/**
+ * Pure, clock-injected classification of the raw live-train feed into plottable,
+ * freshness-tagged markers. EXPIRED positions are dropped entirely so a
+ * dead/offline feed never leaves a frozen dot pretending to be live; STALE ones
+ * are kept but tagged so the renderer can de-emphasise them and show their age.
+ * Extracted from the simulation loop so it is unit-testable without the whole
+ * ViewModel.
+ */
+fun classifyLiveTrains(
+    liveTrains: List<LiveSuburbanTrain>,
+    now: Instant,
+): LiveTrainClassification {
+    val markers = liveTrains.mapNotNull { train ->
+        val fr = classifyLiveVehicleIso(train.updatedAt, now)
+        if (fr.state == LiveVehicleState.EXPIRED) {
+            null
+        } else {
+            LiveTrainMarker(train, fr.state, fr.ageSeconds)
+        }
+    }
+    return LiveTrainClassification(
+        markers = markers,
+        coveredLineIds = markers.map { it.train.lineId }.toSet(),
+    )
+}

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapScreen.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapScreen.kt
@@ -86,7 +86,10 @@ import com.syrmos.core.common.StationNameTranslator
 import com.syrmos.core.designsystem.component.toComposeColor
 import com.syrmos.core.model.transit.Line
 import com.syrmos.core.model.alerts.AlertSeverity
+import com.syrmos.core.model.status.LiveVehicleState
+import com.syrmos.core.model.status.classifyLiveVehicleIso
 import com.syrmos.core.model.transit.LiveSuburbanTrain
+import kotlinx.datetime.Clock
 import com.syrmos.core.model.transit.SimulatedTrain
 import org.koin.compose.koinInject
 
@@ -143,7 +146,7 @@ fun MapScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.End,
         ) {
-            if (uiState.liveTrains.isNotEmpty()) {
+            if (uiState.visibleLiveTrains.isNotEmpty()) {
                 Surface(
                     onClick = { viewModel.toggleLiveTrainsSheet() },
                     modifier = Modifier.size(56.dp).liquidGlassOverlay(),
@@ -312,7 +315,9 @@ fun MapScreen(
 
         if (uiState.showLiveTrainsSheet) {
             LiveTrainsSheet(
-                trains = uiState.liveTrains,
+                // The stale-aware, EXPIRED-dropped list the map plots, so the
+                // sheet never lists a ghost train that is no longer on the map.
+                trains = uiState.visibleLiveTrains.map { it.train },
                 lines = uiState.lines,
                 onTrainSelected = viewModel::flyToTrain,
                 onDismiss = viewModel::toggleLiveTrainsSheet,
@@ -1138,41 +1143,79 @@ private fun TrainDetailCard(
                 }
             }
 
-            // Live stream button
+            // Live stream button. A livestream intrinsically needs connectivity,
+            // so offer it ONLY while the train is freshly tracked (a proxy for
+            // "online and this vehicle is live"). Once the position is stale or
+            // expired (offline / feed dropped) the URL would be dead, so we show a
+            // clear "requires an internet connection" state rather than a button
+            // that opens nothing - mirroring the iOS livestream offline state.
             val streamUrl = train.liveStreamUrl
             if (!streamUrl.isNullOrBlank()) {
-                Button(
-                    onClick = { uriHandler.openUri(streamUrl) },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        contentColor = MaterialTheme.colorScheme.onSurface,
-                    ),
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Info,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(modifier = Modifier.size(8.dp))
-                    Text(
-                        text = vehicleText(lang, "Watch Live", "Ζωντανή προβολή", "Shiko drejtpërdrejt", "Guarda in diretta"),
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    Spacer(modifier = Modifier.weight(1f))
-                    Box(
-                        modifier = Modifier
-                            .size(8.dp)
-                            .background(Color.Red, CircleShape),
-                    )
-                    Spacer(modifier = Modifier.size(4.dp))
-                    Text(
-                        text = vehicleText(lang, "LIVE", "ΖΩΝΤΑΝΑ", "DREJTPËRDREJT", "DIRETTA"),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Bold,
-                        color = Color.Red,
-                    )
+                val streamFresh = classifyLiveVehicleIso(train.updatedAt, Clock.System.now()).state == LiveVehicleState.LIVE
+                if (streamFresh) {
+                    Button(
+                        onClick = { uriHandler.openUri(streamUrl) },
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            contentColor = MaterialTheme.colorScheme.onSurface,
+                        ),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Info,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Text(
+                            text = vehicleText(lang, "Watch Live", "Ζωντανή προβολή", "Shiko drejtpërdrejt", "Guarda in diretta"),
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        Box(
+                            modifier = Modifier
+                                .size(8.dp)
+                                .background(Color.Red, CircleShape),
+                        )
+                        Spacer(modifier = Modifier.size(4.dp))
+                        Text(
+                            text = vehicleText(lang, "LIVE", "ΖΩΝΤΑΝΑ", "DREJTPËRDREJT", "DIRETTA"),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.Red,
+                        )
+                    }
+                } else {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Info,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(modifier = Modifier.size(8.dp))
+                            Text(
+                                text = vehicleText(
+                                    lang,
+                                    "Livestream requires an internet connection",
+                                    "Η ζωντανή ροή απαιτεί σύνδεση στο διαδίκτυο",
+                                    "Transmetimi i drejtpërdrejtë kërkon lidhje interneti",
+                                    "La diretta richiede una connessione a internet",
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
@@ -21,12 +21,14 @@ import com.syrmos.core.model.transit.Line
 import com.syrmos.core.model.transit.LiveSuburbanTrain
 import com.syrmos.core.model.transit.SimulatedTrain
 import com.syrmos.core.model.transit.Station
+import com.syrmos.core.model.status.LiveVehicleState
 import com.syrmos.core.model.alerts.AlertSeverity
 import com.syrmos.core.data.sync.AnnouncementsRepository
 import com.syrmos.core.data.sync.StationOffsetsRepository
 import com.syrmos.core.network.OasaAirportBusService
 import com.syrmos.core.network.RailwayGovLiveTrackerService
 import com.syrmos.core.network.SyrmosLivePositionsService
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.coroutines.CoroutineScope
@@ -50,6 +52,20 @@ data class StationDepartureUi(
     val minutesAway: Int,
 )
 
+/**
+ * A real-GPS live train ready to plot, tagged with its freshness so the renderer
+ * can be honest about age. Only [LiveVehicleState.LIVE] and
+ * [LiveVehicleState.STALE] markers are ever produced; an EXPIRED position is
+ * dropped upstream (and its line handed back to the schedule projector), so a
+ * dead / offline feed never leaves a frozen "live" dot on the map. [ageSeconds]
+ * is `null` when the position carried no usable timestamp.
+ */
+data class LiveTrainMarker(
+    val train: LiveSuburbanTrain,
+    val state: LiveVehicleState,
+    val ageSeconds: Long?,
+)
+
 data class MapUiState(
     val stations: List<Station> = emptyList(),
     val mapStations: List<MapStationNode> = emptyList(),
@@ -63,6 +79,12 @@ data class MapUiState(
     val selectedStationLines: List<Line> = emptyList(),
     val selectedStationDepartures: List<StationDepartureUi> = emptyList(),
     val liveTrains: List<LiveSuburbanTrain> = emptyList(),
+    // The real-GPS trains actually plotted, tagged with per-vehicle freshness and
+    // with EXPIRED positions already dropped. Recomputed every simulation tick so
+    // a marker ages LIVE -> STALE -> gone against wall-clock even when the feed
+    // stops emitting (offline). The renderer must use THIS, not [liveTrains], so
+    // an aged position is never drawn as a plain live dot.
+    val visibleLiveTrains: List<LiveTrainMarker> = emptyList(),
     val simulatedTrains: List<SimulatedTrain> = emptyList(),
     // Live airport express-bus positions (X93/95/96/97) from the OASA telematics
     // feed. Plotted on the map beside the trains; blanked by the vehicles toggle.
@@ -268,14 +290,19 @@ class MapViewModel(
                         closedStationIds = closedIds,
                         geometry = geometry,
                     )
-                    // Suburban A1-A4 dedupe: railway.gov.gr `liveTrains` carry
-                    // raw GPS. Whenever the live feed has a train on a line,
-                    // hide the projected dot for that line so we don't render
-                    // two markers (one accurate GPS, one schedule-projected)
-                    // for the same physical train. If the live feed is empty
-                    // for a line (offline mode or feed dropped), the
-                    // projected dot is the only thing the user sees.
-                    val coveredByLive = state.liveTrains.map { it.lineId }.toSet()
+                    // Classify each real-GPS train by the age of its own position.
+                    // A LIVE or STALE (recent-but-aged) train is plotted; an
+                    // EXPIRED one is dropped so a dead/offline feed cannot leave a
+                    // frozen dot pretending to be live. Recomputed every tick so a
+                    // marker crosses LIVE -> STALE -> gone against wall-clock with
+                    // no new data. Suburban A1-A4 dedupe: a STILL-TRACKED (LIVE or
+                    // STALE) live train hides its line's projected dot; an EXPIRED
+                    // ghost is NOT covered, so the projector fills back in once the
+                    // feed goes stale - the offline fallback the frozen ghost used
+                    // to block.
+                    val classification = classifyLiveTrains(state.liveTrains, Clock.System.now())
+                    val liveMarkers = classification.markers
+                    val coveredByLive = classification.coveredLineIds
                     val filtered = simulated.filter { it.lineId !in coveredByLive }
                     // National rail + rail-replacement buses have no live feed or
                     // offsets, so project them from the bundled timetables.
@@ -295,6 +322,7 @@ class MapViewModel(
                     _uiState.update { current ->
                         current.copy(
                             simulatedTrains = visibleTrains,
+                            visibleLiveTrains = liveMarkers,
                             selectedSimulatedTrain = current.selectedSimulatedTrain?.let { selected ->
                                 visibleTrains.find { it.id == selected.id }
                             },

--- a/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/LiveTrainClassificationTest.kt
+++ b/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/LiveTrainClassificationTest.kt
@@ -1,0 +1,92 @@
+package com.syrmos.feature.map
+
+import com.syrmos.core.model.status.LiveVehicleState
+import com.syrmos.core.model.transit.LiveSuburbanTrain
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The map's honesty guarantee for real-GPS trains: a position is plotted as a
+ * plain live dot ONLY while fresh; once aged it is kept but tagged STALE (so the
+ * renderer de-emphasises it and shows its age), and once EXPIRED it is dropped
+ * so a dead/offline feed never freezes a "live" ghost on the map. EXPIRED trains
+ * must also release their line so the schedule projector fills back in - the
+ * offline-fallback regression this guards.
+ */
+class LiveTrainClassificationTest {
+
+    private val now = Instant.fromEpochSeconds(1_000_000)
+
+    private fun train(id: String, lineId: String, ageSeconds: Long?): LiveSuburbanTrain =
+        LiveSuburbanTrain(
+            id = id,
+            lineId = lineId,
+            trainNumber = id,
+            origin = null,
+            originEn = null,
+            destination = null,
+            destinationEn = null,
+            nextStation = null,
+            nextStationEn = null,
+            delayMinutes = 0,
+            serviceType = "regular",
+            progress = 0.0,
+            speedKph = 0.0,
+            latitude = 38.0,
+            longitude = 23.7,
+            updatedAt = if (ageSeconds == null) "" else Instant.fromEpochSeconds(now.epochSeconds - ageSeconds).toString(),
+        )
+
+    @Test
+    fun freshTrainIsLiveAndCovers() {
+        val c = classifyLiveTrains(listOf(train("t1", "A1", ageSeconds = 10)), now)
+        assertEquals(1, c.markers.size)
+        assertEquals(LiveVehicleState.LIVE, c.markers[0].state)
+        assertEquals(10, c.markers[0].ageSeconds)
+        assertTrue("A1" in c.coveredLineIds)
+    }
+
+    @Test
+    fun agedTrainIsStaleButStillPlottedAndCovers() {
+        val c = classifyLiveTrains(listOf(train("t1", "A2", ageSeconds = 300)), now)
+        assertEquals(1, c.markers.size)
+        assertEquals(LiveVehicleState.STALE, c.markers[0].state)
+        assertEquals(300, c.markers[0].ageSeconds)
+        assertTrue("A2" in c.coveredLineIds)
+    }
+
+    @Test
+    fun expiredTrainIsDroppedAndReleasesItsLine() {
+        val c = classifyLiveTrains(listOf(train("t1", "A3", ageSeconds = 1000)), now)
+        assertTrue(c.markers.isEmpty(), "an expired ghost must not be plotted")
+        assertFalse("A3" in c.coveredLineIds, "an expired line must be released to the projector")
+    }
+
+    @Test
+    fun timestamplessTrainIsStaleWithNoAgeNeverLive() {
+        val c = classifyLiveTrains(listOf(train("t1", "A4", ageSeconds = null)), now)
+        assertEquals(1, c.markers.size)
+        assertEquals(LiveVehicleState.STALE, c.markers[0].state)
+        assertNull(c.markers[0].ageSeconds)
+    }
+
+    @Test
+    fun mixedFleetPartitionsCorrectly() {
+        val c = classifyLiveTrains(
+            listOf(
+                train("t1", "A1", ageSeconds = 10),    // LIVE
+                train("t2", "A2", ageSeconds = 300),   // STALE
+                train("t3", "A3", ageSeconds = 1000),  // EXPIRED -> dropped
+                train("t4", "A4", ageSeconds = null),  // STALE (no ts)
+            ),
+            now,
+        )
+        assertEquals(listOf("A1", "A2", "A4"), c.markers.map { it.train.lineId })
+        assertEquals(setOf("A1", "A2", "A4"), c.coveredLineIds)
+        assertFalse("A3" in c.coveredLineIds)
+    }
+}


### PR DESCRIPTION
Part 1 of 3 (Android/KMP + shared core) of one cross-platform change: **a real-GPS vehicle position must never be shown as a plain live dot once it has aged.** Companion PRs: iOS and web (same freshness rule, mirrored). Docs: `docs/OFFLINE_FIRST_AND_DATA_SOURCES.md`.

## Why
On the map, a stale/offline `/api/trains` feed left the last suburban GPS markers pinned with full pulsing "live" styling — the exact "old position shown as live" the offline-first data-status rules forbid. Root cause on KMP: `LiveSuburbanTrain.updatedAt` was hardcoded `""`, so a marker could never age; a frozen ghost also **blocked its line's offline schedule projection** (`coveredByLive`).

## How
- **Shared classifier** `core/model/status/LiveVehicleFreshness.kt`: age of the vehicle's own timestamp → `LIVE` (≤90s) / `STALE` (90–600s) / `EXPIRED` (>600s). Missing/far-future ts → STALE, never LIVE.
- **`RailwayGovLiveTrackerService`**: stamp `updatedAt` from the feed's snapshot time.
- **`MapViewModel`** (`classifyLiveTrains`): recompute each 1s sim tick → `visibleLiveTrains` (EXPIRED dropped, STALE tagged); `coveredByLive` counts only non-expired, so a dropped feed hands the line back to the projector.
- **`PlatformMapView.android`**: render `visibleLiveTrains`, mute STALE, drop EXPIRED. Sheet, count badge and `FallbackMapView` follow the same list.
- **Livestream** (`MapScreen`): "Watch Live" shows only while the train is freshly tracked; otherwise a clear "requires an internet connection" state (no dead external link offline), mirroring iOS.

## Tests / verification
- `LiveVehicleFreshnessTest` (12) + `LiveTrainClassificationTest` (5), both green.
- `:core:model` + `:core:network` + `:feature:map` unit tests pass; `:androidApp:assembleDebug` **BUILD SUCCESSFUL**.
- Transition (LIVE→STALE→EXPIRED) is proven by deterministic clock-injected unit tests. No local emulator UI capture (CI-tier for Android runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)