### PR TITLE
feat(web): honest live-train marker staleness on the map

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -2686,6 +2686,14 @@
 
         pollOnce();
         setInterval(pollOnce, POLL_INTERVAL_MS);
+        // Re-render from the last snapshot on a timer so the fleet ages out even
+        // with NO new data (offline / dropped feed): the poll only redraws on a
+        // successful fetch, so without this a stale batch would keep its fresh
+        // "live" styling until the next success. Cheap (re-uses lastLiveTrains)
+        // and idempotent - renderLiveTrains recomputes the batch freshness.
+        setInterval(() => {
+            if (lastLiveTrains && lastLiveTrains.length) renderLiveTrains(lastLiveTrains);
+        }, 15_000);
     }
 
     function updateLiveTrains(trainsFromApi, updatedAt) {
@@ -2720,21 +2728,39 @@
         renderLiveTrains(trains);
     }
 
-    // Honest freshness for the real telematics batch. Always shows the age; the
-    // chip colour signals fresh (live) vs stale (shown as an estimate). These
-    // are observed GPS trains, so this is the age of real data, not a schedule
-    // projection. The 90s window mirrors the DataStatus contract; a small future
-    // clock skew is tolerated rather than shown as an error. Uses epoch math
+    // Pure classification of the real-telematics batch by the age of its single
+    // `updatedAt`, mirroring the KMP `classifyLiveVehicle` and iOS
+    // `LiveVehicleFreshnessRule` (90s fresh window, 600s expiry). Returns
+    // { state, ageSec } where state is "live" | "stale" | "expired" | "unknown".
+    // The /api/trains feed carries ONE updatedAt for the whole snapshot (no
+    // per-train GPS timestamps), so the fleet ages as a batch. Epoch math
     // (Date.now vs the absolute updatedAt), not athensNow(), because this is a
     // duration between two absolute timestamps, not a wall-clock comparison.
+    const LIVE_FRESH_WINDOW_SEC = 90;
+    const LIVE_EXPIRY_SEC = 600;
+    function classifyLiveBatch(updatedAtIso, nowMs) {
+        if (!updatedAtIso) return { state: "unknown", ageSec: null };
+        const parsed = Date.parse(updatedAtIso);
+        if (isNaN(parsed)) return { state: "unknown", ageSec: null };
+        const ageSec = Math.round((nowMs - parsed) / 1000);
+        if (ageSec < 0) {
+            // Tolerate a small device clock skew as just-now; distrust a far-future stamp.
+            return -ageSec <= 120 ? { state: "live", ageSec: 0 } : { state: "unknown", ageSec: null };
+        }
+        if (ageSec <= LIVE_FRESH_WINDOW_SEC) return { state: "live", ageSec };
+        if (ageSec <= LIVE_EXPIRY_SEC) return { state: "stale", ageSec };
+        return { state: "expired", ageSec };
+    }
+
+    // Honest freshness for the real telematics batch, for the panel header chip.
+    // Always shows the age; the chip colour signals fresh (live) vs aged (shown
+    // as an estimate). These are observed GPS trains, so this is the age of real
+    // data, not a schedule projection.
     function liveBatchFreshness() {
-        const iso = liveTrainsUpdatedAt;
-        if (!iso) return { mod: "estimated", label: t("live_unknown_age") };
-        const ageSec = Math.round((Date.now() - Date.parse(iso)) / 1000);
-        if (isNaN(ageSec)) return { mod: "estimated", label: t("live_unknown_age") };
-        const human = Math.abs(ageSec) < 90 ? `${Math.max(ageSec, 0)}s` : `${Math.round(ageSec / 60)}m`;
-        const fresh = ageSec <= 90 && ageSec > -120;
-        return { mod: fresh ? "live" : "estimated", label: `${t("live")} · ${t("updated_ago", { t: human })}` };
+        const c = classifyLiveBatch(liveTrainsUpdatedAt, Date.now());
+        if (c.state === "unknown") return { mod: "estimated", label: t("live_unknown_age") };
+        const human = c.ageSec < 90 ? `${Math.max(c.ageSec, 0)}s` : `${Math.round(c.ageSec / 60)}m`;
+        return { mod: c.state === "live" ? "live" : "estimated", label: `${t("live")} · ${t("updated_ago", { t: human })}` };
     }
 
     function renderLiveTrains(trains) {
@@ -2742,6 +2768,13 @@
         if (!map.hasLayer(liveTrainLayer)) liveTrainLayer.addTo(map);
         liveTrainLayer.clearLayers();
         liveTrainMarkers.clear();
+        // Age of the real-GPS batch. Once STALE the markers are drawn
+        // de-emphasised (never pulsing "live"); once EXPIRED they are not drawn
+        // at all, so a dead/offline feed hands the map back to the schedule
+        // projector instead of freezing a fake-live fleet. Recomputed on every
+        // call, and a timer re-renders from lastLiveTrains so this ages with no
+        // new data.
+        const batch = classifyLiveBatch(liveTrainsUpdatedAt, Date.now());
 
         if (trains.length) {
             // Head the real-telematics section with its batch freshness, so a
@@ -2791,9 +2824,23 @@
         // the live markers must follow the identical rule. The zoomend handler
         // re-runs this from lastLiveTrains, so zooming back in restores every
         // marker at its true coordinate (Piraeus, Rentis, Koropi…) untouched.
+        // An EXPIRED batch is too old to plot as real positions at all: leave the
+        // layer cleared so the schedule-projected dots take the map back rather
+        // than pinning a frozen "live" fleet. (The panel above still shows the
+        // aged batch chip so the list is not silently emptied.)
+        if (batch.state === "expired") {
+            return;
+        }
+
         if (window.__syrmosVehiclesHidden || map.getZoom() < MAP_TOKENS.majorHubMinZoom) {
             return;
         }
+
+        // A STALE (or unknown-age) batch is the last-known position, not a current
+        // one: draw every marker de-emphasised so an aged GPS fix never reads as a
+        // live, pulsing dot - the exact "old position shown as live" the
+        // data-status rules forbid.
+        const staleBatch = batch.state !== "live";
 
         for (const train of trains) {
             const line = lineMap.get(train.lineId);
@@ -2803,17 +2850,19 @@
             // faded) so it never reads as a normal boardable train, matching the
             // detail sheet. Parked/yard vehicles are withheld server-side.
             const notInService = train.inService === false || train.status === "position_only";
-            const lineColor = notInService ? "#9CA3AF" : (line ? line.color : "#7C4DFF");
+            // De-emphasise for EITHER reason: not boardable, OR the batch is aged.
+            const muted = notInService || staleBatch;
+            const lineColor = muted ? "#9CA3AF" : (line ? line.color : "#7C4DFF");
             // Custom divIcon so suburban trains are clearly distinguishable
             // from simulated metro/tram dots: pulsing ring + line-id badge.
             const icon = L.divIcon({
-                className: notInService ? "live-train-marker live-train-marker--muted" : "live-train-marker",
+                className: muted ? "live-train-marker live-train-marker--muted" : "live-train-marker",
                 html: `
-                    ${notInService ? "" : `<span class="live-train-marker__pulse" style="border-color:${lineColor}"></span>`}
-                    <span class="live-train-marker__core" style="background:${lineColor}${notInService ? ";opacity:0.55" : ""}">
-                        <span class="live-train-marker__glyph">${notInService ? "⏸" : "🚆"}</span>
+                    ${muted ? "" : `<span class="live-train-marker__pulse" style="border-color:${lineColor}"></span>`}
+                    <span class="live-train-marker__core" style="background:${lineColor}${muted ? ";opacity:0.55" : ""}">
+                        <span class="live-train-marker__glyph">${notInService ? "⏸" : (staleBatch ? "🕒" : "🚆")}</span>
                     </span>
-                    <span class="live-train-marker__badge" style="background:${lineColor}${notInService ? ";opacity:0.7" : ""}">${train.lineId}</span>
+                    <span class="live-train-marker__badge" style="background:${lineColor}${muted ? ";opacity:0.7" : ""}">${train.lineId}</span>
                 `,
                 iconSize: [44, 56],
                 iconAnchor: [22, 22],
@@ -2825,7 +2874,7 @@
             const marker = L.marker([train.lat, train.lng], {
                 icon,
                 keyboard: false,
-                zIndexOffset: notInService ? 400 : 1000,
+                zIndexOffset: muted ? 400 : 1000,
             }).addTo(liveTrainLayer);
             marker.bindTooltip(
                 `${line ? line.name : train.lineId} ${train.trainNumber}<br>${train.origin || "?"} → ${train.destination || "?"}`,

--- a/web-tests/live-train-freshness.test.js
+++ b/web-tests/live-train-freshness.test.js
@@ -1,0 +1,95 @@
+'use strict';
+// Real-GPS live-train marker freshness on the web map. Mirrors the KMP
+// LiveVehicleFreshnessTest and iOS test_freshness_classifier_* so all three
+// clients age a live position out identically (90s fresh window, 600s expiry):
+// a stale batch is drawn de-emphasised, an expired one is dropped, and neither
+// is ever shown as a plain pulsing "live" dot.
+//
+// classifyLiveBatch lives inside the web-map IIFE (not requireable), so it is
+// brace-extracted from source and evaluated - genuine executable coverage of
+// the shipped function, plus static-source guardrails for the marker wiring.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const js = fs.readFileSync(path.join(RES, 'web-map.js'), 'utf8');
+
+// Pull the two window constants + the classifyLiveBatch function out of the IIFE
+// by balanced-brace matching, and evaluate them in isolation.
+function extractFunction(src, name) {
+  const start = src.indexOf('function ' + name);
+  assert.notEqual(start, -1, `function ${name} not found in source`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces extracting ${name}`);
+}
+
+const freshConst = (js.match(/const LIVE_FRESH_WINDOW_SEC = (\d+);/) || [])[1];
+const expiryConst = (js.match(/const LIVE_EXPIRY_SEC = (\d+);/) || [])[1];
+const classifyLiveBatch = new Function(
+  `const LIVE_FRESH_WINDOW_SEC = ${freshConst};
+   const LIVE_EXPIRY_SEC = ${expiryConst};
+   ${extractFunction(js, 'classifyLiveBatch')}
+   return classifyLiveBatch;`
+)();
+
+const NOW = 1_000_000_000; // fixed ms clock
+const iso = (ageSec) => new Date(NOW - ageSec * 1000).toISOString();
+
+test('windows match the cross-platform contract (90s fresh, 600s expiry)', () => {
+  assert.equal(freshConst, '90');
+  assert.equal(expiryConst, '600');
+});
+
+test('fresh batch is live', () => {
+  assert.equal(classifyLiveBatch(iso(10), NOW).state, 'live');
+  assert.equal(classifyLiveBatch(iso(90), NOW).state, 'live', '90s boundary still live');
+});
+
+test('aged batch is stale, past 10 min is expired', () => {
+  assert.equal(classifyLiveBatch(iso(91), NOW).state, 'stale');
+  assert.equal(classifyLiveBatch(iso(300), NOW).state, 'stale');
+  assert.equal(classifyLiveBatch(iso(600), NOW).state, 'stale', '600s boundary still stale');
+  assert.equal(classifyLiveBatch(iso(601), NOW).state, 'expired');
+  assert.equal(classifyLiveBatch(iso(300), NOW).ageSec, 300);
+});
+
+test('missing / malformed / far-future timestamps never read as live', () => {
+  assert.equal(classifyLiveBatch(null, NOW).state, 'unknown');
+  assert.equal(classifyLiveBatch('', NOW).state, 'unknown');
+  assert.equal(classifyLiveBatch('not-a-date', NOW).state, 'unknown');
+  // small clock skew tolerated as just-now
+  assert.equal(classifyLiveBatch(iso(-60), NOW).state, 'live');
+  // far future is not trusted
+  assert.equal(classifyLiveBatch(iso(-100000), NOW).state, 'unknown');
+});
+
+// --- static-source guardrails: the marker wiring uses the batch state ---
+
+test('renderLiveTrains drops an EXPIRED batch instead of plotting ghosts', () => {
+  assert.match(js, /const batch = classifyLiveBatch\(liveTrainsUpdatedAt, Date\.now\(\)\);/,
+    'renderLiveTrains must classify the batch');
+  assert.match(js, /if \(batch\.state === "expired"\) \{\s*return;/,
+    'an expired batch must skip drawing markers');
+});
+
+test('a STALE batch mutes every marker (never pulsing live)', () => {
+  assert.match(js, /const staleBatch = batch\.state !== "live";/, 'staleBatch flag missing');
+  assert.match(js, /const muted = notInService \|\| staleBatch;/, 'markers must mute on a stale batch');
+  // the pulse ring is only emitted when NOT muted
+  assert.match(js, /\$\{muted \? "" : `<span class="live-train-marker__pulse"/, 'pulse must be gated on !muted');
+});
+
+test('a timer re-renders from the last snapshot so markers age with no new data', () => {
+  assert.match(js, /if \(lastLiveTrains && lastLiveTrains\.length\) renderLiveTrains\(lastLiveTrains\);/,
+    're-render timer body missing');
+});


### PR DESCRIPTION
Part 3 of 3 (web) of one cross-platform change: **a real-GPS vehicle position must never be shown as a plain live dot once it has aged.** Companion PRs: #141 (Android/KMP + shared core) and the iOS PR. Same freshness rule (90s / 600s), mirrored in JS.

## Why
`renderLiveTrains` only ran on a successful poll, so a stale/failed `/api/trains` feed froze the last real-GPS markers with full pulsing "live" styling on the map; only the panel header chip degraded. The map is the surface that most implies "this is where the train is now."

## How
- **`classifyLiveBatch(updatedAtIso, nowMs)`**: the feed carries one batch `updatedAt`, so the fleet ages as a batch → `live` / `stale` / `expired` / `unknown` (mirrors KMP + iOS, 90s/600s). `liveBatchFreshness` now derives from it.
- **`renderLiveTrains`**: a STALE (or unknown-age) batch mutes every marker (grey, no pulse); an EXPIRED batch is not drawn, handing the map back to the schedule projector.
- **15s re-render timer** from the last snapshot, so markers age even with no successful poll.

## Tests / verification
- `web-tests/live-train-freshness.test.js`: brace-extracts and **executes the shipped `classifyLiveBatch`** (bucket boundaries, missing/malformed/far-future ts) + static-source guardrails on the marker/timer wiring.
- Full web suite **68 tests, 0 fail**; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)