### PR TITLE
feat(android): subtle map offline indicator + instant offline detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,20 @@ Product direction: Syrmos is a companion, not a schedule. Every feature is measu
 
 ## Unreleased
 
-Honest live-vehicle freshness on the map, and an offline-aware livestream, across
-every client. Answers the offline-first data-status rule that an aged position
-must never be shown as live. See [docs/OFFLINE_FIRST_AND_DATA_SOURCES.md](docs/OFFLINE_FIRST_AND_DATA_SOURCES.md).
+Honest live-vehicle freshness on the map, an offline-aware livestream, a web
+offline Service Worker, and a subtle map offline indicator, across every client.
+Answers the offline-first data-status rule that an aged position must never be
+shown as live, and that the app must say when it is running on schedule/cached
+data. See [docs/OFFLINE_FIRST_AND_DATA_SOURCES.md](docs/OFFLINE_FIRST_AND_DATA_SOURCES.md).
+
+- **Map offline indicator (iOS + Android + web).** A subtle, accessible pill on
+  the map appears when the device is offline OR no live data has arrived within
+  the freshness window (a device reporting "online" does not prove the API is
+  reachable), and hides the moment live data resumes. The map keeps working from
+  the bundled schedule + last-known data throughout; the pill never interrupts.
+  Android gained instant offline detection (`ConnectivityObserver.onLost` +
+  a shared `LiveDataFreshness.isNetworkAvailable` flag) and, in passing, a fix so
+  "hide vehicles" also clears the live-train layer.
 
 - **Live-GPS markers age out honestly (iOS + Android + web).** A real train/bus
   position is now classified by the age of its own `updatedAt`: fresh (<=90s)

--- a/androidApp/src/androidMain/kotlin/com/syrmos/android/ConnectivityObserver.kt
+++ b/androidApp/src/androidMain/kotlin/com/syrmos/android/ConnectivityObserver.kt
@@ -27,8 +27,18 @@ class ConnectivityObserver(context: Context) {
     private val callback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
             // A usable default network appeared (cold start while online, or an
-            // offline -> online transition). Ask the home surface to re-probe.
+            // offline -> online transition). Flag online and ask the home surface
+            // to re-probe.
+            LiveDataFreshness.setNetworkAvailable(true)
             LiveDataFreshness.requestRetry()
+        }
+
+        override fun onLost(network: Network) {
+            // The default network went away: flag offline instantly so the map's
+            // offline indicator appears without waiting for the freshness window
+            // to decay. Live polls keep running and recover on their own once
+            // onAvailable fires again.
+            LiveDataFreshness.setNetworkAvailable(false)
         }
     }
 

--- a/core/common/src/commonMain/kotlin/com/syrmos/core/common/DataFreshness.kt
+++ b/core/common/src/commonMain/kotlin/com/syrmos/core/common/DataFreshness.kt
@@ -59,12 +59,27 @@ object LiveDataFreshness {
     private val _retryRequested = MutableStateFlow(0L)
     val retryRequested: StateFlow<Long> = _retryRequested.asStateFlow()
 
+    /**
+     * Whether the device currently has a usable default network. Set by the
+     * platform connectivity observer (Android [ConnectivityObserver], iOS
+     * NWPathMonitor). Defaults to `true` so a platform that never reports
+     * connectivity behaves as before (freshness alone drives the offline state).
+     * This gives an INSTANT offline signal; freshness still catches the
+     * "online but the API is unreachable" case the spec calls out.
+     */
+    private val _isNetworkAvailable = MutableStateFlow(true)
+    val isNetworkAvailable: StateFlow<Boolean> = _isNetworkAvailable.asStateFlow()
+
     fun markLive(at: Instant = Clock.System.now()) {
         _lastLiveUpdate.value = at
     }
 
     fun requestRetry() {
         _retryRequested.value = Clock.System.now().epochSeconds
+    }
+
+    fun setNetworkAvailable(available: Boolean) {
+        _isNetworkAvailable.value = available
     }
 
     fun freshnessNow(windowSeconds: Long = FreshnessEvaluator.DEFAULT_WINDOW_SECONDS): DataFreshness =

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/LiveTrainClassification.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/LiveTrainClassification.kt
@@ -1,9 +1,20 @@
 package com.syrmos.feature.map
 
+import com.syrmos.core.common.DataFreshness
 import com.syrmos.core.model.status.LiveVehicleState
 import com.syrmos.core.model.status.classifyLiveVehicleIso
 import com.syrmos.core.model.transit.LiveSuburbanTrain
 import kotlinx.datetime.Instant
+
+/**
+ * The map's offline-indicator rule: show it when the device is offline OR no
+ * live data has arrived within the freshness window. Two honest signals - the
+ * connectivity flag is instant, and freshness catches the "device online but the
+ * API is unreachable" case the data-status rules call out (a device reporting
+ * "online" does not prove the API is reachable). Pure so it unit-tests.
+ */
+fun mapShowsOffline(isNetworkAvailable: Boolean, freshness: DataFreshness): Boolean =
+    !isNetworkAvailable || freshness != DataFreshness.LIVE
 
 /**
  * The stale-aware live-train fleet ready to plot, plus the set of line ids a

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapScreen.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapScreen.kt
@@ -116,9 +116,13 @@ fun MapScreen(
             )
         } else {
             PlatformMapView(
+                // Hide-vehicles must also clear visibleLiveTrains: the live-train
+                // renderer switched to it in #141, so zeroing only the raw
+                // liveTrains left GPS trains on the map when vehicles were hidden.
                 uiState = if (uiState.showTrains) uiState else uiState.copy(
                     simulatedTrains = emptyList(),
                     liveTrains = emptyList(),
+                    visibleLiveTrains = emptyList(),
                     busVehicles = emptyList(),
                 ),
                 onStationSelected = viewModel::selectStation,
@@ -134,6 +138,20 @@ fun MapScreen(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .statusBarsPadding()
+                    .zIndex(1f),
+            )
+        }
+
+        // Subtle, non-interrupting offline indicator. The map keeps working from
+        // the bundled schedule + last-known data; this just says so, and hides the
+        // moment live data resumes. Passive pill, never an alert.
+        if (uiState.mapOffline) {
+            com.syrmos.core.designsystem.component.OfflinePill(
+                message = L.RUNNING_OFFLINE.text(lang),
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .statusBarsPadding()
+                    .padding(start = 16.dp, top = 56.dp)
                     .zIndex(1f),
             )
         }

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
@@ -1,5 +1,7 @@
 package com.syrmos.feature.map
 
+import com.syrmos.core.common.DataFreshness
+import com.syrmos.core.common.LiveDataFreshness
 import com.syrmos.core.common.map.LatLng
 import com.syrmos.core.data.repository.LineGeometryRepositoryImpl
 import com.syrmos.core.data.repository.LineRepositoryImpl
@@ -89,6 +91,10 @@ data class MapUiState(
     // Live airport express-bus positions (X93/95/96/97) from the OASA telematics
     // feed. Plotted on the map beside the trains; blanked by the vehicles toggle.
     val busVehicles: List<AirportBusVehicle> = emptyList(),
+    // Subtle map offline indicator: true when the device is offline OR no live
+    // data has arrived within the freshness window. Recomputed on the sim tick so
+    // it flips within ~1s of losing/regaining live data.
+    val mapOffline: Boolean = false,
     val selectedTrain: LiveSuburbanTrain? = null,
     val selectedSimulatedTrain: SimulatedTrain? = null,
     val showTrains: Boolean = true,
@@ -319,10 +325,15 @@ class MapViewModel(
                         todayIso = currentAthensDate().toString(),
                     ).filter { it.lineId !in coveredByLive }
                     val visibleTrains = filtered + projected
+                    val offline = mapShowsOffline(
+                        isNetworkAvailable = LiveDataFreshness.isNetworkAvailable.value,
+                        freshness = LiveDataFreshness.freshnessNow(),
+                    )
                     _uiState.update { current ->
                         current.copy(
                             simulatedTrains = visibleTrains,
                             visibleLiveTrains = liveMarkers,
+                            mapOffline = offline,
                             selectedSimulatedTrain = current.selectedSimulatedTrain?.let { selected ->
                                 visibleTrains.find { it.id == selected.id }
                             },

--- a/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/LiveTrainClassificationTest.kt
+++ b/feature/map/src/commonTest/kotlin/com/syrmos/feature/map/LiveTrainClassificationTest.kt
@@ -1,5 +1,6 @@
 package com.syrmos.feature.map
 
+import com.syrmos.core.common.DataFreshness
 import com.syrmos.core.model.status.LiveVehicleState
 import com.syrmos.core.model.transit.LiveSuburbanTrain
 import kotlinx.datetime.Instant
@@ -88,5 +89,25 @@ class LiveTrainClassificationTest {
         assertEquals(listOf("A1", "A2", "A4"), c.markers.map { it.train.lineId })
         assertEquals(setOf("A1", "A2", "A4"), c.coveredLineIds)
         assertFalse("A3" in c.coveredLineIds)
+    }
+
+    // --- Map offline indicator rule ---
+
+    @Test
+    fun mapOffline_whenDeviceOffline_regardlessOfFreshness() {
+        assertTrue(mapShowsOffline(isNetworkAvailable = false, freshness = DataFreshness.LIVE))
+        assertTrue(mapShowsOffline(isNetworkAvailable = false, freshness = DataFreshness.PREDICTED))
+    }
+
+    @Test
+    fun mapOffline_whenOnlineButNoLiveData_apiUnreachable() {
+        // Device says online but no live data landed in the window -> still offline
+        // indicator (online != API reachable).
+        assertTrue(mapShowsOffline(isNetworkAvailable = true, freshness = DataFreshness.PREDICTED))
+    }
+
+    @Test
+    fun mapNotOffline_onlyWhenOnlineAndLive() {
+        assertFalse(mapShowsOffline(isNetworkAvailable = true, freshness = DataFreshness.LIVE))
     }
 }


### PR DESCRIPTION
Part 1 of 3 (Android/KMP + shared core) of one cross-platform change: the Map now shows a **subtle, accessible offline indicator** when the app is not receiving live data. Companion PRs: iOS and web. Docs: `docs/OFFLINE_FIRST_AND_DATA_SOURCES.md`.

## Why
The Map was connectivity-blind — only Home showed an offline pill. The spec calls for a subtle map offline indicator, and notes a device reporting "online" does not prove the API is reachable, so the honest signal is live-data freshness (plus instant connectivity). Android also only handled `onAvailable` (never `onLost`), so it never learned it went offline in real time.

## How
- `LiveDataFreshness` gains an `isNetworkAvailable` flag; `ConnectivityObserver` now handles **`onLost`** (sets it false) as well as `onAvailable`, so offline is detected instantly instead of only via the 90s freshness decay.
- `MapViewModel` computes `mapOffline` each sim tick via the pure, tested `mapShowsOffline(isNetworkAvailable, freshness)` = offline OR no live data in the window; `MapScreen` shows a subtle `OfflinePill` (top-start) when true, hidden the moment live data resumes.
- **Drive-by fix:** hide-vehicles now also clears `visibleLiveTrains`. The live-train renderer switched to it in #141, so zeroing only the raw `liveTrains` left GPS trains on the map when vehicles were hidden.

## Tests / verification
- `LiveTrainClassificationTest` +3 (`mapShowsOffline`: offline regardless of freshness; online-but-stale; live-only-when-online-and-live).
- `:core:common` + `:feature:map` unit tests pass; `:androidApp:assembleDebug` **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)