### PR TITLE
feat(web): subtle map offline indicator

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -303,9 +303,9 @@
 
         <div class="context-spacer"></div>
 
-        <div class="offline-pill" id="offlinePill">
+        <div class="offline-pill" id="offlinePill" role="status" aria-live="polite" hidden>
             <svg class="ic" aria-hidden="true"><use href="#ic-wifi-off"/></svg>
-            <span id="offlinePillText">Offline snapshot active</span>
+            <span id="offlinePillText">Offline snapshot</span>
         </div>
     </aside>
 

--- a/composeApp/src/wasmJsMain/resources/web-map.css
+++ b/composeApp/src/wasmJsMain/resources/web-map.css
@@ -641,13 +641,25 @@ body.dark-mode .nav-item--active {
 
 /* ===== Offline Pill ===== */
 .offline-pill {
+    /* Floating, non-interrupting map indicator: pinned bottom-centre over the
+       map so it is reliably visible (it used to sit at the bottom of the
+       scrolling context rail and never showed). Shown only when offline; the
+       [hidden] rule below wins over this display:flex. */
+    position: fixed;
+    bottom: 16px; left: 50%; transform: translateX(-50%);
+    z-index: 500;
     display: flex; align-items: center; gap: 8px;
-    width: 100%;
+    width: auto; max-width: min(92vw, 420px);
     padding: 8px 14px;
     border-radius: var(--sy-radius-pill);
     background: var(--sy-background-subtle);
+    border: 1px solid var(--sy-border, rgba(0,0,0,0.08));
+    box-shadow: 0 6px 20px rgba(0,0,0,0.18);
     flex-shrink: 0;
 }
+/* Class+attribute specificity (0,2,0) beats .offline-pill (0,1,0), so the
+   default-hidden element stays hidden despite the display:flex above. */
+.offline-pill[hidden] { display: none; }
 
 .offline-pill .ic {
     width: 16px; height: 16px;

--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -2528,6 +2528,37 @@
     // ISO timestamp of the last real telematics batch (see updateLiveTrains).
     let liveTrainsUpdatedAt = null;
 
+    // --- Map offline indicator ---------------------------------------------
+    // Subtle, non-interrupting pill (#offlinePill) shown when the device is
+    // offline OR no live data has landed within the freshness window. Two honest
+    // signals: navigator.onLine is instant; the staleness check catches the
+    // "online but the API is unreachable" case (online != API reachable). The
+    // map keeps working from the bundled schedule + last-known data throughout.
+    // Optimistic start so a fresh online load shows nothing until a poll proves
+    // otherwise; a cold offline (SW-served) start reads navigator.onLine === false.
+    const LIVE_STALE_MS = 90_000;
+    let lastApiOkMs = Date.now();
+    function updateOfflineIndicator() {
+        const pill = document.getElementById("offlinePill");
+        if (!pill) return;
+        const txt = document.getElementById("offlinePillText");
+        if (txt) txt.textContent = t("offline_snapshot");
+        const stale = (Date.now() - lastApiOkMs) > LIVE_STALE_MS;
+        const offline = (typeof navigator !== "undefined" && navigator.onLine === false) || stale;
+        pill.hidden = !offline;
+    }
+    function markApiOk() {
+        lastApiOkMs = Date.now();
+        updateOfflineIndicator();
+    }
+    if (typeof window !== "undefined") {
+        window.addEventListener("online", updateOfflineIndicator);
+        window.addEventListener("offline", updateOfflineIndicator);
+        setInterval(updateOfflineIndicator, 15_000);
+        onLanguageChange(() => updateOfflineIndicator());
+        updateOfflineIndicator();
+    }
+
     // Guard the fit anyway, so no future handler throw during it can abort init.
     // Open framed on the ATHENS network, not the whole country. The app went
     // nationwide, but fitting every station Ioannina->Alexandroupoli->Kalamata
@@ -2685,6 +2716,7 @@
                 }
                 const payload = await res.json();
                 updateLiveTrains(payload.trains || [], payload.updatedAt);
+                markApiOk();
             } catch (_error) {
                 // Keep showing the last successful frame on transient errors.
             }
@@ -3502,9 +3534,11 @@
                     trains: data.trains || [],
                     generatedAtEpochSeconds: isNaN(generatedAtEpoch) ? Date.now() / 1000 : generatedAtEpoch,
                 };
+                markApiOk();
             } catch (_) {
                 // Offline (or the Pi is down): project from the bundled timetable.
                 applyOfflineFallback();
+                updateOfflineIndicator();
             }
         }
         await loadStationOffsets();

--- a/web-tests/map-offline-indicator.test.js
+++ b/web-tests/map-offline-indicator.test.js
@@ -1,0 +1,49 @@
+'use strict';
+// The map offline indicator: a subtle #offlinePill shown when the device is
+// offline OR no live data has landed within the freshness window (online != API
+// reachable), and hidden the moment live data resumes. Static-source guardrails
+// (web-map is a window-IIFE) + HTML/CSS assertions, mirroring the iOS map pill
+// and the Android MapScreen OfflinePill.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const js = fs.readFileSync(path.join(RES, 'web-map.js'), 'utf8');
+const css = fs.readFileSync(path.join(RES, 'web-map.css'), 'utf8');
+const html = fs.readFileSync(path.join(RES, 'index.html'), 'utf8');
+
+test('the indicator combines connectivity and live-data staleness', () => {
+  assert.match(js, /const LIVE_STALE_MS = 90_000;/, 'freshness window missing');
+  assert.match(js, /navigator\.onLine === false/, 'must consult navigator.onLine');
+  assert.match(js, /const stale = \(Date\.now\(\) - lastApiOkMs\) > LIVE_STALE_MS;/, 'staleness check missing');
+  assert.match(js, /const offline = \(typeof navigator[^\n]*navigator\.onLine === false\) \|\| stale;/,
+    'offline = not online OR stale');
+});
+
+test('the pill is toggled, and text is localized', () => {
+  assert.match(js, /const pill = document\.getElementById\("offlinePill"\);/, 'pill lookup missing');
+  assert.match(js, /pill\.hidden = !offline;/, 'pill must be toggled via hidden');
+  assert.match(js, /txt\.textContent = t\("offline_snapshot"\);/, 'pill text must be localized');
+});
+
+test('online/offline events, a poll, and a fallback interval all drive it', () => {
+  assert.match(js, /window\.addEventListener\("online", updateOfflineIndicator\);/, 'online listener missing');
+  assert.match(js, /window\.addEventListener\("offline", updateOfflineIndicator\);/, 'offline listener missing');
+  assert.match(js, /setInterval\(updateOfflineIndicator, 15_000\);/, 'fallback interval missing');
+  assert.match(js, /function markApiOk\(\)/, 'markApiOk missing');
+  // marked on the two live map feeds
+  assert.match(js, /updateLiveTrains\(payload\.trains \|\| \[\], payload\.updatedAt\);\s*\n\s*markApiOk\(\);/,
+    'trains poll must mark API ok');
+});
+
+test('css floats the pill and honours the hidden attribute', () => {
+  assert.match(css, /\.offline-pill\s*\{[^}]*position:\s*fixed/, 'pill must float (fixed) over the map');
+  assert.match(css, /\.offline-pill\[hidden\]\s*\{\s*display:\s*none;\s*\}/, 'hidden rule must beat display:flex');
+});
+
+test('index.html ships the pill hidden and accessible', () => {
+  assert.match(html, /id="offlinePill"[^>]*role="status"[^>]*aria-live="polite"[^>]*hidden/,
+    'pill must be an accessible live region, hidden by default');
+});


### PR DESCRIPTION
Part 3 of 3 (web) of one cross-platform change: a subtle, accessible offline indicator on the Map. Companion PRs: the Android/core PR and the iOS PR.

## Why
`index.html` shipped an `#offlinePill` element that was never wired (and, being at the bottom of the scrolling context rail, never showed). No `navigator.onLine` handling existed anywhere.

## How
- Repurpose `#offlinePill` as a floating, bottom-centre pill: default-hidden, shown when `navigator.onLine === false` OR no successful API contact within the freshness window (online != API reachable), hidden again on reconnect. Localized text, `role="status"`/`aria-live="polite"`.
- Driven by `online`/`offline` events, each successful poll (`markApiOk`), and a 15s fallback interval.

## Tests / verification
- `web-tests/map-offline-indicator.test.js` (guardrails on the signal, toggle, events, CSS float + `[hidden]` rule, and the accessible hidden-by-default element). Full web suite **86/86**; `node --check` clean.
- **Runtime-verified in-browser** (served the real resources): online -> pill `display:none`; forcing `navigator.onLine=false` + the `offline` event -> pill visible at bottom-centre (`display:flex`); back online -> hidden again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)