### PR TITLE
feat(android): exponential backoff + jitter on the live polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ data. See [docs/OFFLINE_FIRST_AND_DATA_SOURCES.md](docs/OFFLINE_FIRST_AND_DATA_S
   Android gained instant offline detection (`ConnectivityObserver.onLost` +
   a shared `LiveDataFreshness.isNetworkAvailable` flag) and, in passing, a fix so
   "hide vehicles" also clears the live-train layer.
+- **Backoff + jitter on the live polls (iOS + Android + web).** Every live poll
+  (trains, live-positions, airport buses) now backs off exponentially with jitter
+  on repeated failure (`base -> 2x -> 4x`, capped, +/-25% so installed clients do
+  not retry a down Pi in lockstep) and resets to its base interval on the next
+  success, replacing the previous fixed-interval loops. One shared rule:
+  `PollBackoff` (KMP + iOS) / `pollBackoffMs` (web).
 
 - **Live-GPS markers age out honestly (iOS + Android + web).** A real train/bus
   position is now classified by the age of its own `updatedAt`: fresh (<=90s)

--- a/core/common/src/commonMain/kotlin/com/syrmos/core/common/PollBackoff.kt
+++ b/core/common/src/commonMain/kotlin/com/syrmos/core/common/PollBackoff.kt
@@ -1,0 +1,45 @@
+package com.syrmos.core.common
+
+import kotlin.math.min
+import kotlin.random.Random
+
+/**
+ * Exponential backoff with jitter for the live polling loops (trains,
+ * live-positions, airport buses). A healthy loop waits its base interval; after
+ * consecutive failures it waits `min(base * 2^failures, max)`, and every delay is
+ * spread by +/- [jitterFraction] so many installed clients never retry in
+ * lockstep (thundering herd) against the single Pi feed. The failure counter is
+ * reset to 0 on the next success, so the loop snaps back to its normal cadence.
+ *
+ * Pure and rng-injected so it unit-tests without a clock or a real RNG. Mirrored
+ * on iOS (`PollBackoff.nextDelaySeconds`) and web (`pollBackoffMs`).
+ */
+object PollBackoff {
+    /** Cap so a long outage never pushes the retry interval past a minute. */
+    const val DEFAULT_MAX_DELAY_MS: Long = 60_000L
+    const val DEFAULT_JITTER_FRACTION: Double = 0.25
+
+    /** Exponent cap: 2^16 * base already exceeds any sane max, and it keeps the shift safe. */
+    private const val MAX_FAILURES = 16
+
+    fun nextDelayMillis(
+        consecutiveFailures: Int,
+        baseDelayMillis: Long,
+        maxDelayMillis: Long = DEFAULT_MAX_DELAY_MS,
+        jitterFraction: Double = DEFAULT_JITTER_FRACTION,
+        random01: Double = Random.nextDouble(),
+    ): Long {
+        require(baseDelayMillis > 0) { "baseDelayMillis must be > 0, was $baseDelayMillis" }
+        require(maxDelayMillis >= baseDelayMillis) {
+            "maxDelayMillis ($maxDelayMillis) must be >= baseDelayMillis ($baseDelayMillis)"
+        }
+        require(jitterFraction in 0.0..1.0) { "jitterFraction must be in [0,1], was $jitterFraction" }
+        require(random01 in 0.0..1.0) { "random01 must be in [0,1], was $random01" }
+        val failures = consecutiveFailures.coerceIn(0, MAX_FAILURES)
+        val exp = if (failures == 0) baseDelayMillis else baseDelayMillis shl failures
+        // shl can only be positive here (failures <= 16), but guard anyway.
+        val raw = min(if (exp <= 0) maxDelayMillis else exp, maxDelayMillis)
+        val multiplier = (1.0 - jitterFraction) + (2.0 * jitterFraction * random01)
+        return (raw * multiplier).toLong().coerceAtLeast(1L)
+    }
+}

--- a/core/common/src/commonTest/kotlin/com/syrmos/core/common/PollBackoffTest.kt
+++ b/core/common/src/commonTest/kotlin/com/syrmos/core/common/PollBackoffTest.kt
@@ -1,0 +1,69 @@
+package com.syrmos.core.common
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Exponential backoff with jitter for the live polls. rng is injected
+ * (random01) so the jitter is deterministic in tests. Mirrored on iOS + web.
+ */
+class PollBackoffTest {
+
+    // random01 = 0.5 -> multiplier 1.0 (no jitter), so raw delays are exact.
+    private fun noJitter(failures: Int, base: Long, max: Long = 60_000L) =
+        PollBackoff.nextDelayMillis(failures, base, max, random01 = 0.5)
+
+    @Test
+    fun successWaitsTheBaseInterval() {
+        assertEquals(10_000L, noJitter(0, 10_000L))
+        assertEquals(15_000L, noJitter(0, 15_000L))
+    }
+
+    @Test
+    fun failuresBackOffExponentially() {
+        assertEquals(20_000L, noJitter(1, 10_000L)) // 10s * 2
+        assertEquals(40_000L, noJitter(2, 10_000L)) // 10s * 4
+        assertEquals(60_000L, noJitter(3, 10_000L)) // 10s * 8 -> capped at 60s
+    }
+
+    @Test
+    fun cappedAtMax() {
+        assertEquals(60_000L, noJitter(10, 10_000L))
+        assertEquals(30_000L, PollBackoff.nextDelayMillis(10, 10_000L, maxDelayMillis = 30_000L, random01 = 0.5))
+    }
+
+    @Test
+    fun jitterStaysWithinBounds() {
+        // At failures=2, raw = 40s; +/-25% -> [30s, 50s].
+        val low = PollBackoff.nextDelayMillis(2, 10_000L, random01 = 0.0)
+        val high = PollBackoff.nextDelayMillis(2, 10_000L, random01 = 1.0)
+        assertEquals(30_000L, low)
+        assertEquals(50_000L, high)
+        // A spread of random draws all land inside the band and are not all equal.
+        val samples = (0..20).map { PollBackoff.nextDelayMillis(2, 10_000L, random01 = it / 20.0) }
+        assertTrue(samples.all { it in 30_000L..50_000L })
+        assertTrue(samples.toSet().size > 1, "jitter should spread the delay, not fix it")
+    }
+
+    @Test
+    fun jitterAppliesToTheBaseSuccessDelayToo() {
+        // Desyncs clients even when healthy: base 10s +/-25% -> [7.5s, 12.5s].
+        assertEquals(7_500L, PollBackoff.nextDelayMillis(0, 10_000L, random01 = 0.0))
+        assertEquals(12_500L, PollBackoff.nextDelayMillis(0, 10_000L, random01 = 1.0))
+    }
+
+    @Test
+    fun negativeFailuresTreatedAsZero() {
+        assertEquals(10_000L, noJitter(-3, 10_000L))
+    }
+
+    @Test
+    fun invalidConfigurationRejected() {
+        assertFailsWith<IllegalArgumentException> { PollBackoff.nextDelayMillis(0, 0L) }
+        assertFailsWith<IllegalArgumentException> { PollBackoff.nextDelayMillis(0, 10_000L, maxDelayMillis = 5_000L) }
+        assertFailsWith<IllegalArgumentException> { PollBackoff.nextDelayMillis(0, 10_000L, jitterFraction = 1.5) }
+        assertFailsWith<IllegalArgumentException> { PollBackoff.nextDelayMillis(0, 10_000L, random01 = 2.0) }
+    }
+}

--- a/core/network/src/commonMain/kotlin/com/syrmos/core/network/RailwayGovLiveTrackerService.kt
+++ b/core/network/src/commonMain/kotlin/com/syrmos/core/network/RailwayGovLiveTrackerService.kt
@@ -1,6 +1,7 @@
 package com.syrmos.core.network
 
 import com.syrmos.core.common.LiveDataFreshness
+import com.syrmos.core.common.PollBackoff
 import com.syrmos.core.model.transit.LiveSuburbanTrain
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.timeout
@@ -39,6 +40,7 @@ class RailwayGovLiveTrackerService(
     }
 
     fun observeSuburbanTrains(lineIds: Set<String>? = null): Flow<List<LiveSuburbanTrain>> = flow {
+        var consecutiveFailures = 0
         while (currentCoroutineContext().isActive) {
             try {
                 // Fast per-call timeout: this is a live poll feeding the map, so
@@ -77,11 +79,17 @@ class RailwayGovLiveTrackerService(
                 // offline-alive pill flips to "live".
                 LiveDataFreshness.markLive()
                 emit(trains)
+                consecutiveFailures = 0
             } catch (e: Exception) {
                 println("[LiveTracker] poll failed: ${e.message}")
+                consecutiveFailures++
             }
 
-            delay(POLL_INTERVAL_MS)
+            // Exponential backoff + jitter: a healthy feed polls every 10s; a
+            // failing one backs off (20s, 40s, capped 60s) with jitter so every
+            // installed client does not hammer a down Pi in lockstep. Resets to
+            // 10s on the next success.
+            delay(PollBackoff.nextDelayMillis(consecutiveFailures, POLL_INTERVAL_MS))
         }
     }
 

--- a/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/com/syrmos/feature/map/MapViewModel.kt
@@ -2,6 +2,7 @@ package com.syrmos.feature.map
 
 import com.syrmos.core.common.DataFreshness
 import com.syrmos.core.common.LiveDataFreshness
+import com.syrmos.core.common.PollBackoff
 import com.syrmos.core.common.map.LatLng
 import com.syrmos.core.data.repository.LineGeometryRepositoryImpl
 import com.syrmos.core.data.repository.LineRepositoryImpl
@@ -46,6 +47,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DayOfWeek
+
+/** Base interval for the live-positions + airport-bus polls (backoff resets to this). */
+private const val LIVE_POLL_BASE_MS = 15_000L
 
 data class StationDepartureUi(
     val line: Line,
@@ -347,10 +351,18 @@ class MapViewModel(
 
     private fun pollAirportBuses() {
         scope.launch {
+            var failures = 0
             while (isActive) {
-                val vehicles = AirportBusVehicles.parse(airportBusService.fetchAirportBuses())
-                _uiState.update { it.copy(busVehicles = vehicles) }
-                delay(15_000)
+                try {
+                    val vehicles = AirportBusVehicles.parse(airportBusService.fetchAirportBuses())
+                    _uiState.update { it.copy(busVehicles = vehicles) }
+                    failures = 0
+                } catch (e: Exception) {
+                    // Keep the last vehicles on screen and back off (don't clobber
+                    // good data with an empty list on a transient failure).
+                    failures++
+                }
+                delay(PollBackoff.nextDelayMillis(failures, LIVE_POLL_BASE_MS))
             }
         }
     }
@@ -365,11 +377,16 @@ class MapViewModel(
             if (offsetsMap.isEmpty()) {
                 offsetsMap = bundledOffsets()
             }
+            var failures = 0
             while (isActive) {
                 if (offsetsMap.isEmpty()) {
                     offsetsMap = bundledOffsets()
                 }
                 val active = livePositionsService.fetchActiveTrains(targetLines)
+                // A null response is a network failure -> back off. An empty-but-
+                // non-null response means the API is reachable (just no active
+                // trains, e.g. overnight), so that resets the backoff.
+                failures = if (active == null) failures + 1 else 0
                 if (active != null && active.trains.isNotEmpty()) {
                     val generatedAtEpoch = runCatching {
                         Instant.parse(active.generatedAt).epochSeconds
@@ -394,7 +411,7 @@ class MapViewModel(
                         generatedAtEpochSeconds = kotlinx.datetime.Clock.System.now().epochSeconds,
                     )
                 }
-                delay(15_000)
+                delay(PollBackoff.nextDelayMillis(failures, LIVE_POLL_BASE_MS))
             }
         }
     }


### PR DESCRIPTION
Part 1 of 3 (Android/KMP + shared core). The live polls used fixed intervals with no backoff; a sustained Pi outage meant every installed client hammered it on a tight loop, in lockstep. Companion PRs: iOS and web.

## How
- Shared `PollBackoff` (`core/common`, tested): a healthy loop waits its base interval; after consecutive failures it waits `min(base * 2^failures, 60s)` with +/-25% jitter (so clients don't retry in lockstep against the single Pi feed), resetting to base on the next success.
- Wired into the trains tracker (`RailwayGovLiveTrackerService`, 10s base) and the map's live-positions + airport-bus loops (`MapViewModel`, 15s base). A null/failed response counts as a failure; an empty-but-reachable response resets the backoff.

## Tests / verification
- `PollBackoffTest` (base/escalation/cap/jitter-bounds/negative/invalid-config).
- `:core:common` + `:core:network` + `:feature:map` unit tests pass; `:androidApp:assembleDebug` **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)