### PR TITLE
feat(ios): exponential backoff + jitter on the live polls

### DIFF
--- a/iosApp/iosApp/Core/Networking/AirportBusVehicles.swift
+++ b/iosApp/iosApp/Core/Networking/AirportBusVehicles.swift
@@ -29,29 +29,37 @@ final class LiveAirportBusService: ObservableObject {
     func startPolling() {
         guard task == nil else { return }
         task = Task { [weak self] in
+            var failures = 0
             while !Task.isCancelled {
-                await self?.fetchOnce()
-                try? await Task.sleep(nanoseconds: 15_000_000_000)
+                let ok = await self?.fetchOnce() ?? false
+                failures = ok ? 0 : failures + 1
+                // Backoff + jitter: 15s healthy, escalating on failure (capped
+                // 60s), reset on success. Keeps the last frame meanwhile.
+                try? await Task.sleep(nanoseconds: PollBackoff.nextDelayNanos(
+                    consecutiveFailures: failures, baseDelaySeconds: 15))
             }
         }
     }
 
-    private func fetchOnce() async {
+    @discardableResult
+    private func fetchOnce() async -> Bool {
         guard !SyrmosSchedulesStore.shared.offlineOnly else {
             vehicles = []
-            return
+            return true // intentional offline-only mode, not a poll failure
         }
-        guard let url = URL(string: "https://api-syrmos.peterdsp.dev/api/oasa-airport-buses") else { return }
+        guard let url = URL(string: "https://api-syrmos.peterdsp.dev/api/oasa-airport-buses") else { return false }
         var req = URLRequest(url: url)
         req.timeoutInterval = 8
         req.cachePolicy = .reloadIgnoringLocalCacheData
         do {
             let (data, response) = try await URLSession.shared.data(for: req)
-            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return }
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return false }
             let payload = try JSONDecoder().decode(Payload.self, from: data)
             vehicles = Self.parse(payload)
+            return true
         } catch {
             // Keep the last frame on transient errors.
+            return false
         }
     }
 

--- a/iosApp/iosApp/Core/Networking/LivePositionsService.swift
+++ b/iosApp/iosApp/Core/Networking/LivePositionsService.swift
@@ -67,9 +67,10 @@ final class LivePositionsService: ObservableObject {
 
     /// Public entry. Settings' Check now calls this; the in-app
     /// schedule of polling is the user, not a timer.
-    func refresh() async {
+    @discardableResult
+    func refresh() async -> Bool {
         await ensureOffsets()
-        await fetchActiveTrains()
+        return await fetchActiveTrains()
     }
 
     /// Re-fetch active positions on a cadence so metro / tram / A1-A4 dots stay
@@ -82,10 +83,19 @@ final class LivePositionsService: ObservableObject {
     func startPolling(intervalSeconds: UInt64 = 60) {
         guard pollTask == nil else { return }
         pollTask = Task { [weak self] in
+            var failures = 0
+            let base = TimeInterval(intervalSeconds)
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: intervalSeconds * 1_000_000_000)
+                // Backoff + jitter: base cadence while healthy, escalating on
+                // repeated failure (capped 5 min) with jitter, reset on success.
+                // The map keeps projecting metro/tram from the bundle meanwhile.
+                try? await Task.sleep(nanoseconds: PollBackoff.nextDelayNanos(
+                    consecutiveFailures: failures,
+                    baseDelaySeconds: base,
+                    maxDelaySeconds: max(base, 300)))
                 if Task.isCancelled { return }
-                await self?.refresh()
+                let ok = await self?.refresh() ?? false
+                failures = ok ? 0 : failures + 1
             }
         }
     }
@@ -129,12 +139,13 @@ final class LivePositionsService: ObservableObject {
         }
     }
 
-    private func fetchActiveTrains() async {
-        guard var components = URLComponents(string: "\(base)/api/live-positions") else { return }
+    @discardableResult
+    private func fetchActiveTrains() async -> Bool {
+        guard var components = URLComponents(string: "\(base)/api/live-positions") else { return false }
         components.queryItems = [
             URLQueryItem(name: "lineIds", value: projectedLineIds.joined(separator: ",")),
         ]
-        guard let url = components.url else { return }
+        guard let url = components.url else { return false }
         var req = URLRequest(url: url)
         req.timeoutInterval = 6
         do {
@@ -161,6 +172,7 @@ final class LivePositionsService: ObservableObject {
             // Live positions came back from the API: we're online. Surface
             // it on the home offline-alive pill.
             LiveDataFreshness.shared.markLive()
+            return true
         } catch {
             // Offline (or Pi down): project metro/tram from the bundled
             // timetable so the map still shows live-moving dots, including
@@ -182,6 +194,7 @@ final class LivePositionsService: ObservableObject {
                 }
             }
             // else: keep existing trains so a brief glitch animates smoothly.
+            return false
         }
     }
 }

--- a/iosApp/iosApp/Core/Schedule/DataFreshness.swift
+++ b/iosApp/iosApp/Core/Schedule/DataFreshness.swift
@@ -144,3 +144,44 @@ enum LiveVehicleFreshnessRule {
         return LiveVehicleFreshness(state: .expired, ageSeconds: Int(age))
     }
 }
+
+// MARK: - Live poll backoff
+
+/// Exponential backoff with jitter for the live polling loops. Swift mirror of
+/// the KMP `PollBackoff` - keep the 2^failures growth, the +/-25% jitter and the
+/// 60s default cap in lockstep. A healthy loop waits its base interval; after
+/// consecutive failures it waits `min(base * 2^failures, max)`, jittered so many
+/// installed clients never retry a down Pi in lockstep. Reset the failure count
+/// to 0 on the next success. Pure + rng-injected so it unit-tests.
+enum PollBackoff {
+    static let defaultMaxDelaySeconds: TimeInterval = 60
+    static let defaultJitterFraction: Double = 0.25
+    private static let maxFailures = 16
+
+    static func nextDelaySeconds(
+        consecutiveFailures: Int,
+        baseDelaySeconds: TimeInterval,
+        maxDelaySeconds: TimeInterval = defaultMaxDelaySeconds,
+        jitterFraction: Double = defaultJitterFraction,
+        random01: Double = Double.random(in: 0..<1)
+    ) -> TimeInterval {
+        let failures = min(max(consecutiveFailures, 0), maxFailures)
+        let exp = failures == 0 ? baseDelaySeconds : baseDelaySeconds * pow(2.0, Double(failures))
+        let raw = min(exp, maxDelaySeconds)
+        let multiplier = (1.0 - jitterFraction) + (2.0 * jitterFraction * random01)
+        return max(raw * multiplier, 0.001)
+    }
+
+    /// Convenience for `Task.sleep(nanoseconds:)`.
+    static func nextDelayNanos(
+        consecutiveFailures: Int,
+        baseDelaySeconds: TimeInterval,
+        maxDelaySeconds: TimeInterval = defaultMaxDelaySeconds
+    ) -> UInt64 {
+        UInt64(nextDelaySeconds(
+            consecutiveFailures: consecutiveFailures,
+            baseDelaySeconds: baseDelaySeconds,
+            maxDelaySeconds: maxDelaySeconds
+        ) * 1_000_000_000)
+    }
+}

--- a/iosApp/iosApp/Core/Schedule/TransitData.swift
+++ b/iosApp/iosApp/Core/Schedule/TransitData.swift
@@ -890,9 +890,15 @@ final class LiveTrainService: ObservableObject, @unchecked Sendable {
     func startPolling() {
         guard task == nil else { return }
         task = Task { [weak self] in
+            var failures = 0
             while !Task.isCancelled {
-                await LiveTrainService.fetchOnce(self)
-                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                let ok = await LiveTrainService.fetchOnce(self)
+                failures = ok ? 0 : failures + 1
+                // Exponential backoff + jitter: 10s while healthy, then 20/40/60s
+                // on repeated failure, reset to 10s on the next success. Mirrors
+                // the KMP tracker service so no client hammers a down Pi.
+                try? await Task.sleep(nanoseconds: PollBackoff.nextDelayNanos(
+                    consecutiveFailures: failures, baseDelaySeconds: 10))
             }
         }
     }
@@ -902,7 +908,8 @@ final class LiveTrainService: ObservableObject, @unchecked Sendable {
         await LiveTrainService.fetchOnce(self)
     }
 
-    private static func fetchOnce(_ instance: LiveTrainService?) async {
+    @discardableResult
+    private static func fetchOnce(_ instance: LiveTrainService?) async -> Bool {
         let url = URL(string: "https://api-syrmos.peterdsp.dev/api/trains")!
         do {
             var req = URLRequest(url: url)
@@ -961,10 +968,12 @@ final class LiveTrainService: ObservableObject, @unchecked Sendable {
                 LiveDataFreshness.shared.markLive()
                 LiveTrainService.onLiveDataRefreshed?(trainCount)
             }
+            return true
         } catch {
             // Silent — the user's previous Check now still has whatever
             // the last poll returned. Map keeps rendering bundled
             // polylines + stations regardless.
+            return false
         }
     }
 

--- a/iosApp/iosAppTests/SuburbanProjectionTests.swift
+++ b/iosApp/iosAppTests/SuburbanProjectionTests.swift
@@ -97,4 +97,30 @@ final class SuburbanProjectionTests: XCTestCase {
         XCTAssertEqual(covered, ["A1", "A2"], "A3 expired so its line is handed back to the projector")
         XCTAssertFalse(covered.contains("A3"))
     }
+
+    // MARK: - Live poll backoff (mirrors KMP PollBackoffTest)
+
+    func test_pollBackoff_successWaitsBaseAndFailuresEscalate() {
+        // random01 = 0.5 -> multiplier 1.0, so raw delays are exact.
+        func d(_ f: Int, _ base: TimeInterval, _ maxD: TimeInterval = 60) -> TimeInterval {
+            PollBackoff.nextDelaySeconds(consecutiveFailures: f, baseDelaySeconds: base, maxDelaySeconds: maxD, random01: 0.5)
+        }
+        XCTAssertEqual(d(0, 10), 10, accuracy: 0.001)  // healthy -> base
+        XCTAssertEqual(d(1, 10), 20, accuracy: 0.001)  // 10 * 2
+        XCTAssertEqual(d(2, 10), 40, accuracy: 0.001)  // 10 * 4
+        XCTAssertEqual(d(3, 10), 60, accuracy: 0.001)  // capped at 60
+        XCTAssertEqual(d(10, 10), 60, accuracy: 0.001) // stays capped
+    }
+
+    func test_pollBackoff_jitterWithinBounds() {
+        // failures=2 -> raw 40s; +/-25% -> [30, 50].
+        XCTAssertEqual(PollBackoff.nextDelaySeconds(consecutiveFailures: 2, baseDelaySeconds: 10, random01: 0.0), 30, accuracy: 0.001)
+        XCTAssertEqual(PollBackoff.nextDelaySeconds(consecutiveFailures: 2, baseDelaySeconds: 10, random01: 1.0), 50, accuracy: 0.001)
+        // base success delay is jittered too, to desync clients: 10 +/-25% -> [7.5, 12.5].
+        XCTAssertEqual(PollBackoff.nextDelaySeconds(consecutiveFailures: 0, baseDelaySeconds: 10, random01: 0.0), 7.5, accuracy: 0.001)
+    }
+
+    func test_pollBackoff_negativeFailuresTreatedAsZero() {
+        XCTAssertEqual(PollBackoff.nextDelaySeconds(consecutiveFailures: -5, baseDelaySeconds: 15, random01: 0.5), 15, accuracy: 0.001)
+    }
 }


### PR DESCRIPTION
Part 2 of 3 (iOS). Companion PRs: the Android/core PR and the web PR.

## How
- Swift `PollBackoff` mirror of the KMP policy (2^failures, +/-25% jitter, 60s default cap; positions cap 5 min since its base is 60s).
- Each poll loop now reports success/failure and schedules the next run via `PollBackoff.nextDelayNanos`, resetting to base on success: `LiveTrainService` (trains, 10s), `LivePositionsService` (positions, 60s), `LiveAirportBusService` (buses, 15s). `fetchOnce`/`fetchActiveTrains`/`refresh` became `@discardableResult -> Bool`.

## Tests / verification
- `SuburbanProjectionTests` +3 (base/escalation/cap, jitter bounds, negative failures).
- Full iOS suite **176 tests, 0 failures**; app builds for the iPhone 17 simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)