### PR TITLE
feat(web): exponential backoff + jitter on the live polls

### DIFF
--- a/composeApp/src/wasmJsMain/resources/web-map.js
+++ b/composeApp/src/wasmJsMain/resources/web-map.js
@@ -2700,11 +2700,36 @@
         });
     }
 
+    // Exponential backoff with jitter for the live polls. Mirrors the KMP
+    // PollBackoff + iOS PollBackoff (2^failures growth, +/-25% jitter, 60s cap).
+    // A healthy loop waits its base interval; after consecutive failures it waits
+    // min(base * 2^failures, max), jittered so many clients never retry a down Pi
+    // in lockstep. Reset failures to 0 on the next success.
+    const POLL_MAX_BACKOFF_MS = 60_000;
+    function pollBackoffMs(consecutiveFailures, baseMs, maxMs = POLL_MAX_BACKOFF_MS, jitterFraction = 0.25, random01 = Math.random()) {
+        const failures = Math.max(0, Math.min(consecutiveFailures | 0, 16));
+        const raw = Math.min(failures === 0 ? baseMs : baseMs * Math.pow(2, failures), maxMs);
+        const mult = (1 - jitterFraction) + (2 * jitterFraction * random01);
+        return Math.max(Math.round(raw * mult), 1);
+    }
+    // Self-scheduling poll loop with backoff: run `pollOnce` (returns true on
+    // success), then schedule the next run after pollBackoffMs(failures, baseMs).
+    function startPollLoop(pollOnce, baseMs, maxMs = POLL_MAX_BACKOFF_MS) {
+        let failures = 0;
+        async function loop() {
+            let ok = false;
+            try { ok = await pollOnce(); } catch (_) { ok = false; }
+            failures = ok ? 0 : failures + 1;
+            setTimeout(loop, pollBackoffMs(failures, baseMs, maxMs));
+        }
+        loop();
+    }
+
     function connectLiveTrainStream() {
-        // Poll the Syrmos API cached JSON every 10 seconds. The Pi handles the
-        // upstream SSE connection and pre-filters the data so each browser
-        // downloads only ~1.5 KB per poll instead of holding an SSE stream
-        // that emits 10+ KB of schedule cards per second.
+        // Poll the Syrmos API cached JSON. The Pi handles the upstream SSE
+        // connection and pre-filters the data so each browser downloads only
+        // ~1.5 KB per poll instead of holding an SSE stream that emits 10+ KB of
+        // schedule cards per second. 10s while healthy; backs off on failure.
         const TRAINS_URL = "https://api-syrmos.peterdsp.dev/api/trains";
         const POLL_INTERVAL_MS = 10_000;
 
@@ -2712,18 +2737,19 @@
             try {
                 const res = await fetch(TRAINS_URL, { cache: "no-store" });
                 if (!res.ok) {
-                    return;
+                    return false;
                 }
                 const payload = await res.json();
                 updateLiveTrains(payload.trains || [], payload.updatedAt);
                 markApiOk();
+                return true;
             } catch (_error) {
                 // Keep showing the last successful frame on transient errors.
+                return false;
             }
         }
 
-        pollOnce();
-        setInterval(pollOnce, POLL_INTERVAL_MS);
+        startPollLoop(pollOnce, POLL_INTERVAL_MS);
         // Re-render from the last snapshot on a timer so the fleet ages out even
         // with NO new data (offline / dropped feed): the poll only redraws on a
         // successful fetch, so without this a stale batch would keep its fresh
@@ -2934,15 +2960,16 @@
         async function pollOnce() {
             try {
                 const res = await fetch(URL, { cache: "no-store" });
-                if (!res.ok) return;
+                if (!res.ok) return false;
                 const payload = await res.json();
                 renderAirportBusVehicles(SyrmosAirport.airportBusVehicles(payload));
+                return true;
             } catch (_error) {
                 // Keep the last frame on transient errors.
+                return false;
             }
         }
-        pollOnce();
-        setInterval(pollOnce, 15_000);
+        startPollLoop(pollOnce, 15_000);
     }
 
     function renderAirportBusVehicles(vehicles) {
@@ -3535,15 +3562,16 @@
                     generatedAtEpochSeconds: isNaN(generatedAtEpoch) ? Date.now() / 1000 : generatedAtEpoch,
                 };
                 markApiOk();
+                return true;
             } catch (_) {
                 // Offline (or the Pi is down): project from the bundled timetable.
                 applyOfflineFallback();
                 updateOfflineIndicator();
+                return false;
             }
         }
         await loadStationOffsets();
-        await tick();
-        setInterval(tick, 15000);
+        startPollLoop(tick, 15000);
     }
 
     // Position a train ALONG the real line polyline instead of on the straight

--- a/web-tests/poll-backoff.test.js
+++ b/web-tests/poll-backoff.test.js
@@ -1,0 +1,72 @@
+'use strict';
+// Exponential backoff with jitter for the live polls, mirroring the KMP
+// PollBackoffTest and iOS test_pollBackoff_*. pollBackoffMs is IIFE-internal, so
+// it is brace-extracted from source and executed (genuine coverage of the
+// shipped function) + static-source guardrails that the three live loops were
+// converted from fixed setInterval to the self-scheduling backoff loop.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RES = path.join(__dirname, '..', 'composeApp', 'src', 'wasmJsMain', 'resources');
+const js = fs.readFileSync(path.join(RES, 'web-map.js'), 'utf8');
+
+function extractFunction(src, name) {
+  const start = src.indexOf('function ' + name);
+  assert.notEqual(start, -1, `function ${name} not found`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) return src.slice(start, i + 1); }
+  }
+  throw new Error('unbalanced braces');
+}
+const maxConst = (js.match(/const POLL_MAX_BACKOFF_MS = ([\d_]+);/) || [])[1];
+const pollBackoffMs = new Function(
+  `const POLL_MAX_BACKOFF_MS = ${maxConst};\n${extractFunction(js, 'pollBackoffMs')}\nreturn pollBackoffMs;`,
+)();
+
+// random01 = 0.5 -> multiplier 1.0 (no jitter), exact delays.
+const d = (f, base, max = 60000) => pollBackoffMs(f, base, max, 0.25, 0.5);
+
+test('cap constant matches the cross-platform 60s', () => {
+  assert.equal(maxConst.replace(/_/g, ''), '60000');
+});
+
+test('success waits base; failures escalate; capped', () => {
+  assert.equal(d(0, 10000), 10000);
+  assert.equal(d(1, 10000), 20000);
+  assert.equal(d(2, 10000), 40000);
+  assert.equal(d(3, 10000), 60000); // 80000 capped to 60000
+  assert.equal(d(10, 10000), 60000);
+});
+
+test('jitter stays within +/-25% and spreads', () => {
+  assert.equal(pollBackoffMs(2, 10000, 60000, 0.25, 0.0), 30000); // 40000 * 0.75
+  assert.equal(pollBackoffMs(2, 10000, 60000, 0.25, 1.0), 50000); // 40000 * 1.25
+  // base success delay is jittered too (desync): 10000 -> [7500, 12500]
+  assert.equal(pollBackoffMs(0, 10000, 60000, 0.25, 0.0), 7500);
+  const spread = [0, 0.2, 0.4, 0.6, 0.8, 1.0].map((r) => pollBackoffMs(2, 10000, 60000, 0.25, r));
+  assert.ok(spread.every((v) => v >= 30000 && v <= 50000));
+  assert.ok(new Set(spread).size > 1, 'jitter must spread, not fix, the delay');
+});
+
+test('negative failures treated as zero', () => {
+  assert.equal(d(-4, 15000), 15000);
+});
+
+// --- static-source guardrails: loops use the backoff scheduler ---
+
+test('a self-scheduling backoff loop replaced fixed setInterval polling', () => {
+  assert.match(js, /function startPollLoop\(pollOnce, baseMs/, 'startPollLoop helper missing');
+  assert.match(js, /setTimeout\(loop, pollBackoffMs\(failures, baseMs, maxMs\)\);/, 'loop must schedule via pollBackoffMs');
+  // the three live feeds drive it, and pollOnce returns a success boolean
+  assert.match(js, /startPollLoop\(pollOnce, POLL_INTERVAL_MS\);/, 'trains loop not on backoff');
+  assert.match(js, /startPollLoop\(pollOnce, 15_000\);/, 'airport loop not on backoff');
+  assert.match(js, /startPollLoop\(tick, 15000\);/, 'live-positions loop not on backoff');
+  // trains/airport/positions pollOnce/tick now return true on success
+  assert.match(js, /updateLiveTrains\(payload\.trains \|\| \[\], payload\.updatedAt\);\s*\n\s*markApiOk\(\);\s*\n\s*return true;/,
+    'trains pollOnce must return true on success');
+});


### PR DESCRIPTION
Part 3 of 3 (web). Companion PRs: the Android/core PR and the iOS PR.

## How
- `pollBackoffMs` mirrors the KMP + iOS policy (2^failures, +/-25% jitter, 60s cap).
- A self-scheduling `startPollLoop(pollOnce, baseMs)` replaces the fixed `setInterval` loops for trains, live-positions and airport buses; each `pollOnce`/`tick` returns a success boolean, backs off on failure and resets on success.

## Tests / verification
- `web-tests/poll-backoff.test.js`: brace-extracts and **executes the shipped `pollBackoffMs`** (base/escalation/cap/jitter) + static-source guardrails that all three loops were converted to the backoff scheduler. Full web suite **91/91**; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)