### PR TITLE
feat(web): offline Service Worker — true offline page load

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -551,5 +551,15 @@
 <script src="/web-planner.js"></script>
 <script src="/web-go-panel.js"></script>
 <script src="/web-map.js"></script>
+<!-- Offline Service Worker: caches the app shell + bundled seed so a reload or a
+     dropped connection keeps the app usable with no network. Registered on load
+     so it never competes with the first paint's resource fetches. -->
+<script>
+    if ("serviceWorker" in navigator) {
+        window.addEventListener("load", function () {
+            navigator.serviceWorker.register("/sw.js").catch(function () { /* offline-first is best-effort */ });
+        });
+    }
+</script>
 </body>
 </html>

--- a/composeApp/src/wasmJsMain/resources/sw.js
+++ b/composeApp/src/wasmJsMain/resources/sw.js
@@ -1,0 +1,177 @@
+/*
+ * Syrmos offline Service Worker.
+ *
+ * Goal: after one successful load the web app opens and runs with NO network -
+ * the page shell, the hand-written JS, the bundled seed (stations / lines /
+ * routes / schedules-v2 / offsets) and the map overlays all come from cache, and
+ * a reload or a mid-session connectivity drop never leaves a blank screen. Live
+ * data still enriches the same UI when online.
+ *
+ * GitHub Pages ships the app bundles content-hashed (composeApp.<hash>.js,
+ * web-map.<hash>.js, web-map.<hash>.css) and rewrites index.html to point at
+ * them. The SW therefore does NOT precache those by name - it runtime-caches
+ * whatever the page actually loads, so a new deploy's fresh hashes are picked up
+ * automatically. Navigations are network-first (an online user always gets the
+ * latest index.html -> latest hashes), so there is no stale-app trap.
+ */
+const VERSION = "v1";
+const CACHE = `syrmos-${VERSION}`;
+const TILE_CACHE = `syrmos-tiles-${VERSION}`;
+const TILE_MAX = 300; // opportunistic, capped: only tiles the user actually viewed
+
+// Stable, non-content-hashed critical assets, known by name. The hashed bundles
+// are intentionally absent (runtime-cached instead). One failed entry must not
+// fail the whole install, so each is fetched individually.
+const PRECACHE = [
+  "/",
+  "/index.html",
+  "/manifest.webmanifest",
+  "/favicon.png",
+  "/design-tokens.css",
+  "/web-ariadne-rag.js",
+  "/web-ariadne.js",
+  "/web-router.js",
+  "/web-nav.js",
+  "/web-go.js",
+  "/web-airport.js",
+  "/web-departures.js",
+  "/web-planner.js",
+  "/web-go-panel.js",
+  "/shapes.json",
+  "/files/seed/stations.json",
+  "/files/seed/schedules-v2/lines.json",
+  "/files/seed/routes.json",
+  "/files/seed/service_patterns.json",
+  "/files/seed/station-offsets.json",
+  "/icons/vehicles/manifest.json",
+  "/icons/stations/manifest.json",
+  // Leaflet from its CDN (cross-origin; stored as an opaque response).
+  "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js",
+  "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE);
+    await Promise.all(PRECACHE.map(async (url) => {
+      try {
+        const res = await fetch(new Request(url, { cache: "reload" }));
+        if (res && (res.ok || res.type === "opaque")) await cache.put(url, res.clone());
+      } catch (_) { /* a missing optional asset must not abort install */ }
+    }));
+    await self.skipWaiting();
+  })());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(
+      keys
+        .filter((k) => (k.startsWith("syrmos-") && k !== CACHE && k !== TILE_CACHE))
+        .map((k) => caches.delete(k)),
+    );
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+  if (req.method !== "GET") return;
+  let url;
+  try { url = new URL(req.url); } catch (_) { return; }
+
+  // 1) HTML navigations: network-first so a new deploy lands; cached shell offline.
+  if (req.mode === "navigate") {
+    event.respondWith(networkFirstNavigation(req));
+    return;
+  }
+  // 2) Live API: network-first, fall back to the last cached response (stale) or
+  //    an honest 503 the app's own .catch/!res.ok handlers already expect.
+  if (url.hostname === "api-syrmos.peterdsp.dev") {
+    event.respondWith(networkFirstApi(req));
+    return;
+  }
+  // 3) Map tiles: cache-first into a capped, separate cache (opportunistic - only
+  //    tiles the user actually loaded; never a bulk pre-download).
+  if (isTile(url)) {
+    event.respondWith(cacheFirstTile(req));
+    return;
+  }
+  // 4) Everything else (same-origin assets + seed, cross-origin Leaflet):
+  //    cache-first, then network (and cache it for next time).
+  event.respondWith(cacheFirst(req));
+});
+
+function isTile(url) {
+  const h = url.hostname;
+  return (
+    h.includes("arcgisonline.com") ||
+    h.includes("basemaps.cartocdn.com") ||
+    h.includes("tile.openstreetmap.org") ||
+    /\/tile\/\d+\//.test(url.pathname)
+  );
+}
+
+async function networkFirstNavigation(req) {
+  const cache = await caches.open(CACHE);
+  try {
+    const res = await fetch(req);
+    if (res && res.ok) cache.put("/index.html", res.clone());
+    return res;
+  } catch (_) {
+    return (await cache.match("/index.html")) || (await cache.match("/")) || Response.error();
+  }
+}
+
+async function networkFirstApi(req) {
+  const cache = await caches.open(CACHE);
+  try {
+    const res = await fetch(req);
+    if (res && res.ok) cache.put(req, res.clone());
+    return res;
+  } catch (_) {
+    const cached = await cache.match(req);
+    if (cached) return cached;
+    return new Response(JSON.stringify({ offline: true }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+
+async function cacheFirst(req) {
+  const cache = await caches.open(CACHE);
+  const cached = await cache.match(req);
+  if (cached) return cached;
+  try {
+    const res = await fetch(req);
+    if (res && (res.ok || res.type === "opaque")) cache.put(req, res.clone());
+    return res;
+  } catch (_) {
+    return cached || Response.error();
+  }
+}
+
+async function cacheFirstTile(req) {
+  const cache = await caches.open(TILE_CACHE);
+  const cached = await cache.match(req);
+  if (cached) return cached;
+  try {
+    const res = await fetch(req);
+    if (res && (res.ok || res.type === "opaque")) {
+      await cache.put(req, res.clone());
+      trimCache(TILE_CACHE, TILE_MAX);
+    }
+    return res;
+  } catch (_) {
+    return cached || Response.error();
+  }
+}
+
+async function trimCache(name, max) {
+  const cache = await caches.open(name);
+  const keys = await cache.keys();
+  if (keys.length <= max) return;
+  for (const key of keys.slice(0, keys.length - max)) await cache.delete(key);
+}

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -651,8 +651,13 @@
         if (activeTrainSheet) showTrainSheet(activeTrainSheet.kind, activeTrainSheet.train);
     });
 
+    // Each core seed fetch carries its own .catch returning an empty default, so
+    // a first-ever visit with NO network (before the Service Worker has cached
+    // the seed) degrades to an empty-but-alive map instead of rejecting the whole
+    // init and rendering a blank screen. Once the SW is installed these are
+    // served from cache offline and the .catch never fires.
     const [stations, lines, routes, servicePatterns, vehicleManifest] = await Promise.all([
-        fetch("/files/seed/stations.json").then((r) => r.json()),
+        fetch("/files/seed/stations.json").then((r) => r.json()).catch(() => []),
         // schedules-v2 is the generator's payload and the single source of truth
         // for lines. The legacy flat seed/lines.json was transcribed from
         // hardcoded Swift by a script broken since June 2026, so it carries
@@ -662,9 +667,10 @@
         fetch("/files/seed/schedules-v2/lines.json")
             .then((r) => r.json())
             .then((d) => (Array.isArray(d?.lines) && d.lines.length ? d.lines : Promise.reject()))
-            .catch(() => fetch("/files/seed/lines.json").then((r) => r.json())),
-        fetch("/files/seed/routes.json").then((r) => r.json()),
-        fetch("/files/seed/service_patterns.json").then((r) => r.json()),
+            .catch(() => fetch("/files/seed/lines.json").then((r) => r.json()))
+            .catch(() => []),
+        fetch("/files/seed/routes.json").then((r) => r.json()).catch(() => []),
+        fetch("/files/seed/service_patterns.json").then((r) => r.json()).catch(() => ({})),
         fetch("/icons/vehicles/manifest.json").then((r) => r.json()).catch(() => ({ directional_icons: [] })),
     ]);
 

--- a/web-tests/service-worker-behavior.test.js
+++ b/web-tests/service-worker-behavior.test.js
@@ -1,0 +1,148 @@
+'use strict';
+// Executes the REAL sw.js event handlers in Node against a mocked Cache API +
+// controllable fetch, to prove the offline behaviour directly (no browser
+// needed): install precaches the shell + seed, an offline navigation is served
+// from cache, an offline asset is served from cache, the live API falls back to
+// a cached response or an honest 503, tiles go to a capped separate cache, and
+// activate purges stale caches. This is the runtime contract the browser relies
+// on, verified as a deterministic unit test.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SW_PATH = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources', 'sw.js');
+
+// --- Minimal, spec-faithful mocks -------------------------------------------
+class ResMock {
+  constructor(body, init = {}) {
+    this.body = body;
+    this.status = init.status || 200;
+    this.ok = this.status >= 200 && this.status < 300;
+    this.type = init.type || 'basic';
+    this._headers = init.headers || {};
+  }
+  clone() { return new ResMock(this.body, { status: this.status, type: this.type, headers: this._headers }); }
+  async text() { return this.body; }
+}
+class ReqMock {
+  constructor(url, init = {}) { this.url = typeof url === 'string' ? url : url.url; this.method = init.method || 'GET'; this.mode = init.mode; }
+}
+const keyOf = (req) => (typeof req === 'string' ? req : req.url);
+class CacheMock {
+  constructor() { this.store = new Map(); }
+  async match(req) { return this.store.get(keyOf(req)); }
+  async put(req, res) { this.store.set(keyOf(req), res); }
+  async keys() { return [...this.store.keys()].map((k) => ({ url: k })); }
+  async delete(req) { return this.store.delete(keyOf(req)); }
+}
+function makeCaches() {
+  const map = new Map();
+  return {
+    map,
+    async open(n) { if (!map.has(n)) map.set(n, new CacheMock()); return map.get(n); },
+    async keys() { return [...map.keys()]; },
+    async delete(n) { return map.delete(n); },
+    async match(req) { for (const c of map.values()) { const hit = await c.match(req); if (hit) return hit; } return undefined; },
+  };
+}
+
+// Load a fresh SW instance with an injected fetch. `net.online` toggles
+// connectivity; `net.body(url)` supplies the network response body.
+function loadSW(net) {
+  const handlers = {};
+  const self = {
+    addEventListener: (t, h) => { handlers[t] = h; },
+    skipWaiting: async () => {},
+    clients: { claim: async () => {} },
+  };
+  const caches = makeCaches();
+  const fetchMock = async (req) => {
+    if (!net.online) throw new Error('offline');
+    const url = keyOf(req);
+    const opaque = url.startsWith('https://unpkg.com') || url.includes('arcgisonline.com');
+    return new ResMock(net.body ? net.body(url) : `body:${url}`, opaque ? { type: 'opaque', status: 0 } : { status: 200 });
+  };
+  const swText = fs.readFileSync(SW_PATH, 'utf8');
+  // eslint-disable-next-line no-new-func
+  new Function('self', 'caches', 'fetch', 'Response', 'Request', 'URL', swText)(
+    self, caches, fetchMock, ResMock, ReqMock, URL,
+  );
+  return { handlers, caches, self };
+}
+async function install(h) { let p; h.install({ waitUntil: (x) => { p = x; } }); await p; }
+async function activate(h) { let p; h.activate({ waitUntil: (x) => { p = x; } }); await p; }
+async function doFetch(h, request) { let r; h.fetch({ request, respondWith: (x) => { r = x; } }); return r ? await r : undefined; }
+const shellCache = (caches) => caches.map.get('syrmos-v1');
+const tileCache = (caches) => caches.map.get('syrmos-tiles-v1');
+
+// --- Tests ------------------------------------------------------------------
+
+test('install precaches the app shell and the bundled seed', async () => {
+  const { handlers, caches } = loadSW({ online: true });
+  await install(handlers);
+  const c = shellCache(caches);
+  assert.ok(await c.match('/index.html'), 'index.html precached');
+  assert.ok(await c.match('/files/seed/schedules-v2/lines.json'), 'schedules seed precached');
+  assert.ok(await c.match('/files/seed/stations.json'), 'stations seed precached');
+  assert.ok(await c.match('/web-map.js') || await c.match('/design-tokens.css'), 'shell assets precached');
+});
+
+test('OFFLINE navigation is served the cached app shell (no blank page)', async () => {
+  const net = { online: true };
+  const { handlers } = loadSW(net);
+  await install(handlers);
+  net.online = false; // connection drops
+  const res = await doFetch(handlers, new ReqMock('http://localhost:8791/', { mode: 'navigate' }));
+  assert.ok(res, 'a response was produced offline');
+  assert.equal(res.ok, true, 'offline navigation returns the cached shell, not an error');
+});
+
+test('OFFLINE static asset is served from cache after a prior online load', async () => {
+  const net = { online: true };
+  const { handlers } = loadSW(net);
+  await install(handlers);
+  const url = 'http://localhost:8791/web-map.612c4bf81048.js';
+  const online = await doFetch(handlers, new ReqMock(url)); // caches on first (online) load
+  assert.equal(online.ok, true);
+  net.online = false;
+  const offline = await doFetch(handlers, new ReqMock(url));
+  assert.ok(offline && offline.ok, 'the hashed bundle is served from cache offline');
+});
+
+test('live API is network-first and falls back to a cached response, else 503', async () => {
+  const net = { online: true };
+  const { handlers } = loadSW(net);
+  await install(handlers);
+  const url = 'https://api-syrmos.peterdsp.dev/api/trains?x=1';
+  const live = await doFetch(handlers, new ReqMock(url));
+  assert.equal(live.ok, true, 'online: live response');
+  net.online = false;
+  const cached = await doFetch(handlers, new ReqMock(url));
+  assert.ok(cached && cached.ok, 'offline: last cached API response is served');
+  const unseen = await doFetch(handlers, new ReqMock('https://api-syrmos.peterdsp.dev/api/never-fetched'));
+  assert.equal(unseen.status, 503, 'offline + never cached: honest 503 the app handles');
+});
+
+test('tiles go to a capped, separate cache (opportunistic, not the shell)', async () => {
+  const net = { online: true };
+  const { handlers, caches } = loadSW(net);
+  await install(handlers);
+  const tileUrl = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Light_Gray_Base/MapServer/tile/7/45/72';
+  await doFetch(handlers, new ReqMock(tileUrl));
+  assert.ok(tileCache(caches), 'a dedicated tile cache exists');
+  assert.ok(await tileCache(caches).match(tileUrl), 'the viewed tile is cached');
+  assert.equal(await shellCache(caches).match(tileUrl), undefined, 'tiles do not pollute the shell cache');
+});
+
+test('activate purges stale caches from a previous version', async () => {
+  const { handlers, caches } = loadSW({ online: true });
+  await caches.open('syrmos-v0');          // a stale prior-version cache
+  await caches.open('syrmos-tiles-v0');
+  await install(handlers);
+  await activate(handlers);
+  const keys = await caches.keys();
+  assert.ok(!keys.includes('syrmos-v0'), 'stale shell cache deleted');
+  assert.ok(!keys.includes('syrmos-tiles-v0'), 'stale tile cache deleted');
+  assert.ok(keys.includes('syrmos-v1'), 'current cache retained');
+});

--- a/web-tests/service-worker.test.js
+++ b/web-tests/service-worker.test.js
@@ -1,0 +1,81 @@
+'use strict';
+// The offline Service Worker: after one load, the app shell + bundled seed are
+// served from cache so a reload / dropped connection never blanks the page.
+// isTile() is pure and brace-extracted for executable coverage; the caching
+// strategies + registration are asserted as static-source guardrails (the SW
+// relies on ServiceWorker globals that node does not provide).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const sw = fs.readFileSync(path.join(RES, 'sw.js'), 'utf8');
+const html = fs.readFileSync(path.join(RES, 'index.html'), 'utf8');
+const map = fs.readFileSync(path.join(RES, 'web-map.js'), 'utf8');
+
+function extractFunction(src, name) {
+  const start = src.indexOf('function ' + name);
+  assert.notEqual(start, -1, `function ${name} not found`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) return src.slice(start, i + 1); }
+  }
+  throw new Error(`unbalanced braces extracting ${name}`);
+}
+
+const isTile = new Function(`${extractFunction(sw, 'isTile')}; return isTile;`)();
+
+test('isTile matches basemap tile hosts, not app/api requests', () => {
+  const tile = (u) => isTile(new URL(u));
+  assert.equal(tile('https://server.arcgisonline.com/ArcGIS/rest/services/World_Light_Gray_Base/MapServer/tile/7/45/72'), true);
+  assert.equal(tile('https://basemaps.cartocdn.com/light_all/7/72/45.png'), true);
+  assert.equal(tile('https://a.tile.openstreetmap.org/7/72/45.png'), true);
+  assert.equal(tile('https://api-syrmos.peterdsp.dev/api/trains'), false);
+  assert.equal(tile('https://syrmos.peterdsp.dev/files/seed/stations.json'), false);
+  assert.equal(tile('https://syrmos.peterdsp.dev/web-map.abc123.js'), false);
+});
+
+test('index.html registers the service worker on load', () => {
+  assert.match(html, /navigator\.serviceWorker\.register\("\/sw\.js"\)/, 'SW registration missing');
+  assert.match(html, /"serviceWorker" in navigator/, 'SW feature-detect missing');
+});
+
+test('SW precaches the app shell and the bundled seed', () => {
+  for (const asset of [
+    '"/"', '"/index.html"', '"/design-tokens.css"', '"/shapes.json"',
+    '"/files/seed/stations.json"',
+    '"/files/seed/schedules-v2/lines.json"',
+    '"/files/seed/routes.json"',
+    '"/files/seed/station-offsets.json"',
+  ]) {
+    assert.ok(sw.includes(asset), `precache must include ${asset}`);
+  }
+});
+
+test('SW uses network-first for navigations and the live API, cache-first otherwise', () => {
+  assert.match(sw, /req\.mode === "navigate"[\s\S]*?networkFirstNavigation/, 'navigations must be network-first');
+  assert.match(sw, /url\.hostname === "api-syrmos\.peterdsp\.dev"[\s\S]*?networkFirstApi/, 'API must be network-first');
+  assert.match(sw, /if \(isTile\(url\)\)[\s\S]*?cacheFirstTile/, 'tiles must route to the capped tile cache');
+  assert.match(sw, /function cacheFirst\(/, 'cache-first fallback missing');
+});
+
+test('SW versions its caches and cleans up old ones on activate', () => {
+  assert.match(sw, /const VERSION = "v\d+";/, 'versioned cache name missing');
+  assert.match(sw, /caches\.delete/, 'activate must delete stale caches');
+  assert.match(sw, /skipWaiting\(\)/, 'skipWaiting missing');
+  assert.match(sw, /clients\.claim\(\)/, 'clients.claim missing');
+});
+
+test('tile cache is capped (opportunistic, never a bulk download)', () => {
+  assert.match(sw, /const TILE_MAX = \d+;/, 'tile cap constant missing');
+  assert.match(sw, /trimCache\(TILE_CACHE, TILE_MAX\)/, 'tile cache must be trimmed');
+});
+
+test('web-map.js core seed fetches degrade instead of rejecting init offline', () => {
+  assert.match(map, /fetch\("\/files\/seed\/stations\.json"\)\.then\(\(r\) => r\.json\(\)\)\.catch\(\(\) => \[\]\)/, 'stations.json needs a .catch');
+  assert.match(map, /fetch\("\/files\/seed\/routes\.json"\)\.then\(\(r\) => r\.json\(\)\)\.catch\(\(\) => \[\]\)/, 'routes.json needs a .catch');
+  assert.match(map, /fetch\("\/files\/seed\/service_patterns\.json"\)\.then\(\(r\) => r\.json\(\)\)\.catch\(\(\) => \(\{\}\)\)/, 'service_patterns.json needs a .catch');
+});


### PR DESCRIPTION
The web app had **no Service Worker**, so a reload or a dropped connection blanked the page and a cold start depended on the network — the biggest remaining offline-first gap on web (the native apps already bundle a full seed and launch offline). This adds one.

## Why
GitHub Pages ships the app bundles content-hashed (`composeApp.<hash>.js`, `web-map.<hash>.js/.css`) and rewrites index.html to point at them, so the SW must **not** precache those by name.

## How (`sw.js`)
- **Precache** the stable app shell + bundled seed on install (stations / lines / routes / schedules-v2 / station-offsets / shapes / the web-*.js modules / Leaflet). One failed entry never aborts install.
- **Runtime-cache** the content-hashed bundles on first fetch, so a deploy's new hashes are picked up automatically (no stale precache list).
- **Strategies:** network-first navigations (an online user always gets the latest index.html → latest hashes; offline → cached shell), network-first live API with a stale-cache fallback then an honest 503 (live still enriches; offline uses the last response), cache-first for static assets, and a **capped, opportunistic tile cache** (only tiles the user actually viewed — never a bulk download).
- Versioned caches + activate cleanup + `skipWaiting`/`clients.claim`. Registered on load from index.html.
- **Seed init hardened** with a `.catch` so a first-ever offline visit (before the SW has cached anything) degrades to an empty-but-alive map instead of rejecting init and rendering blank.

## Tests / verification
- `web-tests/service-worker-behavior.test.js` **executes the real sw.js handlers** against a mocked Cache API + controllable fetch: install precaches shell+seed; an **offline navigation returns the cached shell** (no blank page); an offline hashed bundle is served from cache; the live API is network-first with a cached/503 fallback; tiles use a capped separate cache; activate purges stale caches.
- `web-tests/service-worker.test.js`: executable `isTile` + static-source guardrails (strategies, registration, precache list).
- Full web suite **81/81**; `node --check` clean. Built the real Pages bundle (`stageWebRelease` + `prepare-pages`) and served it locally: app renders, `/sw.js` served at web root with the right MIME + registration wired.

**Env note:** a live browser SW-install capture wasn't possible here — no Chromium is installed and the sandbox's instrumented browser cannot install Service Workers. The behavior is proven by executing the real handlers (above); the final in-browser confirmation is on the deployed site (DevTools → Application → Service Workers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)